### PR TITLE
chore(#99): Cleanup theme transitions, test mocks, and E2E timeouts

### DIFF
--- a/lua-learning-website/e2e/constants.ts
+++ b/lua-learning-website/e2e/constants.ts
@@ -1,0 +1,41 @@
+/**
+ * E2E Test Timeout Constants
+ *
+ * Centralized timeout values for Playwright tests.
+ * Use semantic names based on the purpose, not duration.
+ */
+
+/**
+ * UI Stabilization Timeouts
+ * Used after interactions to let the UI settle before assertions
+ */
+export const TIMEOUTS = {
+  /** Very brief pause for minimal UI updates (100ms) */
+  BRIEF: 100,
+
+  /** Standard UI stabilization wait (200ms) */
+  UI_STABLE: 200,
+
+  /** Wait for CSS transitions to complete (300ms) */
+  TRANSITION: 300,
+
+  /** Wait for animations to complete (500ms) */
+  ANIMATION: 500,
+
+  /** Wait for component initialization (1000ms) */
+  INIT: 1000,
+
+  /** Wait for async operations like Lua execution (5000ms) */
+  ASYNC_OPERATION: 5000,
+
+  /** Wait for elements to become visible (10000ms) */
+  ELEMENT_VISIBLE: 10000,
+
+  /** Extended timeout for slow CI environments (30000ms) */
+  CI_EXTENDED: 30000,
+} as const
+
+/**
+ * Type for timeout constant keys
+ */
+export type TimeoutKey = keyof typeof TIMEOUTS

--- a/lua-learning-website/e2e/theme-editor.spec.ts
+++ b/lua-learning-website/e2e/theme-editor.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { TIMEOUTS } from './constants'
 
 // Helper to create and open a file so Monaco editor is visible
 async function createAndOpenFile(page: import('@playwright/test').Page) {
@@ -6,11 +7,11 @@ async function createAndOpenFile(page: import('@playwright/test').Page) {
   await sidebar.getByRole('button', { name: /new file/i }).click()
   const input = sidebar.getByRole('textbox')
   await input.press('Enter') // Accept default name
-  await page.waitForTimeout(200)
+  await page.waitForTimeout(TIMEOUTS.UI_STABLE)
   // Click the file to open it
   const treeItem = page.getByRole('treeitem').first()
   await treeItem.click()
-  await page.waitForTimeout(500)
+  await page.waitForTimeout(TIMEOUTS.ANIMATION)
 }
 
 test.describe('Theme - Monaco Editor', () => {
@@ -33,7 +34,7 @@ test.describe('Theme - Monaco Editor', () => {
 
     // Wait for Monaco editor to be visible
     const monacoEditor = page.locator('.monaco-editor')
-    await expect(monacoEditor).toBeVisible({ timeout: 10000 })
+    await expect(monacoEditor).toBeVisible({ timeout: TIMEOUTS.ELEMENT_VISIBLE })
 
     // Monaco adds theme class to the editor element
     // vs-dark theme adds 'vs-dark' class
@@ -51,7 +52,7 @@ test.describe('Theme - Monaco Editor', () => {
 
     // Wait for Monaco editor to be visible
     const monacoEditor = page.locator('.monaco-editor')
-    await expect(monacoEditor).toBeVisible({ timeout: 10000 })
+    await expect(monacoEditor).toBeVisible({ timeout: TIMEOUTS.ELEMENT_VISIBLE })
 
     // vs (light) theme should NOT have vs-dark class
     await expect(monacoEditor).not.toHaveClass(/vs-dark/)
@@ -68,7 +69,7 @@ test.describe('Theme - Monaco Editor', () => {
 
     // Wait for Monaco editor
     const monacoEditor = page.locator('.monaco-editor')
-    await expect(monacoEditor).toBeVisible({ timeout: 10000 })
+    await expect(monacoEditor).toBeVisible({ timeout: TIMEOUTS.ELEMENT_VISIBLE })
 
     // Check background color - vs-dark uses #1e1e1e
     const bgColor = await monacoEditor.evaluate(el =>
@@ -89,7 +90,7 @@ test.describe('Theme - Monaco Editor', () => {
 
     // Wait for Monaco editor
     const monacoEditor = page.locator('.monaco-editor')
-    await expect(monacoEditor).toBeVisible({ timeout: 10000 })
+    await expect(monacoEditor).toBeVisible({ timeout: TIMEOUTS.ELEMENT_VISIBLE })
 
     // Check background color - vs (light) uses #fffffe (near white)
     const bgColor = await monacoEditor.evaluate(el =>
@@ -110,7 +111,7 @@ test.describe('Theme - Monaco Editor', () => {
 
     // Wait for Monaco editor and verify dark theme
     let monacoEditor = page.locator('.monaco-editor')
-    await expect(monacoEditor).toBeVisible({ timeout: 10000 })
+    await expect(monacoEditor).toBeVisible({ timeout: TIMEOUTS.ELEMENT_VISIBLE })
     await expect(monacoEditor).toHaveClass(/vs-dark/)
 
     // Change theme to light and reload (simulating user switching themes)
@@ -123,7 +124,7 @@ test.describe('Theme - Monaco Editor', () => {
 
     // Monaco should now have vs (light) theme
     monacoEditor = page.locator('.monaco-editor')
-    await expect(monacoEditor).toBeVisible({ timeout: 10000 })
+    await expect(monacoEditor).toBeVisible({ timeout: TIMEOUTS.ELEMENT_VISIBLE })
     await expect(monacoEditor).not.toHaveClass(/vs-dark/)
   })
 })

--- a/lua-learning-website/e2e/theme-layout.spec.ts
+++ b/lua-learning-website/e2e/theme-layout.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { TIMEOUTS } from './constants'
 
 test.describe('Theme - Layout Components', () => {
   test.beforeEach(async ({ page }) => {
@@ -51,7 +52,7 @@ test.describe('Theme - Layout Components', () => {
       localStorage.setItem('lua-ide-theme', 'light')
       document.documentElement.setAttribute('data-theme', 'light')
     })
-    await page.waitForTimeout(300) // Wait for transition
+    await page.waitForTimeout(TIMEOUTS.TRANSITION) // Wait for transition
 
     // In light theme, bg-primary should be #ffffff
     const lightBgColor = await ideLayout.evaluate(el =>
@@ -78,7 +79,7 @@ test.describe('Theme - Layout Components', () => {
       localStorage.setItem('lua-ide-theme', 'light')
       document.documentElement.setAttribute('data-theme', 'light')
     })
-    await page.waitForTimeout(300)
+    await page.waitForTimeout(TIMEOUTS.TRANSITION)
 
     // In light theme, bg-tertiary should be #e8e8e8
     const lightBgColor = await activityBar.evaluate(el =>
@@ -105,7 +106,7 @@ test.describe('Theme - Layout Components', () => {
       localStorage.setItem('lua-ide-theme', 'light')
       document.documentElement.setAttribute('data-theme', 'light')
     })
-    await page.waitForTimeout(300)
+    await page.waitForTimeout(TIMEOUTS.TRANSITION)
 
     // In light theme, bg-secondary should be #f3f3f3
     const lightBgColor = await sidebarPanel.evaluate(el =>
@@ -132,7 +133,7 @@ test.describe('Theme - Layout Components', () => {
       localStorage.setItem('lua-ide-theme', 'light')
       document.documentElement.setAttribute('data-theme', 'light')
     })
-    await page.waitForTimeout(300)
+    await page.waitForTimeout(TIMEOUTS.TRANSITION)
 
     // In light theme, accent-primary should be #0066b8
     const lightBgColor = await statusBar.evaluate(el =>
@@ -159,7 +160,7 @@ test.describe('Theme - Layout Components', () => {
       localStorage.setItem('lua-ide-theme', 'light')
       document.documentElement.setAttribute('data-theme', 'light')
     })
-    await page.waitForTimeout(300)
+    await page.waitForTimeout(TIMEOUTS.TRANSITION)
 
     // In light theme, bg-primary should be #ffffff
     const lightBgColor = await bottomPanel.evaluate(el =>
@@ -224,7 +225,7 @@ test.describe('Theme - Layout Components', () => {
       localStorage.setItem('lua-ide-theme', 'light')
       document.documentElement.setAttribute('data-theme', 'light')
     })
-    await page.waitForTimeout(300)
+    await page.waitForTimeout(TIMEOUTS.TRANSITION)
 
     // In light theme, bg-secondary should be #f3f3f3
     const lightBgColor = await fileExplorer.evaluate(el =>

--- a/lua-learning-website/e2e/theme-terminal.spec.ts
+++ b/lua-learning-website/e2e/theme-terminal.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { TIMEOUTS } from './constants'
 
 test.describe('Theme - Terminal Components', () => {
   test.beforeEach(async ({ page }) => {
@@ -21,10 +22,10 @@ test.describe('Theme - Terminal Components', () => {
 
     // Wait for terminal container to be visible
     const terminalContainer = page.locator('[data-testid="bash-terminal-container"]')
-    await expect(terminalContainer).toBeVisible({ timeout: 10000 })
+    await expect(terminalContainer).toBeVisible({ timeout: TIMEOUTS.ELEMENT_VISIBLE })
 
     // Wait for xterm to create its DOM
-    await page.waitForSelector('.xterm-viewport', { timeout: 10000 })
+    await page.waitForSelector('.xterm-viewport', { timeout: TIMEOUTS.ELEMENT_VISIBLE })
 
     // Check the xterm viewport background
     const xtermViewport = page.locator('.xterm-viewport')
@@ -47,8 +48,8 @@ test.describe('Theme - Terminal Components', () => {
 
     // Wait for terminal
     const terminalContainer = page.locator('[data-testid="bash-terminal-container"]')
-    await expect(terminalContainer).toBeVisible({ timeout: 10000 })
-    await page.waitForSelector('.xterm-viewport', { timeout: 10000 })
+    await expect(terminalContainer).toBeVisible({ timeout: TIMEOUTS.ELEMENT_VISIBLE })
+    await page.waitForSelector('.xterm-viewport', { timeout: TIMEOUTS.ELEMENT_VISIBLE })
 
     // Check the xterm viewport background
     const xtermViewport = page.locator('.xterm-viewport')
@@ -71,8 +72,8 @@ test.describe('Theme - Terminal Components', () => {
 
     // Wait for terminal container
     const terminalContainer = page.locator('[data-testid="bash-terminal-container"]')
-    await expect(terminalContainer).toBeVisible({ timeout: 10000 })
-    await page.waitForTimeout(1000) // Wait for REPL to initialize
+    await expect(terminalContainer).toBeVisible({ timeout: TIMEOUTS.ELEMENT_VISIBLE })
+    await page.waitForTimeout(TIMEOUTS.INIT) // Wait for REPL to initialize
 
     // Find any canvas element in the terminal (xterm uses canvas for text rendering)
     const canvases = page.locator('[data-testid="bash-terminal-container"] canvas')
@@ -160,21 +161,21 @@ test.describe('Theme - Terminal Components', () => {
 
     // Wait for terminal container
     const terminalContainer = page.locator('[data-testid="bash-terminal-container"]')
-    await expect(terminalContainer).toBeVisible({ timeout: 10000 })
-    await page.waitForTimeout(500)
+    await expect(terminalContainer).toBeVisible({ timeout: TIMEOUTS.ELEMENT_VISIBLE })
+    await page.waitForTimeout(TIMEOUTS.ANIMATION)
 
     // Switch to light theme
     await page.evaluate(() => {
       localStorage.setItem('lua-ide-theme', 'light')
       document.documentElement.setAttribute('data-theme', 'light')
     })
-    await page.waitForTimeout(1000)
+    await page.waitForTimeout(TIMEOUTS.INIT)
 
     // Type something in the REPL to create new text with the new theme
     await terminalContainer.click()
     await page.keyboard.type('print("test")')
     await page.keyboard.press('Enter')
-    await page.waitForTimeout(500)
+    await page.waitForTimeout(TIMEOUTS.ANIMATION)
 
     // Find canvas and check text color
     const canvases = page.locator('[data-testid="bash-terminal-container"] canvas')

--- a/lua-learning-website/src/__tests__/utils/mockTheme.ts
+++ b/lua-learning-website/src/__tests__/utils/mockTheme.ts
@@ -1,0 +1,94 @@
+import { vi } from 'vitest'
+
+/**
+ * ⚠️ VITEST HOISTING LIMITATION ⚠️
+ *
+ * These utilities CANNOT be used directly in vi.mock() factory functions
+ * due to vitest's hoisting behavior. vi.mock() calls are hoisted to the
+ * top of the file BEFORE imports are evaluated, causing errors like:
+ * "Cannot access '__vi_import_X__' before initialization"
+ *
+ * RECOMMENDED PATTERN: Use inline mock definitions instead:
+ *
+ * @example
+ * // ❌ DON'T DO THIS - will cause hoisting error
+ * import { createUseThemeMock } from '../../__tests__/utils/mockTheme'
+ * vi.mock('../../contexts/useTheme', () => createUseThemeMock())
+ *
+ * // ✅ DO THIS - inline mock definition works
+ * vi.mock('../../contexts/useTheme', () => ({
+ *   useTheme: () => ({
+ *     theme: 'dark',
+ *     setTheme: vi.fn(),
+ *     toggleTheme: vi.fn(),
+ *     isDark: true,
+ *   }),
+ * }))
+ *
+ * @example
+ * // ✅ ALTERNATIVE - use vi.hoisted() for shared mocks
+ * const { mockUseTheme } = vi.hoisted(() => ({
+ *   mockUseTheme: vi.fn(() => ({
+ *     theme: 'dark',
+ *     setTheme: vi.fn(),
+ *     toggleTheme: vi.fn(),
+ *     isDark: true,
+ *   })),
+ * }))
+ * vi.mock('../../contexts/useTheme', () => ({ useTheme: mockUseTheme }))
+ *
+ * These utilities can still be used for type definitions and as reference
+ * for the expected shape of theme mocks.
+ */
+
+/**
+ * Theme type (duplicated to avoid circular import issues with vi.mock hoisting)
+ */
+export type Theme = 'light' | 'dark'
+
+/**
+ * ThemeContextValue interface (duplicated to avoid circular import issues)
+ */
+export interface ThemeContextValue {
+  theme: Theme
+  setTheme: (theme: Theme) => void
+  toggleTheme: () => void
+  isDark: boolean
+}
+
+/**
+ * Default mock values for useTheme hook.
+ * Use these when you need a static theme context that doesn't change.
+ *
+ * NOTE: Cannot be used directly in vi.mock() - see hoisting warning above.
+ */
+export const defaultThemeMock: ThemeContextValue = {
+  theme: 'dark' as Theme,
+  isDark: true,
+  toggleTheme: vi.fn(),
+  setTheme: vi.fn(),
+}
+
+/**
+ * Creates a mock return value for useTheme with custom values.
+ * Useful for testing specific theme states with mockReturnValue().
+ *
+ * NOTE: Use this with mockReturnValue(), not in vi.mock() factory.
+ *
+ * @param overrides - Partial theme context values to override defaults
+ * @returns Complete ThemeContextValue with defaults and overrides merged
+ *
+ * @example
+ * // Use with mockReturnValue in tests
+ * (useTheme as Mock).mockReturnValue(createThemeMock({ theme: 'light', isDark: false }))
+ */
+export function createThemeMock(
+  overrides: Partial<ThemeContextValue> = {}
+): ThemeContextValue {
+  return {
+    ...defaultThemeMock,
+    toggleTheme: vi.fn(),
+    setTheme: vi.fn(),
+    ...overrides,
+  }
+}

--- a/lua-learning-website/src/components/ActivityBar/ActivityBar.module.css
+++ b/lua-learning-website/src/components/ActivityBar/ActivityBar.module.css
@@ -5,6 +5,7 @@
   width: 48px;
   background-color: var(--theme-bg-tertiary);
   border-right: 1px solid var(--theme-border-primary);
+  transition: var(--theme-transition);
 }
 
 .items {

--- a/lua-learning-website/src/components/ActivityBar/ActivityBar.test.tsx
+++ b/lua-learning-website/src/components/ActivityBar/ActivityBar.test.tsx
@@ -8,6 +8,7 @@ vi.mock('../../contexts', () => ({
     theme: 'dark',
     isDark: true,
     toggleTheme: vi.fn(),
+    setTheme: vi.fn(),
   }),
 }))
 

--- a/lua-learning-website/src/components/BashTerminal/BashTerminal.module.css
+++ b/lua-learning-website/src/components/BashTerminal/BashTerminal.module.css
@@ -28,6 +28,7 @@
   border-radius: 8px;
   padding: 1rem;
   overflow: hidden;
+  transition: var(--theme-transition);
 }
 
 .containerEmbedded .terminal {

--- a/lua-learning-website/src/components/BottomPanel/BottomPanel.module.css
+++ b/lua-learning-website/src/components/BottomPanel/BottomPanel.module.css
@@ -3,6 +3,7 @@
   flex-direction: column;
   height: 100%;
   background-color: var(--theme-bg-primary);
+  transition: var(--theme-transition);
 }
 
 .tabBar {

--- a/lua-learning-website/src/components/CodeEditor/CodeEditor.module.css
+++ b/lua-learning-website/src/components/CodeEditor/CodeEditor.module.css
@@ -12,4 +12,5 @@
   background-color: var(--theme-editor-bg);
   color: var(--theme-text-muted);
   font-size: 14px;
+  transition: var(--theme-transition);
 }

--- a/lua-learning-website/src/components/EditorPanel/EditorPanel.module.css
+++ b/lua-learning-website/src/components/EditorPanel/EditorPanel.module.css
@@ -3,6 +3,7 @@
   flex-direction: column;
   height: 100%;
   background-color: var(--theme-bg-primary);
+  transition: var(--theme-transition);
 }
 
 .toolbar {

--- a/lua-learning-website/src/components/FileExplorer/FileExplorer.module.css
+++ b/lua-learning-website/src/components/FileExplorer/FileExplorer.module.css
@@ -4,6 +4,7 @@
   height: 100%;
   background-color: var(--theme-bg-secondary);
   color: var(--theme-text-primary);
+  transition: var(--theme-transition);
 }
 
 .toolbar {

--- a/lua-learning-website/src/components/IDELayout/IDELayout.module.css
+++ b/lua-learning-website/src/components/IDELayout/IDELayout.module.css
@@ -5,6 +5,7 @@
   background-color: var(--theme-bg-primary);
   color: var(--theme-text-primary);
   overflow: hidden;
+  transition: var(--theme-transition);
 }
 
 .mainContainer {

--- a/lua-learning-website/src/components/IDEPanel/IDEPanel.module.css
+++ b/lua-learning-website/src/components/IDEPanel/IDEPanel.module.css
@@ -4,6 +4,7 @@
   height: 100%;
   overflow: hidden;
   background: var(--theme-bg-primary);
+  transition: var(--theme-transition);
 }
 
 .header {

--- a/lua-learning-website/src/components/SidebarPanel/SidebarPanel.module.css
+++ b/lua-learning-website/src/components/SidebarPanel/SidebarPanel.module.css
@@ -4,6 +4,7 @@
   height: 100%;
   background-color: var(--theme-bg-secondary);
   color: var(--theme-text-primary);
+  transition: var(--theme-transition);
 }
 
 .header {

--- a/lua-learning-website/src/components/StatusBar/StatusBar.module.css
+++ b/lua-learning-website/src/components/StatusBar/StatusBar.module.css
@@ -8,6 +8,7 @@
   color: #ffffff;
   font-size: 12px;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  transition: var(--theme-transition);
 }
 
 .left,

--- a/lua-learning-website/src/components/TabBar/TabBar.module.css
+++ b/lua-learning-website/src/components/TabBar/TabBar.module.css
@@ -4,6 +4,7 @@
   background-color: var(--theme-bg-secondary);
   border-bottom: 1px solid var(--theme-border-primary);
   overflow: hidden;
+  transition: var(--theme-transition);
 }
 
 .tabsContainer {

--- a/lua-learning-website/src/styles/themes.css
+++ b/lua-learning-website/src/styles/themes.css
@@ -119,19 +119,14 @@
 /**
  * Theme transition
  *
- * Apply smooth transitions when switching themes.
- * This class is applied to elements that should animate theme changes.
+ * Transitions are scoped to specific components for better performance.
+ * Each component's CSS module applies theme transitions to its root element.
+ * Use var(--theme-transition) in component CSS modules.
  */
 :root {
   --theme-transition-duration: 200ms;
   --theme-transition-timing: ease-in-out;
-}
-
-/* Base transition for all theme-affected properties */
-*,
-*::before,
-*::after {
-  transition:
+  --theme-transition:
     background-color var(--theme-transition-duration) var(--theme-transition-timing),
     border-color var(--theme-transition-duration) var(--theme-transition-timing),
     color var(--theme-transition-duration) var(--theme-transition-timing);


### PR DESCRIPTION
## Summary

Consolidates three tech debt items from Epic #58:

- **Scoped CSS Transitions**: Removed global `*` selector for theme transitions in favor of component-specific transitions using `--theme-transition` CSS variable. This improves performance by only transitioning elements that need it.

- **useTheme Mock Utility**: Added `src/__tests__/utils/mockTheme.ts` with type definitions and comprehensive documentation about vitest hoisting limitations. Test files use inline mocks (the only pattern that works with vitest's hoisting behavior).

- **E2E Timeout Constants**: Created `e2e/constants.ts` with standardized timeout constants (BRIEF, UI_STABLE, TRANSITION, ANIMATION, INIT, ASYNC_OPERATION, ELEMENT_VISIBLE, CI_EXTENDED) to replace magic numbers.

Closes #99

## Test plan

- [x] All 1005 unit tests pass
- [x] Lint passes with no errors
- [x] Build completes successfully  
- [x] All 27 theme-related E2E tests pass
- [ ] Manually verify theme transitions are smooth when toggling light/dark mode
- [ ] Verify no visual regressions in IDE layout components

🤖 Generated with [Claude Code](https://claude.com/claude-code)