### PR TITLE
[Tech Debt] E2E: Fix embeddable-editor error message assertion

### DIFF
--- a/lua-learning-website/e2e/embeddable-editor.spec.ts
+++ b/lua-learning-website/e2e/embeddable-editor.spec.ts
@@ -60,8 +60,9 @@ test.describe('EmbeddableEditor', () => {
     // Click Run
     await page.click('button:has-text("Run")')
 
-    // Output should show an error message (case insensitive check)
+    // Output should show a Lua error message
+    // Lua errors have the format: [string "..."]:line: message
     const outputPanel = page.locator('[data-testid="output-panel"]').first()
-    await expect(outputPanel).toContainText(/error/i, { timeout: 10000 })
+    await expect(outputPanel).toContainText(/\[string.*\]:\d+:/, { timeout: 10000 })
   })
 })


### PR DESCRIPTION
## Summary
- Updated E2E test assertion to match actual Lua error format
- Changed regex from `/error/i` to `/\[string.*\]:\d+:/` to match Lua's error output format: `[string "..."]:line: message`

## Test plan
- [x] E2E test `displays Lua errors without crashing` now passes reliably
- [x] All 5 embeddable-editor E2E tests pass
- [x] 695 unit tests pass
- [x] Lint passes
- [x] Build succeeds

Fixes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)