### PR TITLE
feat(#120): Initialize shell-core package structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,14 @@
 # Claude Code session log
 .claude-log
 
+# Root npm workspace
+node_modules/
+package-lock.json
+
+# Package build outputs
+packages/*/dist/
+packages/*/node_modules/
+
 # Python bytecode
 __pycache__/
 *.pyc

--- a/EPIC.md
+++ b/EPIC.md
@@ -1,109 +1,94 @@
-# Epic #58: Add light/dark mode theme switcher for the editor
+# Epic #119: Shell Core Package Extraction
 
-**Status:** Complete (5/5 complete)
-**Branch:** epic-58
-**Created:** 2025-12-09
-**Last Updated:** 2025-12-09
+**Status:** In Progress (1/6 complete)
+**Branch:** epic-119
+**Created:** 2025-12-10
+**Last Updated:** 2025-12-10 13:48
 
 ## Overview
 
-Add support for light and dark mode themes in the editor, allowing users to switch between them. This will improve accessibility and user comfort, especially for users who prefer working in different lighting conditions.
+Extract the shell infrastructure into an independent `@lua-learning/shell-core` package to enable:
+- Isolated testing (faster feedback, clearer coverage)
+- Independent versioning
+- Cleaner architectural boundaries
+- Reuse potential (CLI, tutorials, other contexts)
+
+### Context
+
+The shell infrastructure in `src/shell/` is already ~95% decoupled from the editor with clean abstractions:
+- `IFileSystem` interface for filesystem operations
+- `createFileSystemAdapter` bridges editor filesystem to shell
+- Commands are pure logic with no editor dependencies
+- Only `ShellTerminal.tsx` connects to IDE context
+
+### Package Structure
+
+```
+LuaInTheWeb/
+├── packages/
+│   └── shell-core/              # Independent shell package
+│       ├── src/
+│       │   ├── commands/
+│       │   ├── types.ts
+│       │   ├── CommandRegistry.ts
+│       │   ├── createFileSystemAdapter.ts
+│       │   ├── parseCommand.ts
+│       │   ├── pathUtils.ts
+│       │   └── index.ts
+│       ├── tests/
+│       ├── package.json
+│       ├── tsconfig.json
+│       └── vitest.config.ts
+│
+└── lua-learning-website/        # Editor (imports shell-core)
+    ├── src/components/ShellTerminal/  # Integration wrapper
+    └── package.json             # Depends on shell-core
+```
 
 ## Architecture Decisions
 
-- **CSS Variables approach**: Theme colors defined as CSS custom properties on `:root` with `[data-theme="dark"]` and `[data-theme="light"]` selectors
-- **React Context pattern**: `ThemeProvider` wraps the app, `useTheme()` hook provides access
-- **Persistence**: localStorage with key `lua-ide-theme`, falls back to system preference via `prefers-color-scheme`
-- **File structure**: Follows IDEContext pattern with separate files for context, types, provider, and hook
+<!-- Document key decisions as work progresses -->
+
+(none yet)
 
 ## Sub-Issues
 
 | # | Title | Status | Branch | Notes |
 |---|-------|--------|--------|-------|
-| #60 | Create theme infrastructure (CSS variables, context, localStorage) | ✅ Complete | 60-create-theme-infrastructure | Merged PR #74 |
-| #61 | Theme core layout components (sidebar, panels, tabs) | ✅ Complete | 61-theme-core-layout-components | Merged PR #84 |
-| #62 | Theme terminal and REPL components | ✅ Complete | 62-theme-terminal-and-repl-components | Merged PR #89 |
-| #63 | Integrate Monaco Editor theme switching | ✅ Complete | 63-integrate-monaco-editor-theme-switching | Merged PR #94 |
-| #64 | Add theme switcher UI control | ✅ Complete | 64-add-theme-switcher-ui-control | Merged PR #97 |
+| #120 | Initialize shell-core package structure | ✅ Complete | epic-119 | Package structure, workspace, build/test configured |
+| #121 | Extract shell types and utilities | ⏳ Pending | - | - |
+| #122 | Extract CommandRegistry and filesystem adapter | ⏳ Pending | - | - |
+| #123 | Extract shell commands (cd, pwd, ls, help) | ⏳ Pending | - | - |
+| #124 | Integrate shell-core into editor | ⏳ Pending | - | - |
+| #125 | Shell-core documentation and cleanup | ⏳ Pending | - | - |
 
 **Status Legend:**
 - ⏳ Pending - Not yet started
 - 🔄 In Progress - Currently being worked on
-- 📝 Needs Review - PR created, awaiting review
 - ✅ Complete - Merged to epic branch
 - ❌ Blocked - Has unresolved blockers
-
-**Suggested order:** #60 → (#61, #62, #63 in parallel) → #64
 
 ## Progress Log
 
 <!-- Updated after each sub-issue completion -->
 
-### 2025-12-09
+### 2025-12-10
 - Epic started
-- Started work on #60: Create theme infrastructure
-- Completed #60 implementation, PR #74 created
-- PR #74 merged, #60 complete
-- Started work on #61: Theme core layout components
-- Completed #61 implementation, PR #84 created
-- Fixed file explorer theming (FileExplorer, FileTree, FileTreeItem CSS files)
-- PR #84 merged, #61 complete
-- Started work on #62: Theme terminal and REPL components
-- Created xterm.js theme configuration (dark/light terminal themes)
-- Updated BashTerminal to use useTheme() with dynamic theme switching
-- Converted BashTerminal.css to CSS module with theme variables
-- Converted LuaRepl.css to CSS module with theme variables
-- Fixed xterm.js theme application (set theme after terminal.open())
-- Themed BottomPanel terminal output (replaced hardcoded colors with CSS variables)
-- Added E2E tests for terminal theme colors
-- PR #89 merged, #62 complete
-- Started work on #63: Integrate Monaco Editor theme switching
-- Connected CodeEditor to useTheme() hook with Monaco theme mapping (dark → vs-dark, light → vs)
-- Updated CodeEditor.module.css loading state to use theme CSS variables
-- Added E2E tests for Monaco editor theme switching (theme-editor.spec.ts)
-- Fixed test files to mock useTheme (IDELayout, EmbeddableEditor, EditorPanel, LuaRepl)
-- PR #93 created for #63, targeting epic-58 branch
-- PR #94 merged, #63 complete
-- Tech debt issues created: #95 (useTheme mock), #96 (E2E timeouts)
-- Started work on #64: Add theme switcher UI control
-- Created ThemeToggle component with sun/moon icons
-- Added ThemeToggle to ActivityBar bottom section
-- Added unit tests (14) and E2E tests (8) for theme toggle
-- PR #97 created for #64, targeting epic-58 branch
-- Fixed IDEPanel.module.css to use theme variables (light mode fix)
-- PR #97 merged, #64 complete
-- **All 5 sub-issues complete - Epic ready for review**
+- **#120 Complete**: Initialized shell-core package structure
+  - Created `packages/shell-core/` with src, tests directories
+  - Configured package.json, tsconfig.json, vitest.config.ts
+  - Set up npm workspaces at root level
+  - Verified build and test pass
 
 ## Key Files
 
-- `src/styles/themes.css` - CSS custom properties for light/dark themes + transitions
-- `src/contexts/ThemeContext.tsx` - ThemeProvider component
-- `src/contexts/useTheme.ts` - useTheme hook
-- `src/contexts/types.ts` - Theme and ThemeContextValue types
-- `src/contexts/context.ts` - ThemeContext creation
-- `src/contexts/index.ts` - Public exports
-- `src/main.tsx` - ThemeProvider integration
-- `src/components/ActivityBar/ActivityBar.module.css` - Themed activity bar styles
-- `src/components/SidebarPanel/SidebarPanel.module.css` - Themed sidebar styles
-- `src/components/IDELayout/IDELayout.module.css` - Themed layout styles
-- `src/components/StatusBar/StatusBar.module.css` - Themed status bar styles
-- `src/components/EditorPanel/EditorPanel.module.css` - Themed editor panel styles
-- `src/components/TabBar/TabBar.module.css` - Themed tab bar styles
-- `src/components/BottomPanel/BottomPanel.module.css` - Themed bottom panel styles
-- `src/components/IDEResizeHandle/IDEResizeHandle.module.css` - Themed resize handle styles
-- `src/components/FileExplorer/FileExplorer.module.css` - Themed file explorer styles
-- `src/components/FileTree/FileTree.module.css` - Themed file tree styles
-- `src/components/FileTreeItem/FileTreeItem.module.css` - Themed file tree item styles
-- `e2e/theme-layout.spec.ts` - E2E tests for theme layout components
-- `src/components/BashTerminal/terminalTheme.ts` - xterm.js dark/light theme configuration
-- `src/components/BashTerminal/BashTerminal.module.css` - Themed terminal container styles
-- `src/components/LuaRepl/LuaRepl.module.css` - Themed REPL container styles
-- `src/components/BottomPanel/BottomPanel.module.css` - Themed bottom panel terminal output styles
-- `e2e/theme-terminal.spec.ts` - E2E tests for terminal theme colors
-- `e2e/theme-editor.spec.ts` - E2E tests for Monaco editor theme switching
-- `src/components/ThemeToggle/ThemeToggle.tsx` - Theme toggle button component
-- `src/components/ThemeToggle/ThemeToggle.module.css` - Theme toggle button styles
-- `e2e/theme-toggle.spec.ts` - E2E tests for theme toggle UI
+<!-- Populated as files are created/modified -->
+
+- `package.json` - Root workspace configuration
+- `packages/shell-core/package.json` - Shell-core package definition
+- `packages/shell-core/tsconfig.json` - TypeScript configuration
+- `packages/shell-core/vitest.config.ts` - Test configuration
+- `packages/shell-core/src/index.ts` - Package entry point
 
 ## Open Questions
 
@@ -114,11 +99,3 @@ Add support for light and dark mode themes in the editor, allowing users to swit
 ## Blockers
 
 (none)
-
-## Tech Debt
-
-| # | Description | Priority | Notes |
-|---|-------------|----------|-------|
-| #75 | Scope theme transitions to specific components instead of global `*` selector | Low | Address at end of epic if performance issues observed |
-| #95 | Extract shared useTheme mock to test utility | Low | PR #94 review feedback |
-| #96 | Extract E2E test timeouts to constants | Low | PR #94 review feedback |

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "lua-in-the-web",
+  "private": true,
+  "workspaces": [
+    "packages/*",
+    "lua-learning-website"
+  ],
+  "scripts": {
+    "build:shell-core": "npm run build -w @lua-learning/shell-core",
+    "test:shell-core": "npm run test -w @lua-learning/shell-core"
+  }
+}

