### PR TITLE
feat(#122): Extract CommandRegistry and filesystem adapter

### DIFF
--- a/packages/shell-core/src/CommandRegistry.ts
+++ b/packages/shell-core/src/CommandRegistry.ts
@@ -1,0 +1,104 @@
+/**
+ * Registry for shell commands.
+ * Manages command registration, lookup, and execution.
+ */
+
+import type { Command, CommandResult, IFileSystem } from './types'
+
+/**
+ * A registry that stores and manages shell commands.
+ * Commands can be registered, looked up by name, and executed.
+ */
+export class CommandRegistry {
+  private commands: Map<string, Command> = new Map()
+
+  /**
+   * Register a command with the registry.
+   * @param command - The command to register
+   * @returns The registry instance for method chaining
+   * @throws Error if a command with the same name is already registered
+   */
+  register(command: Command): this {
+    if (this.commands.has(command.name)) {
+      throw new Error(`Command '${command.name}' is already registered`)
+    }
+    this.commands.set(command.name, command)
+    return this
+  }
+
+  /**
+   * Get a command by name.
+   * @param name - The command name to look up
+   * @returns The command if found, undefined otherwise
+   */
+  get(name: string): Command | undefined {
+    return this.commands.get(name)
+  }
+
+  /**
+   * Check if a command is registered.
+   * @param name - The command name to check
+   * @returns True if the command exists, false otherwise
+   */
+  has(name: string): boolean {
+    return this.commands.has(name)
+  }
+
+  /**
+   * Get all registered commands.
+   * @returns Array of all registered commands in insertion order
+   */
+  list(): Command[] {
+    return Array.from(this.commands.values())
+  }
+
+  /**
+   * Get all registered command names.
+   * @returns Array of command names
+   */
+  names(): string[] {
+    return Array.from(this.commands.keys())
+  }
+
+  /**
+   * Get the number of registered commands.
+   */
+  get size(): number {
+    return this.commands.size
+  }
+
+  /**
+   * Unregister a command by name.
+   * @param name - The command name to remove
+   * @returns True if the command was removed, false if it didn't exist
+   */
+  unregister(name: string): boolean {
+    return this.commands.delete(name)
+  }
+
+  /**
+   * Remove all registered commands.
+   */
+  clear(): void {
+    this.commands.clear()
+  }
+
+  /**
+   * Execute a command by name.
+   * @param name - The command name to execute
+   * @param args - Arguments to pass to the command
+   * @param fs - Filesystem to use for command execution
+   * @returns The command result
+   */
+  execute(name: string, args: string[], fs: IFileSystem): CommandResult {
+    const command = this.commands.get(name)
+    if (!command) {
+      return {
+        exitCode: 127,
+        stdout: '',
+        stderr: `Command not found: ${name}`,
+      }
+    }
+    return command.execute(args, fs)
+  }
+}

--- a/packages/shell-core/src/createFileSystemAdapter.ts
+++ b/packages/shell-core/src/createFileSystemAdapter.ts
@@ -1,0 +1,162 @@
+/**
+ * Factory function to create an IFileSystem adapter from an external filesystem.
+ * This bridges external filesystem implementations (like the editor's useFileSystem)
+ * to the shell-core's IFileSystem interface.
+ */
+
+import type { IFileSystem, FileEntry } from './types'
+import { normalizePath, joinPath, getParentPath, isAbsolutePath } from './pathUtils'
+
+/**
+ * External filesystem interface that the adapter wraps.
+ * This represents what an external system (like useFileSystem hook) provides.
+ */
+export interface ExternalFileSystem {
+  exists(path: string): boolean
+  readFile(path: string): string | null
+  writeFile(path: string, content: string): void
+  createFile(path: string, content?: string): void
+  createFolder(path: string): void
+  deleteFile(path: string): void
+  deleteFolder(path: string): void
+  listDirectory(path: string): string[]
+  isDirectory(path: string): boolean
+}
+
+/**
+ * Creates an IFileSystem adapter that wraps an external filesystem implementation.
+ *
+ * @param external - The external filesystem to wrap
+ * @param initialCwd - Initial current working directory (defaults to '/')
+ * @returns An IFileSystem implementation
+ */
+export function createFileSystemAdapter(
+  external: ExternalFileSystem,
+  initialCwd = '/'
+): IFileSystem {
+  let currentDirectory = normalizePath(initialCwd)
+
+  /**
+   * Resolve a path to an absolute path based on current directory.
+   */
+  function resolvePath(path: string): string {
+    if (isAbsolutePath(path)) {
+      return normalizePath(path)
+    }
+    return normalizePath(joinPath(currentDirectory, path))
+  }
+
+  return {
+    getCurrentDirectory(): string {
+      return currentDirectory
+    },
+
+    setCurrentDirectory(path: string): void {
+      const resolved = resolvePath(path)
+      if (!external.exists(resolved)) {
+        throw new Error(`Directory not found: ${resolved}`)
+      }
+      if (!external.isDirectory(resolved)) {
+        throw new Error(`Not a directory: ${resolved}`)
+      }
+      currentDirectory = resolved
+    },
+
+    exists(path: string): boolean {
+      const resolved = resolvePath(path)
+      return external.exists(resolved)
+    },
+
+    isDirectory(path: string): boolean {
+      const resolved = resolvePath(path)
+      if (!external.exists(resolved)) {
+        return false
+      }
+      return external.isDirectory(resolved)
+    },
+
+    isFile(path: string): boolean {
+      const resolved = resolvePath(path)
+      if (!external.exists(resolved)) {
+        return false
+      }
+      return !external.isDirectory(resolved)
+    },
+
+    listDirectory(path: string): FileEntry[] {
+      const resolved = resolvePath(path)
+      if (!external.exists(resolved)) {
+        throw new Error(`Directory not found: ${resolved}`)
+      }
+      if (!external.isDirectory(resolved)) {
+        throw new Error(`Not a directory: ${resolved}`)
+      }
+
+      const entries = external.listDirectory(resolved)
+      return entries.map((name) => {
+        const entryPath = joinPath(resolved, name)
+        const isDir = external.isDirectory(entryPath)
+        return {
+          name,
+          type: isDir ? 'directory' : 'file',
+          path: entryPath,
+        } as FileEntry
+      })
+    },
+
+    readFile(path: string): string {
+      const resolved = resolvePath(path)
+      if (!external.exists(resolved)) {
+        throw new Error(`File not found: ${resolved}`)
+      }
+      if (external.isDirectory(resolved)) {
+        throw new Error(`Not a file: ${resolved}`)
+      }
+      const content = external.readFile(resolved)
+      if (content === null) {
+        throw new Error(`File not found: ${resolved}`)
+      }
+      return content
+    },
+
+    writeFile(path: string, content: string): void {
+      const resolved = resolvePath(path)
+      if (external.exists(resolved)) {
+        if (external.isDirectory(resolved)) {
+          throw new Error(`Cannot write to directory: ${resolved}`)
+        }
+        external.writeFile(resolved, content)
+      } else {
+        external.createFile(resolved, content)
+      }
+    },
+
+    createDirectory(path: string): void {
+      const resolved = resolvePath(path)
+      if (external.exists(resolved)) {
+        throw new Error(`Path already exists: ${resolved}`)
+      }
+      const parent = getParentPath(resolved)
+      if (!external.exists(parent)) {
+        throw new Error(`Parent directory not found: ${parent}`)
+      }
+      external.createFolder(resolved)
+    },
+
+    delete(path: string): void {
+      const resolved = resolvePath(path)
+      if (!external.exists(resolved)) {
+        throw new Error(`Path not found: ${resolved}`)
+      }
+      if (external.isDirectory(resolved)) {
+        const entries = external.listDirectory(resolved)
+        if (entries.length > 0) {
+          throw new Error(`Directory not empty: ${resolved}`)
+        }
+        external.deleteFolder(resolved)
+      } else {
+        external.deleteFile(resolved)
+      }
+    },
+  }
+}

--- a/packages/shell-core/src/index.ts
+++ b/packages/shell-core/src/index.ts
@@ -29,3 +29,10 @@ export {
 
 // Command parsing
 export { parseCommand } from './parseCommand'
+
+// Command registry
+export { CommandRegistry } from './CommandRegistry'
+
+// Filesystem adapter
+export { createFileSystemAdapter } from './createFileSystemAdapter'
+export type { ExternalFileSystem } from './createFileSystemAdapter'

--- a/packages/shell-core/tests/CommandRegistry.test.ts
+++ b/packages/shell-core/tests/CommandRegistry.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { CommandRegistry } from '../src/CommandRegistry'
+import type { Command, IFileSystem, CommandResult } from '../src/types'
+
+// Mock command factory for testing
+function createMockCommand(name: string, description = 'Test command'): Command {
+  return {
+    name,
+    description,
+    usage: `${name} [args]`,
+    execute: (): CommandResult => ({ exitCode: 0, stdout: '', stderr: '' }),
+  }
+}
+
+describe('CommandRegistry', () => {
+  let registry: CommandRegistry
+
+  beforeEach(() => {
+    registry = new CommandRegistry()
+  })
+
+  describe('register', () => {
+    it('should register a command', () => {
+      const cmd = createMockCommand('test')
+      registry.register(cmd)
+      expect(registry.get('test')).toBe(cmd)
+    })
+
+    it('should register multiple commands', () => {
+      const cmd1 = createMockCommand('cmd1')
+      const cmd2 = createMockCommand('cmd2')
+      registry.register(cmd1)
+      registry.register(cmd2)
+      expect(registry.get('cmd1')).toBe(cmd1)
+      expect(registry.get('cmd2')).toBe(cmd2)
+    })
+
+    it('should throw error when registering duplicate command name', () => {
+      const cmd1 = createMockCommand('test')
+      const cmd2 = createMockCommand('test', 'Different description')
+      registry.register(cmd1)
+      expect(() => registry.register(cmd2)).toThrow(
+        "Command 'test' is already registered"
+      )
+    })
+
+    it('should return the registry instance for chaining', () => {
+      const cmd = createMockCommand('test')
+      const result = registry.register(cmd)
+      expect(result).toBe(registry)
+    })
+  })
+
+  describe('get', () => {
+    it('should return registered command by name', () => {
+      const cmd = createMockCommand('mycommand')
+      registry.register(cmd)
+      expect(registry.get('mycommand')).toBe(cmd)
+    })
+
+    it('should return undefined for non-existent command', () => {
+      expect(registry.get('nonexistent')).toBeUndefined()
+    })
+
+    it('should be case-sensitive', () => {
+      const cmd = createMockCommand('Test')
+      registry.register(cmd)
+      expect(registry.get('Test')).toBe(cmd)
+      expect(registry.get('test')).toBeUndefined()
+      expect(registry.get('TEST')).toBeUndefined()
+    })
+  })
+
+  describe('has', () => {
+    it('should return true for registered command', () => {
+      const cmd = createMockCommand('exists')
+      registry.register(cmd)
+      expect(registry.has('exists')).toBe(true)
+    })
+
+    it('should return false for non-existent command', () => {
+      expect(registry.has('nothere')).toBe(false)
+    })
+  })
+
+  describe('list', () => {
+    it('should return empty array when no commands registered', () => {
+      expect(registry.list()).toEqual([])
+    })
+
+    it('should return all registered commands', () => {
+      const cmd1 = createMockCommand('alpha')
+      const cmd2 = createMockCommand('beta')
+      const cmd3 = createMockCommand('gamma')
+      registry.register(cmd1)
+      registry.register(cmd2)
+      registry.register(cmd3)
+
+      const list = registry.list()
+      expect(list).toHaveLength(3)
+      expect(list).toContain(cmd1)
+      expect(list).toContain(cmd2)
+      expect(list).toContain(cmd3)
+    })
+
+    it('should return commands in insertion order', () => {
+      const cmd1 = createMockCommand('first')
+      const cmd2 = createMockCommand('second')
+      const cmd3 = createMockCommand('third')
+      registry.register(cmd1)
+      registry.register(cmd2)
+      registry.register(cmd3)
+
+      const list = registry.list()
+      expect(list[0]).toBe(cmd1)
+      expect(list[1]).toBe(cmd2)
+      expect(list[2]).toBe(cmd3)
+    })
+  })
+
+  describe('names', () => {
+    it('should return empty array when no commands registered', () => {
+      expect(registry.names()).toEqual([])
+    })
+
+    it('should return all registered command names', () => {
+      registry.register(createMockCommand('cd'))
+      registry.register(createMockCommand('ls'))
+      registry.register(createMockCommand('pwd'))
+
+      const names = registry.names()
+      expect(names).toHaveLength(3)
+      expect(names).toContain('cd')
+      expect(names).toContain('ls')
+      expect(names).toContain('pwd')
+    })
+  })
+
+  describe('size', () => {
+    it('should return 0 for empty registry', () => {
+      expect(registry.size).toBe(0)
+    })
+
+    it('should return correct count after registering commands', () => {
+      registry.register(createMockCommand('a'))
+      expect(registry.size).toBe(1)
+      registry.register(createMockCommand('b'))
+      expect(registry.size).toBe(2)
+      registry.register(createMockCommand('c'))
+      expect(registry.size).toBe(3)
+    })
+  })
+
+  describe('unregister', () => {
+    it('should remove a registered command', () => {
+      const cmd = createMockCommand('removeme')
+      registry.register(cmd)
+      expect(registry.has('removeme')).toBe(true)
+
+      const result = registry.unregister('removeme')
+      expect(result).toBe(true)
+      expect(registry.has('removeme')).toBe(false)
+      expect(registry.get('removeme')).toBeUndefined()
+    })
+
+    it('should return false when unregistering non-existent command', () => {
+      expect(registry.unregister('nothere')).toBe(false)
+    })
+
+    it('should not affect other commands when unregistering', () => {
+      const cmd1 = createMockCommand('keep')
+      const cmd2 = createMockCommand('remove')
+      registry.register(cmd1)
+      registry.register(cmd2)
+
+      registry.unregister('remove')
+      expect(registry.has('keep')).toBe(true)
+      expect(registry.get('keep')).toBe(cmd1)
+    })
+  })
+
+  describe('clear', () => {
+    it('should remove all commands', () => {
+      registry.register(createMockCommand('a'))
+      registry.register(createMockCommand('b'))
+      registry.register(createMockCommand('c'))
+      expect(registry.size).toBe(3)
+
+      registry.clear()
+      expect(registry.size).toBe(0)
+      expect(registry.list()).toEqual([])
+    })
+
+    it('should be safe to call on empty registry', () => {
+      expect(() => registry.clear()).not.toThrow()
+      expect(registry.size).toBe(0)
+    })
+  })
+
+  describe('execute', () => {
+    it('should execute a registered command with arguments', () => {
+      const mockFs: IFileSystem = {
+        getCurrentDirectory: () => '/',
+        setCurrentDirectory: () => {},
+        exists: () => true,
+        isDirectory: () => true,
+        isFile: () => false,
+        listDirectory: () => [],
+        readFile: () => '',
+        writeFile: () => {},
+        createDirectory: () => {},
+        delete: () => {},
+      }
+
+      const cmd: Command = {
+        name: 'echo',
+        description: 'Echo arguments',
+        usage: 'echo [text]',
+        execute: (args: string[]): CommandResult => ({
+          exitCode: 0,
+          stdout: args.join(' '),
+          stderr: '',
+        }),
+      }
+
+      registry.register(cmd)
+      const result = registry.execute('echo', ['hello', 'world'], mockFs)
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toBe('hello world')
+      expect(result.stderr).toBe('')
+    })
+
+    it('should return error result for non-existent command', () => {
+      const mockFs: IFileSystem = {
+        getCurrentDirectory: () => '/',
+        setCurrentDirectory: () => {},
+        exists: () => true,
+        isDirectory: () => true,
+        isFile: () => false,
+        listDirectory: () => [],
+        readFile: () => '',
+        writeFile: () => {},
+        createDirectory: () => {},
+        delete: () => {},
+      }
+
+      const result = registry.execute('nonexistent', [], mockFs)
+      expect(result.exitCode).toBe(127)
+      expect(result.stderr).toBe("Command not found: nonexistent")
+      expect(result.stdout).toBe('')
+    })
+  })
+})

--- a/packages/shell-core/tests/createFileSystemAdapter.test.ts
+++ b/packages/shell-core/tests/createFileSystemAdapter.test.ts
@@ -1,0 +1,346 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createFileSystemAdapter } from '../src/createFileSystemAdapter'
+import type { IFileSystem, FileEntry } from '../src/types'
+
+/**
+ * External filesystem interface that the adapter wraps.
+ * This represents what the editor's useFileSystem hook provides.
+ */
+interface ExternalFileSystem {
+  exists(path: string): boolean
+  readFile(path: string): string | null
+  writeFile(path: string, content: string): void
+  createFolder(path: string): void
+  deleteFile(path: string): void
+  deleteFolder(path: string): void
+  listDirectory(path: string): string[]
+  createFile(path: string, content?: string): void
+}
+
+function createMockExternalFs(): ExternalFileSystem & { _isDirectory: Set<string> } {
+  const _isDirectory = new Set<string>(['/'])
+
+  return {
+    _isDirectory,
+    exists: vi.fn(() => false),
+    readFile: vi.fn(() => null),
+    writeFile: vi.fn(),
+    createFile: vi.fn(),
+    createFolder: vi.fn(),
+    deleteFile: vi.fn(),
+    deleteFolder: vi.fn(),
+    listDirectory: vi.fn(() => []),
+  }
+}
+
+describe('createFileSystemAdapter', () => {
+  let externalFs: ReturnType<typeof createMockExternalFs>
+  let adapter: IFileSystem
+
+  beforeEach(() => {
+    externalFs = createMockExternalFs()
+    adapter = createFileSystemAdapter({
+      exists: externalFs.exists,
+      readFile: externalFs.readFile,
+      writeFile: externalFs.writeFile,
+      createFile: externalFs.createFile,
+      createFolder: externalFs.createFolder,
+      deleteFile: externalFs.deleteFile,
+      deleteFolder: externalFs.deleteFolder,
+      listDirectory: externalFs.listDirectory,
+      isDirectory: (path: string) => externalFs._isDirectory.has(path),
+    })
+  })
+
+  describe('getCurrentDirectory / setCurrentDirectory', () => {
+    it('should default to root directory', () => {
+      expect(adapter.getCurrentDirectory()).toBe('/')
+    })
+
+    it('should set and get current directory', () => {
+      // Setup: pretend /home exists and is a directory
+      externalFs._isDirectory.add('/home')
+      vi.mocked(externalFs.exists).mockImplementation((p) => p === '/home' || p === '/')
+
+      adapter.setCurrentDirectory('/home')
+      expect(adapter.getCurrentDirectory()).toBe('/home')
+    })
+
+    it('should throw error when setting to non-existent path', () => {
+      vi.mocked(externalFs.exists).mockReturnValue(false)
+
+      expect(() => adapter.setCurrentDirectory('/nonexistent')).toThrow(
+        "Directory not found: /nonexistent"
+      )
+    })
+
+    it('should throw error when setting to a file path', () => {
+      vi.mocked(externalFs.exists).mockReturnValue(true)
+      // Not in isDirectory set means it's a file
+
+      expect(() => adapter.setCurrentDirectory('/file.txt')).toThrow(
+        "Not a directory: /file.txt"
+      )
+    })
+  })
+
+  describe('exists', () => {
+    it('should delegate to external filesystem', () => {
+      vi.mocked(externalFs.exists).mockReturnValue(true)
+      expect(adapter.exists('/some/path')).toBe(true)
+      expect(externalFs.exists).toHaveBeenCalledWith('/some/path')
+    })
+
+    it('should return false for non-existent paths', () => {
+      vi.mocked(externalFs.exists).mockReturnValue(false)
+      expect(adapter.exists('/missing')).toBe(false)
+    })
+  })
+
+  describe('isDirectory', () => {
+    it('should return true for directories', () => {
+      externalFs._isDirectory.add('/mydir')
+      vi.mocked(externalFs.exists).mockReturnValue(true)
+
+      expect(adapter.isDirectory('/mydir')).toBe(true)
+    })
+
+    it('should return false for files', () => {
+      vi.mocked(externalFs.exists).mockReturnValue(true)
+      // Not in _isDirectory means it's a file
+
+      expect(adapter.isDirectory('/file.txt')).toBe(false)
+    })
+
+    it('should return false for non-existent paths', () => {
+      vi.mocked(externalFs.exists).mockReturnValue(false)
+      expect(adapter.isDirectory('/nothing')).toBe(false)
+    })
+  })
+
+  describe('isFile', () => {
+    it('should return true for files', () => {
+      vi.mocked(externalFs.exists).mockReturnValue(true)
+      // Not in _isDirectory means it's a file
+
+      expect(adapter.isFile('/file.txt')).toBe(true)
+    })
+
+    it('should return false for directories', () => {
+      externalFs._isDirectory.add('/mydir')
+      vi.mocked(externalFs.exists).mockReturnValue(true)
+
+      expect(adapter.isFile('/mydir')).toBe(false)
+    })
+
+    it('should return false for non-existent paths', () => {
+      vi.mocked(externalFs.exists).mockReturnValue(false)
+      expect(adapter.isFile('/nothing')).toBe(false)
+    })
+  })
+
+  describe('listDirectory', () => {
+    it('should convert string array to FileEntry array', () => {
+      vi.mocked(externalFs.exists).mockReturnValue(true)
+      externalFs._isDirectory.add('/test')
+      vi.mocked(externalFs.listDirectory).mockReturnValue(['file1.txt', 'folder1'])
+
+      // Setup: folder1 is a directory, file1.txt is a file
+      vi.mocked(externalFs.exists).mockImplementation((p) =>
+        ['/test', '/test/file1.txt', '/test/folder1'].includes(p)
+      )
+      externalFs._isDirectory.add('/test/folder1')
+
+      const entries = adapter.listDirectory('/test')
+
+      expect(entries).toHaveLength(2)
+      expect(entries).toContainEqual({
+        name: 'file1.txt',
+        type: 'file',
+        path: '/test/file1.txt',
+      })
+      expect(entries).toContainEqual({
+        name: 'folder1',
+        type: 'directory',
+        path: '/test/folder1',
+      })
+    })
+
+    it('should throw error for non-existent directory', () => {
+      vi.mocked(externalFs.exists).mockReturnValue(false)
+
+      expect(() => adapter.listDirectory('/nonexistent')).toThrow(
+        "Directory not found: /nonexistent"
+      )
+    })
+
+    it('should throw error when path is a file', () => {
+      vi.mocked(externalFs.exists).mockReturnValue(true)
+      // Not in _isDirectory
+
+      expect(() => adapter.listDirectory('/file.txt')).toThrow(
+        "Not a directory: /file.txt"
+      )
+    })
+
+    it('should return empty array for empty directory', () => {
+      vi.mocked(externalFs.exists).mockReturnValue(true)
+      externalFs._isDirectory.add('/empty')
+      vi.mocked(externalFs.listDirectory).mockReturnValue([])
+
+      const entries = adapter.listDirectory('/empty')
+      expect(entries).toEqual([])
+    })
+  })
+
+  describe('readFile', () => {
+    it('should read file content', () => {
+      vi.mocked(externalFs.exists).mockReturnValue(true)
+      vi.mocked(externalFs.readFile).mockReturnValue('file content')
+
+      const content = adapter.readFile('/test.txt')
+      expect(content).toBe('file content')
+      expect(externalFs.readFile).toHaveBeenCalledWith('/test.txt')
+    })
+
+    it('should throw error for non-existent file', () => {
+      vi.mocked(externalFs.exists).mockReturnValue(false)
+
+      expect(() => adapter.readFile('/missing.txt')).toThrow(
+        "File not found: /missing.txt"
+      )
+    })
+
+    it('should throw error when path is a directory', () => {
+      vi.mocked(externalFs.exists).mockReturnValue(true)
+      externalFs._isDirectory.add('/mydir')
+
+      expect(() => adapter.readFile('/mydir')).toThrow(
+        "Not a file: /mydir"
+      )
+    })
+
+    it('should throw error when external readFile returns null', () => {
+      vi.mocked(externalFs.exists).mockReturnValue(true)
+      vi.mocked(externalFs.readFile).mockReturnValue(null)
+
+      expect(() => adapter.readFile('/ghost.txt')).toThrow(
+        "File not found: /ghost.txt"
+      )
+    })
+  })
+
+  describe('writeFile', () => {
+    it('should write content to existing file', () => {
+      vi.mocked(externalFs.exists).mockReturnValue(true)
+
+      adapter.writeFile('/test.txt', 'new content')
+      expect(externalFs.writeFile).toHaveBeenCalledWith('/test.txt', 'new content')
+    })
+
+    it('should create file if it does not exist', () => {
+      vi.mocked(externalFs.exists).mockReturnValue(false)
+
+      adapter.writeFile('/new.txt', 'content')
+      expect(externalFs.createFile).toHaveBeenCalledWith('/new.txt', 'content')
+    })
+
+    it('should throw error when path is a directory', () => {
+      vi.mocked(externalFs.exists).mockReturnValue(true)
+      externalFs._isDirectory.add('/mydir')
+
+      expect(() => adapter.writeFile('/mydir', 'content')).toThrow(
+        "Cannot write to directory: /mydir"
+      )
+    })
+  })
+
+  describe('createDirectory', () => {
+    it('should create a directory', () => {
+      vi.mocked(externalFs.exists).mockImplementation((p) => p === '/')
+      externalFs._isDirectory.add('/')
+
+      adapter.createDirectory('/newdir')
+      expect(externalFs.createFolder).toHaveBeenCalledWith('/newdir')
+    })
+
+    it('should throw error if path already exists', () => {
+      vi.mocked(externalFs.exists).mockReturnValue(true)
+
+      expect(() => adapter.createDirectory('/existing')).toThrow(
+        "Path already exists: /existing"
+      )
+    })
+
+    it('should throw error if parent does not exist', () => {
+      vi.mocked(externalFs.exists).mockReturnValue(false)
+
+      expect(() => adapter.createDirectory('/missing/child')).toThrow(
+        "Parent directory not found: /missing"
+      )
+    })
+  })
+
+  describe('delete', () => {
+    it('should delete a file', () => {
+      vi.mocked(externalFs.exists).mockReturnValue(true)
+      // Not in _isDirectory means file
+
+      adapter.delete('/file.txt')
+      expect(externalFs.deleteFile).toHaveBeenCalledWith('/file.txt')
+    })
+
+    it('should delete an empty directory', () => {
+      vi.mocked(externalFs.exists).mockReturnValue(true)
+      externalFs._isDirectory.add('/emptydir')
+      vi.mocked(externalFs.listDirectory).mockReturnValue([])
+
+      adapter.delete('/emptydir')
+      expect(externalFs.deleteFolder).toHaveBeenCalledWith('/emptydir')
+    })
+
+    it('should throw error for non-existent path', () => {
+      vi.mocked(externalFs.exists).mockReturnValue(false)
+
+      expect(() => adapter.delete('/missing')).toThrow(
+        "Path not found: /missing"
+      )
+    })
+
+    it('should throw error for non-empty directory', () => {
+      vi.mocked(externalFs.exists).mockReturnValue(true)
+      externalFs._isDirectory.add('/nonempty')
+      vi.mocked(externalFs.listDirectory).mockReturnValue(['file.txt'])
+
+      expect(() => adapter.delete('/nonempty')).toThrow(
+        "Directory not empty: /nonempty"
+      )
+    })
+  })
+
+  describe('path normalization', () => {
+    it('should handle paths without leading slash', () => {
+      vi.mocked(externalFs.exists).mockReturnValue(true)
+      vi.mocked(externalFs.readFile).mockReturnValue('content')
+
+      // When we call with a relative-looking path, it should normalize
+      adapter.readFile('file.txt')
+
+      // The adapter should normalize to absolute path
+      expect(externalFs.readFile).toHaveBeenCalledWith('/file.txt')
+    })
+
+    it('should handle current directory in relative paths', () => {
+      // Setup current directory to /home
+      externalFs._isDirectory.add('/home')
+      vi.mocked(externalFs.exists).mockReturnValue(true)
+      adapter.setCurrentDirectory('/home')
+
+      vi.mocked(externalFs.readFile).mockReturnValue('content')
+
+      // Reading a relative path should resolve from current directory
+      adapter.readFile('test.txt')
+      expect(externalFs.readFile).toHaveBeenCalledWith('/home/test.txt')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Created CommandRegistry class to manage shell command registration, lookup, and execution
- Created createFileSystemAdapter factory function to bridge external filesystems to IFileSystem interface
- Added comprehensive tests for both components (55 new tests)
- Exported both from package index.ts along with ExternalFileSystem type

## Test plan
- [x] Unit tests pass: 122 total tests
- [x] Mutation tests pass: 87.80% overall (CommandRegistry 100%, createFileSystemAdapter 91.14%)
- [x] Build succeeds: tsc compiles without errors
- [ ] Manual verification: Import CommandRegistry and createFileSystemAdapter in consuming code

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)