### PR TITLE
feat(#63): [#58] Integrate Monaco Editor theme switching

### DIFF
--- a/EPIC.md
+++ b/EPIC.md
@@ -1,6 +1,6 @@
 # Epic #58: Add light/dark mode theme switcher for the editor
 
-**Status:** In Progress (3/5 complete)
+**Status:** In Progress (3/5 complete, #63 in progress)
 **Branch:** epic-58
 **Created:** 2025-12-09
 **Last Updated:** 2025-12-09
@@ -23,7 +23,7 @@ Add support for light and dark mode themes in the editor, allowing users to swit
 | #60 | Create theme infrastructure (CSS variables, context, localStorage) | ✅ Complete | 60-create-theme-infrastructure | Merged PR #74 |
 | #61 | Theme core layout components (sidebar, panels, tabs) | ✅ Complete | 61-theme-core-layout-components | Merged PR #84 |
 | #62 | Theme terminal and REPL components | ✅ Complete | 62-theme-terminal-and-repl-components | Merged PR #89 |
-| #63 | Integrate Monaco Editor theme switching | ⏳ Pending | - | - |
+| #63 | Integrate Monaco Editor theme switching | 🔄 In Progress | 63-integrate-monaco-editor-theme-switching | - |
 | #64 | Add theme switcher UI control | ⏳ Pending | - | - |
 
 **Status Legend:**
@@ -57,6 +57,11 @@ Add support for light and dark mode themes in the editor, allowing users to swit
 - Themed BottomPanel terminal output (replaced hardcoded colors with CSS variables)
 - Added E2E tests for terminal theme colors
 - PR #89 merged, #62 complete
+- Started work on #63: Integrate Monaco Editor theme switching
+- Connected CodeEditor to useTheme() hook with Monaco theme mapping (dark → vs-dark, light → vs)
+- Updated CodeEditor.module.css loading state to use theme CSS variables
+- Added E2E tests for Monaco editor theme switching (theme-editor.spec.ts)
+- Fixed test files to mock useTheme (IDELayout, EmbeddableEditor, EditorPanel, LuaRepl)
 
 ## Key Files
 
@@ -84,6 +89,7 @@ Add support for light and dark mode themes in the editor, allowing users to swit
 - `src/components/LuaRepl/LuaRepl.module.css` - Themed REPL container styles
 - `src/components/BottomPanel/BottomPanel.module.css` - Themed bottom panel terminal output styles
 - `e2e/theme-terminal.spec.ts` - E2E tests for terminal theme colors
+- `e2e/theme-editor.spec.ts` - E2E tests for Monaco editor theme switching
 
 ## Open Questions
 

--- a/lua-learning-website/e2e/theme-editor.spec.ts
+++ b/lua-learning-website/e2e/theme-editor.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from '@playwright/test'
+
+// Helper to create and open a file so Monaco editor is visible
+async function createAndOpenFile(page: import('@playwright/test').Page) {
+  const sidebar = page.getByTestId('sidebar-panel')
+  await sidebar.getByRole('button', { name: /new file/i }).click()
+  const input = sidebar.getByRole('textbox')
+  await input.press('Enter') // Accept default name
+  await page.waitForTimeout(200)
+  // Click the file to open it
+  const treeItem = page.getByRole('treeitem').first()
+  await treeItem.click()
+  await page.waitForTimeout(500)
+}
+
+test.describe('Theme - Monaco Editor', () => {
+  test.beforeEach(async ({ page }) => {
+    // Clear localStorage to start fresh
+    await page.goto('/editor')
+    await page.evaluate(() => localStorage.clear())
+    // Wait for IDE layout to be ready
+    await expect(page.locator('[data-testid="ide-layout"]')).toBeVisible()
+  })
+
+  test('Monaco editor uses vs-dark theme in dark mode', async ({ page }) => {
+    // Set dark theme
+    await page.evaluate(() => localStorage.setItem('lua-ide-theme', 'dark'))
+    await page.reload()
+    await expect(page.locator('[data-testid="ide-layout"]')).toBeVisible()
+
+    // Create and open a file to show Monaco editor
+    await createAndOpenFile(page)
+
+    // Wait for Monaco editor to be visible
+    const monacoEditor = page.locator('.monaco-editor')
+    await expect(monacoEditor).toBeVisible({ timeout: 10000 })
+
+    // Monaco adds theme class to the editor element
+    // vs-dark theme adds 'vs-dark' class
+    await expect(monacoEditor).toHaveClass(/vs-dark/)
+  })
+
+  test('Monaco editor uses vs theme in light mode', async ({ page }) => {
+    // Set light theme
+    await page.evaluate(() => localStorage.setItem('lua-ide-theme', 'light'))
+    await page.reload()
+    await expect(page.locator('[data-testid="ide-layout"]')).toBeVisible()
+
+    // Create and open a file to show Monaco editor
+    await createAndOpenFile(page)
+
+    // Wait for Monaco editor to be visible
+    const monacoEditor = page.locator('.monaco-editor')
+    await expect(monacoEditor).toBeVisible({ timeout: 10000 })
+
+    // vs (light) theme should NOT have vs-dark class
+    await expect(monacoEditor).not.toHaveClass(/vs-dark/)
+  })
+
+  test('Monaco editor background matches theme in dark mode', async ({ page }) => {
+    // Set dark theme
+    await page.evaluate(() => localStorage.setItem('lua-ide-theme', 'dark'))
+    await page.reload()
+    await expect(page.locator('[data-testid="ide-layout"]')).toBeVisible()
+
+    // Create and open a file to show Monaco editor
+    await createAndOpenFile(page)
+
+    // Wait for Monaco editor
+    const monacoEditor = page.locator('.monaco-editor')
+    await expect(monacoEditor).toBeVisible({ timeout: 10000 })
+
+    // Check background color - vs-dark uses #1e1e1e
+    const bgColor = await monacoEditor.evaluate(el =>
+      getComputedStyle(el).backgroundColor
+    )
+    // #1e1e1e = rgb(30, 30, 30)
+    expect(bgColor).toBe('rgb(30, 30, 30)')
+  })
+
+  test('Monaco editor background matches theme in light mode', async ({ page }) => {
+    // Set light theme
+    await page.evaluate(() => localStorage.setItem('lua-ide-theme', 'light'))
+    await page.reload()
+    await expect(page.locator('[data-testid="ide-layout"]')).toBeVisible()
+
+    // Create and open a file to show Monaco editor
+    await createAndOpenFile(page)
+
+    // Wait for Monaco editor
+    const monacoEditor = page.locator('.monaco-editor')
+    await expect(monacoEditor).toBeVisible({ timeout: 10000 })
+
+    // Check background color - vs (light) uses #fffffe (near white)
+    const bgColor = await monacoEditor.evaluate(el =>
+      getComputedStyle(el).backgroundColor
+    )
+    // Monaco vs light theme uses #fffffe = rgb(255, 255, 254)
+    expect(bgColor).toBe('rgb(255, 255, 254)')
+  })
+
+  test('Monaco editor theme persists after page reload', async ({ page }) => {
+    // Start in dark mode
+    await page.evaluate(() => localStorage.setItem('lua-ide-theme', 'dark'))
+    await page.reload()
+    await expect(page.locator('[data-testid="ide-layout"]')).toBeVisible()
+
+    // Create and open a file to show Monaco editor
+    await createAndOpenFile(page)
+
+    // Wait for Monaco editor and verify dark theme
+    let monacoEditor = page.locator('.monaco-editor')
+    await expect(monacoEditor).toBeVisible({ timeout: 10000 })
+    await expect(monacoEditor).toHaveClass(/vs-dark/)
+
+    // Change theme to light and reload (simulating user switching themes)
+    await page.evaluate(() => localStorage.setItem('lua-ide-theme', 'light'))
+    await page.reload()
+    await expect(page.locator('[data-testid="ide-layout"]')).toBeVisible()
+
+    // Open a file again
+    await createAndOpenFile(page)
+
+    // Monaco should now have vs (light) theme
+    monacoEditor = page.locator('.monaco-editor')
+    await expect(monacoEditor).toBeVisible({ timeout: 10000 })
+    await expect(monacoEditor).not.toHaveClass(/vs-dark/)
+  })
+})

--- a/lua-learning-website/src/components/CodeEditor/CodeEditor.module.css
+++ b/lua-learning-website/src/components/CodeEditor/CodeEditor.module.css
@@ -9,6 +9,7 @@
   align-items: center;
   justify-content: center;
   height: 100%;
-  color: #666;
+  background-color: var(--theme-editor-bg);
+  color: var(--theme-text-muted);
   font-size: 14px;
 }

--- a/lua-learning-website/src/components/CodeEditor/CodeEditor.tsx
+++ b/lua-learning-website/src/components/CodeEditor/CodeEditor.tsx
@@ -1,6 +1,7 @@
 import Editor from '@monaco-editor/react'
 import type { CodeEditorProps } from './types'
 import styles from './CodeEditor.module.css'
+import { useTheme } from '../../contexts/useTheme'
 
 /**
  * A code editor component wrapping Monaco Editor
@@ -13,6 +14,9 @@ export function CodeEditor({
   readOnly = false,
   onRun,
 }: CodeEditorProps) {
+  const { theme } = useTheme()
+  const monacoTheme = theme === 'dark' ? 'vs-dark' : 'vs'
+
   const handleKeyDown = (event: React.KeyboardEvent) => {
     if (event.key === 'Enter' && event.ctrlKey) {
       onRun?.()
@@ -29,6 +33,7 @@ export function CodeEditor({
         height={height}
         language={language}
         value={value}
+        theme={monacoTheme}
         onChange={(newValue) => onChange(newValue ?? '')}
         options={{
           readOnly,

--- a/lua-learning-website/src/components/EditorPanel/EditorPanel.test.tsx
+++ b/lua-learning-website/src/components/EditorPanel/EditorPanel.test.tsx
@@ -22,6 +22,16 @@ vi.mock('@monaco-editor/react', () => ({
   },
 }))
 
+// Mock theme context (CodeEditor uses useTheme)
+vi.mock('../../contexts/useTheme', () => ({
+  useTheme: () => ({
+    theme: 'dark',
+    setTheme: vi.fn(),
+    toggleTheme: vi.fn(),
+    isDark: true,
+  }),
+}))
+
 describe('EditorPanel', () => {
   const defaultProps = {
     code: 'print("hello")',

--- a/lua-learning-website/src/components/EmbeddableEditor/EmbeddableEditor.test.tsx
+++ b/lua-learning-website/src/components/EmbeddableEditor/EmbeddableEditor.test.tsx
@@ -26,6 +26,16 @@ vi.mock('@monaco-editor/react', () => ({
   },
 }))
 
+// Mock theme context (CodeEditor uses useTheme)
+vi.mock('../../contexts/useTheme', () => ({
+  useTheme: () => ({
+    theme: 'dark',
+    setTheme: vi.fn(),
+    toggleTheme: vi.fn(),
+    isDark: true,
+  }),
+}))
+
 // Mock useLuaEngine
 const mockExecute = vi.fn()
 const mockReset = vi.fn()

--- a/lua-learning-website/src/components/IDELayout/IDELayout.test.tsx
+++ b/lua-learning-website/src/components/IDELayout/IDELayout.test.tsx
@@ -28,6 +28,16 @@ vi.mock('../LuaRepl', () => ({
   default: () => <div data-testid="lua-repl">LuaRepl Mock</div>,
 }))
 
+// Mock theme context (CodeEditor uses useTheme)
+vi.mock('../../contexts/useTheme', () => ({
+  useTheme: () => ({
+    theme: 'dark',
+    setTheme: vi.fn(),
+    toggleTheme: vi.fn(),
+    isDark: true,
+  }),
+}))
+
 describe('IDELayout', () => {
   describe('rendering', () => {
     it('should render IDEContextProvider (context available)', () => {

--- a/lua-learning-website/src/components/LuaRepl/LuaRepl.test.tsx
+++ b/lua-learning-website/src/components/LuaRepl/LuaRepl.test.tsx
@@ -26,6 +26,16 @@ vi.mock('wasmoon', () => ({
   LuaEngine: class MockLuaEngine {},
 }))
 
+// Mock theme context (LuaRepl uses useTheme for CSS module styling)
+vi.mock('../../contexts/useTheme', () => ({
+  useTheme: () => ({
+    theme: 'dark',
+    setTheme: vi.fn(),
+    toggleTheme: vi.fn(),
+    isDark: true,
+  }),
+}))
+
 import LuaRepl from './LuaRepl'
 
 describe('LuaRepl', () => {


### PR DESCRIPTION
## Summary
- Connected CodeEditor to useTheme() hook with Monaco theme mapping (dark → vs-dark, light → vs)
- Updated CSS module loading state to use theme CSS variables
- Added E2E tests for Monaco editor theme switching
- Fixed test files to mock useTheme context

## Test plan
- Unit tests pass (991 tests)
- E2E tests pass (5 new theme-editor tests)
- Build and lint pass

Fixes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)