### PR TITLE
feat(#66): Worktree scripts have bugs on Windows (directory cleanup + Unicode)

### DIFF
--- a/scripts/worktree-create.py
+++ b/scripts/worktree-create.py
@@ -36,6 +36,8 @@ def run(cmd, capture=True, check=True, cwd=None):
         shell=True,
         capture_output=capture,
         text=True,
+        encoding='utf-8',
+        errors='replace',
         cwd=cwd
     )
     if check and result.returncode != 0:

--- a/scripts/worktree-remove.py
+++ b/scripts/worktree-remove.py
@@ -18,6 +18,7 @@ Options:
 import subprocess
 import sys
 import re
+import shutil
 from pathlib import Path
 
 # ANSI colors
@@ -34,7 +35,9 @@ def run(cmd, capture=True, check=True):
         cmd,
         shell=True,
         capture_output=capture,
-        text=True
+        text=True,
+        encoding='utf-8',
+        errors='replace'
     )
     if check and result.returncode != 0:
         if result.stderr:
@@ -124,6 +127,17 @@ def main():
         # Try pruning if remove failed
         print(f"{YELLOW}Worktree remove failed, trying to prune...{NC}")
         run('git worktree prune')
+
+    # Clean up directory if it still exists (Windows often leaves directories behind)
+    worktree_dir = Path(worktree_path)
+    if worktree_dir.exists():
+        print(f"{YELLOW}Directory still exists, cleaning up...{NC}")
+        try:
+            shutil.rmtree(worktree_dir)
+            print(f"  {GREEN}Directory deleted{NC}")
+        except Exception as e:
+            print(f"  {RED}Failed to delete directory: {e}{NC}")
+            print(f"  {YELLOW}Please manually delete: {worktree_path}{NC}")
 
     # Delete the branch unless --keep-branch was specified
     if not keep_branch and branch_name:


### PR DESCRIPTION
## Summary
Fix two Windows-specific bugs in worktree management scripts: (1) Add UTF-8 encoding to subprocess calls in both worktree-create.py and worktree-remove.py to prevent Unicode decode errors, (2) Add directory cleanup fallback in worktree-remove.py using shutil.rmtree() when git worktree remove fails to delete directories

## Test plan
Verify Python syntax is valid for both scripts; Test worktree-create.py with issues containing Unicode characters; Test worktree-remove.py cleans up directories that persist after git worktree remove

Fixes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)