--- a/packages/shell-core/package.json
+++ b/packages/shell-core/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@lua-learning/shell-core",
+  "version": "0.0.1",
+  "description": "Core shell infrastructure for Lua learning platform",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "lua",
+    "shell",
+    "terminal"
+  ],
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "~5.9.3",
+    "vitest": "^4.0.15"
+  }
+}

--- a/packages/shell-core/src/index.ts
+++ b/packages/shell-core/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @lua-learning/shell-core
+ *
+ * Core shell infrastructure for the Lua learning platform.
+ * Provides filesystem abstractions, command registry, and built-in commands.
+ */
+
+export const VERSION = '0.0.1'

--- a/packages/shell-core/tests/index.test.ts
+++ b/packages/shell-core/tests/index.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest'
+import { VERSION } from '../src/index'
+
+describe('shell-core package', () => {
+  it('exports VERSION constant', () => {
+    expect(VERSION).toBe('0.0.1')
+  })
+})

--- a/packages/shell-core/tsconfig.json
+++ b/packages/shell-core/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/shell-core/vitest.config.ts
+++ b/packages/shell-core/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['tests/**/*.{test,spec}.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: ['node_modules/', '**/*.d.ts', '**/*.config.*'],
+    },
+  },
+})


### PR DESCRIPTION
## Summary

- Create `packages/shell-core/` with src and tests directories
- Configure `@lua-learning/shell-core` package.json (ESM, TypeScript, Vitest)
- Set up npm workspaces at root level
- Add TypeScript and Vitest configuration for isolated testing
- Update `.gitignore` for monorepo structure

## Parent Epic
Part of Epic #119: Shell Core Package Extraction

Closes #120

## Test plan
- [x] `npm install` from root succeeds with workspaces
- [x] `npm run build:shell-core` compiles TypeScript
- [x] `npm run test:shell-core` passes (1 placeholder test)
- [x] `lua-learning-website` build still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)