### PR TITLE
fix(useToast): resolve ESLint ref cleanup warning

### DIFF
--- a/lua-learning-website/src/components/Toast/useToast.test.ts
+++ b/lua-learning-website/src/components/Toast/useToast.test.ts
@@ -169,4 +169,26 @@ describe('useToast', () => {
     expect(result.current.toasts).toHaveLength(1)
     expect(result.current.toasts[0].message).toBe('Second')
   })
+
+  it('should clear all timers on unmount', () => {
+    // Arrange
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')
+    const { result, unmount } = renderHook(() => useToast())
+
+    act(() => {
+      result.current.showToast({ message: 'First', type: 'error', duration: 10000 })
+      result.current.showToast({ message: 'Second', type: 'error', duration: 10000 })
+    })
+
+    expect(result.current.toasts).toHaveLength(2)
+    clearTimeoutSpy.mockClear() // Reset to only count cleanup calls
+
+    // Act - unmount the hook
+    unmount()
+
+    // Assert - should have cleared both timers
+    expect(clearTimeoutSpy).toHaveBeenCalledTimes(2)
+
+    clearTimeoutSpy.mockRestore()
+  })
 })

--- a/lua-learning-website/src/components/Toast/useToast.ts
+++ b/lua-learning-website/src/components/Toast/useToast.ts
@@ -10,8 +10,9 @@ export function useToast(): UseToastReturn {
 
   // Clean up timers on unmount
   useEffect(() => {
+    const timers = timersRef.current
     return () => {
-      for (const timer of timersRef.current.values()) {
+      for (const timer of timers.values()) {
         clearTimeout(timer)
       }
     }


### PR DESCRIPTION
## Summary
- Fixed ESLint warning about `timersRef.current` in useEffect cleanup
- Copied ref value to local variable before cleanup function per React best practices
- Added test to verify timer cleanup behavior on unmount

## Test plan
- [x] All 635 unit tests pass
- [x] Lint passes (no more warning on useToast.ts)
- [x] Build succeeds

Fixes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)