### PR TITLE
feat(#34): useBashTerminal: Improve mutation test coverage (77% -> 80%)

### DIFF
--- a/lua-learning-website/src/components/BashTerminal/useBashTerminal.test.ts
+++ b/lua-learning-website/src/components/BashTerminal/useBashTerminal.test.ts
@@ -1003,5 +1003,498 @@ describe('useBashTerminal', () => {
       expect(result.current.isMultiLineMode).toBe(false)
       expect(result.current.multiLineBuffer).toEqual([])
     })
+
+    it('should return writeln command with empty data when entering multi-line mode', () => {
+      // Arrange
+      const { result } = renderHook(() => useBashTerminal())
+
+      // Act
+      act(() => {
+        result.current.handleCharacter('a')
+      })
+
+      let commands: TerminalCommand[]
+      act(() => {
+        commands = result.current.handleShiftEnter()
+      })
+
+      // Assert - verify exact command structure
+      expect(commands!).toEqual([{ type: 'writeln', data: '' }])
+    })
+
+    it('should return writeln command with empty data when exiting multi-line mode', () => {
+      // Arrange
+      const onCommand = vi.fn()
+      const { result } = renderHook(() => useBashTerminal({ onCommand }))
+
+      // Act
+      act(() => {
+        result.current.handleCharacter('a')
+      })
+      act(() => {
+        result.current.handleShiftEnter() // Enter multi-line mode
+      })
+
+      let commands: TerminalCommand[]
+      act(() => {
+        commands = result.current.handleShiftEnter() // Exit multi-line mode
+      })
+
+      // Assert - verify exact command structure
+      expect(commands!).toEqual([{ type: 'writeln', data: '' }])
+    })
+
+    it('should return writeln command with empty data in multi-line Enter', () => {
+      // Arrange
+      const { result } = renderHook(() => useBashTerminal())
+
+      // Act
+      act(() => {
+        result.current.handleCharacter('a')
+      })
+      act(() => {
+        result.current.handleShiftEnter() // Enter multi-line mode
+      })
+
+      let commands: TerminalCommand[]
+      act(() => {
+        commands = result.current.handleEnter() // Add new line in multi-line mode
+      })
+
+      // Assert - verify exact command structure
+      expect(commands!).toEqual([{ type: 'writeln', data: '' }])
+    })
+
+    it('should preserve buffer content when adding new line in multi-line mode', () => {
+      // Arrange
+      const { result } = renderHook(() => useBashTerminal())
+
+      // Act
+      act(() => {
+        result.current.handleCharacter('f')
+      })
+      act(() => {
+        result.current.handleCharacter('i')
+      })
+      act(() => {
+        result.current.handleCharacter('r')
+      })
+      act(() => {
+        result.current.handleCharacter('s')
+      })
+      act(() => {
+        result.current.handleCharacter('t')
+      })
+      act(() => {
+        result.current.handleShiftEnter() // Enter multi-line mode with "first"
+      })
+      act(() => {
+        result.current.handleEnter() // Add new line
+      })
+
+      // Assert - buffer should contain "first" and empty string, not be reset
+      expect(result.current.multiLineBuffer).toEqual(['first', ''])
+      expect(result.current.multiLineBuffer[0]).toBe('first')
+    })
+
+    it('should reset currentLine to empty after exiting multi-line mode', () => {
+      // Arrange
+      const { result } = renderHook(() => useBashTerminal())
+
+      // Act
+      act(() => {
+        result.current.handleCharacter('a')
+      })
+      act(() => {
+        result.current.handleShiftEnter() // Enter multi-line mode
+      })
+      act(() => {
+        result.current.handleCharacter('b')
+      })
+      act(() => {
+        result.current.handleShiftEnter() // Exit multi-line mode
+      })
+
+      // Assert
+      expect(result.current.currentLine).toBe('')
+    })
+
+    it('should reset multiLineBuffer to empty array after exiting multi-line mode', () => {
+      // Arrange
+      const { result } = renderHook(() => useBashTerminal())
+
+      // Act
+      act(() => {
+        result.current.handleCharacter('a')
+      })
+      act(() => {
+        result.current.handleShiftEnter() // Enter multi-line mode
+      })
+      act(() => {
+        result.current.handleShiftEnter() // Exit multi-line mode
+      })
+
+      // Assert
+      expect(result.current.multiLineBuffer).toEqual([])
+    })
+
+    it('should add multi-line command to history', () => {
+      // Arrange
+      const { result } = renderHook(() => useBashTerminal())
+
+      // Act
+      act(() => {
+        result.current.handleCharacter('a')
+      })
+      act(() => {
+        result.current.handleShiftEnter() // Enter multi-line mode
+      })
+      act(() => {
+        result.current.handleEnter() // Add new line
+      })
+      act(() => {
+        result.current.handleCharacter('b')
+      })
+      act(() => {
+        result.current.handleShiftEnter() // Exit and execute
+      })
+
+      // Assert
+      expect(result.current.history).toContain('a\nb')
+    })
+
+    it('should reset historyIndex to -1 after multi-line command execution', () => {
+      // Arrange
+      const { result } = renderHook(() => useBashTerminal())
+
+      // Execute a regular command first to set history
+      act(() => {
+        result.current.handleCharacter('x')
+      })
+      act(() => {
+        result.current.handleEnter()
+      })
+
+      // Navigate up to set historyIndex
+      act(() => {
+        result.current.handleArrowUp()
+      })
+      expect(result.current.historyIndex).toBe(0)
+
+      // Now execute a multi-line command
+      act(() => {
+        result.current.handleCharacter('a')
+      })
+      act(() => {
+        result.current.handleShiftEnter() // Enter multi-line mode
+      })
+      act(() => {
+        result.current.handleShiftEnter() // Exit and execute
+      })
+
+      // Assert - historyIndex should be reset to -1
+      expect(result.current.historyIndex).toBe(-1)
+    })
+
+    it('should not call onCommand for whitespace-only multi-line command', () => {
+      // Arrange
+      const onCommand = vi.fn()
+      const { result } = renderHook(() => useBashTerminal({ onCommand }))
+
+      // Act
+      act(() => {
+        result.current.handleCharacter(' ')
+      })
+      act(() => {
+        result.current.handleShiftEnter() // Enter multi-line mode
+      })
+      act(() => {
+        result.current.handleEnter() // Add new line
+      })
+      act(() => {
+        result.current.handleCharacter(' ')
+      })
+      act(() => {
+        result.current.handleShiftEnter() // Exit and try to execute
+      })
+
+      // Assert - onCommand should not be called for whitespace-only
+      expect(onCommand).not.toHaveBeenCalled()
+    })
+
+    it('should not add whitespace-only multi-line command to history', () => {
+      // Arrange
+      const { result } = renderHook(() => useBashTerminal())
+
+      // Act
+      act(() => {
+        result.current.handleCharacter(' ')
+      })
+      act(() => {
+        result.current.handleShiftEnter() // Enter multi-line mode
+      })
+      act(() => {
+        result.current.handleShiftEnter() // Exit and try to execute
+      })
+
+      // Assert
+      expect(result.current.history).toEqual([])
+    })
+
+    it('should reset multiLineCursorLine to 0 when exiting multi-line mode via Ctrl+C', () => {
+      // Arrange
+      const { result } = renderHook(() => useBashTerminal())
+
+      // Act
+      act(() => {
+        result.current.handleCharacter('a')
+      })
+      act(() => {
+        result.current.handleShiftEnter() // Enter multi-line mode
+      })
+      act(() => {
+        result.current.handleEnter() // Add new line, cursorLine becomes 1
+      })
+      expect(result.current.multiLineCursorLine).toBe(1)
+
+      act(() => {
+        result.current.handleCtrlC()
+      })
+
+      // Assert
+      expect(result.current.multiLineCursorLine).toBe(0)
+    })
+  })
+
+  describe('history navigation commands', () => {
+    it('should return empty array when arrow down pressed without history navigation', () => {
+      // Arrange
+      const { result } = renderHook(() => useBashTerminal())
+
+      // Execute a command but don't navigate
+      act(() => {
+        result.current.handleCharacter('a')
+      })
+      act(() => {
+        result.current.handleEnter()
+      })
+
+      // Press arrow down without being in history navigation (historyIndex is -1)
+      let commands: TerminalCommand[]
+      act(() => {
+        commands = result.current.handleArrowDown()
+      })
+
+      // Assert - should return empty array since not navigating history
+      expect(commands!).toEqual([])
+    })
+
+    it('should return clearLine command when navigating past end of history', () => {
+      // Arrange
+      const { result } = renderHook(() => useBashTerminal())
+
+      // Execute a command
+      act(() => {
+        result.current.handleCharacter('a')
+      })
+      act(() => {
+        result.current.handleEnter()
+      })
+
+      // Navigate up then down
+      act(() => {
+        result.current.handleArrowUp()
+      })
+
+      let commands: TerminalCommand[]
+      act(() => {
+        commands = result.current.handleArrowDown()
+      })
+
+      // Assert - should have clearLine command
+      expect(commands!).toEqual([{ type: 'clearLine' }])
+    })
+
+    it('should set historyIndex to -1 when navigating past end of history', () => {
+      // Arrange
+      const { result } = renderHook(() => useBashTerminal())
+
+      // Execute a command
+      act(() => {
+        result.current.handleCharacter('a')
+      })
+      act(() => {
+        result.current.handleEnter()
+      })
+
+      // Navigate up
+      act(() => {
+        result.current.handleArrowUp()
+      })
+      expect(result.current.historyIndex).toBe(0)
+
+      // Navigate down past end
+      act(() => {
+        result.current.handleArrowDown()
+      })
+
+      // Assert
+      expect(result.current.historyIndex).toBe(-1)
+    })
+
+    it('should return clearLine and write commands when navigating within history', () => {
+      // Arrange
+      const { result } = renderHook(() => useBashTerminal())
+
+      // Execute two commands
+      act(() => {
+        result.current.handleCharacter('a')
+      })
+      act(() => {
+        result.current.handleEnter()
+      })
+      act(() => {
+        result.current.handleCharacter('b')
+      })
+      act(() => {
+        result.current.handleEnter()
+      })
+
+      // Navigate up twice then down once
+      act(() => {
+        result.current.handleArrowUp()
+      })
+      act(() => {
+        result.current.handleArrowUp()
+      })
+
+      let commands: TerminalCommand[]
+      act(() => {
+        commands = result.current.handleArrowDown()
+      })
+
+      // Assert - should have clearLine and write commands
+      expect(commands!).toEqual([
+        { type: 'clearLine' },
+        { type: 'write', data: 'b' },
+      ])
+    })
+
+    it('should return clearLine and write commands when navigating up', () => {
+      // Arrange
+      const { result } = renderHook(() => useBashTerminal())
+
+      // Execute a command
+      act(() => {
+        result.current.handleCharacter('t')
+      })
+      act(() => {
+        result.current.handleCharacter('e')
+      })
+      act(() => {
+        result.current.handleCharacter('s')
+      })
+      act(() => {
+        result.current.handleCharacter('t')
+      })
+      act(() => {
+        result.current.handleEnter()
+      })
+
+      // Navigate up
+      let commands: TerminalCommand[]
+      act(() => {
+        commands = result.current.handleArrowUp()
+      })
+
+      // Assert - should have clearLine and write commands
+      expect(commands!).toEqual([
+        { type: 'clearLine' },
+        { type: 'write', data: 'test' },
+      ])
+    })
+
+    it('should return empty array when at first history entry and pressing up', () => {
+      // Arrange
+      const { result } = renderHook(() => useBashTerminal())
+
+      // Execute a command
+      act(() => {
+        result.current.handleCharacter('a')
+      })
+      act(() => {
+        result.current.handleEnter()
+      })
+
+      // Navigate up to first entry
+      act(() => {
+        result.current.handleArrowUp()
+      })
+      expect(result.current.historyIndex).toBe(0)
+
+      // Try to navigate up again
+      let commands: TerminalCommand[]
+      act(() => {
+        commands = result.current.handleArrowUp()
+      })
+
+      // Assert - should return empty array
+      expect(commands!).toEqual([])
+    })
+
+    it('should return empty array when no history and pressing up', () => {
+      // Arrange
+      const { result } = renderHook(() => useBashTerminal())
+
+      // Press up without any history
+      let commands: TerminalCommand[]
+      act(() => {
+        commands = result.current.handleArrowUp()
+      })
+
+      // Assert
+      expect(commands!).toEqual([])
+    })
+  })
+
+  describe('ctrl+c edge cases', () => {
+    it('should not affect multiLineBuffer when not in multi-line mode', () => {
+      // Arrange
+      const { result } = renderHook(() => useBashTerminal())
+
+      // Don't enter multi-line mode
+      act(() => {
+        result.current.handleCharacter('a')
+      })
+      act(() => {
+        result.current.handleCtrlC()
+      })
+
+      // Assert - multiLineBuffer should still be empty
+      expect(result.current.multiLineBuffer).toEqual([])
+      expect(result.current.isMultiLineMode).toBe(false)
+    })
+
+    it('should clear multiLineBuffer when in multi-line mode', () => {
+      // Arrange
+      const { result } = renderHook(() => useBashTerminal())
+
+      // Enter multi-line mode with content
+      act(() => {
+        result.current.handleCharacter('a')
+      })
+      act(() => {
+        result.current.handleShiftEnter()
+      })
+      expect(result.current.multiLineBuffer).toEqual(['a'])
+
+      // Press Ctrl+C
+      act(() => {
+        result.current.handleCtrlC()
+      })
+
+      // Assert
+      expect(result.current.multiLineBuffer).toEqual([])
+    })
   })
 })


### PR DESCRIPTION
## Summary
- Added 20 tests targeting surviving mutants in useBashTerminal hook
- Tests cover multi-line mode commands, buffer preservation, history navigation, and Ctrl+C edge cases
- Mutation score improved from 77.24% to 91.13%

## Test plan
- All 71 tests pass
- Mutation score exceeds 80% target (91.13%)

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)