### PR TITLE
feat(#123): Add shell commands (pwd, cd, ls, help) to shell-core

### DIFF
--- a/EPIC.md
+++ b/EPIC.md
@@ -1,9 +1,9 @@
 # Epic #119: Shell Core Package Extraction
 
-**Status:** In Progress (3/6 complete)
+**Status:** In Progress (4/6 complete)
 **Branch:** epic-119
 **Created:** 2025-12-10
-**Last Updated:** 2025-12-10 17:47
+**Last Updated:** 2025-12-10 16:00
 
 ## Overview
 
@@ -58,7 +58,7 @@ LuaInTheWeb/
 | #120 | Initialize shell-core package structure | ✅ Complete | 120-initialize-shell-core | Merged PR #126 |
 | #121 | Extract shell types and utilities | ✅ Complete | 121-extract-shell-types-and-utilities | Merged PR #127 |
 | #122 | Extract CommandRegistry and filesystem adapter | ✅ Complete | 122-extract-commandregistry-and-filesystem-adapter | Merged PR #128 |
-| #123 | Extract shell commands (cd, pwd, ls, help) | ⏳ Pending | - | - |
+| #123 | Extract shell commands (cd, pwd, ls, help) | 🔄 In Progress | 123-extract-shell-commands | Implementation complete, awaiting review |
 | #124 | Integrate shell-core into editor | ⏳ Pending | - | - |
 | #125 | Shell-core documentation and cleanup | ⏳ Pending | - | - |
 
@@ -92,6 +92,14 @@ LuaInTheWeb/
   - Added 55 tests (122 total)
   - Mutation scores: CommandRegistry 100%, createFileSystemAdapter 91.14%
   - Merged PR #128 to epic-119
+- **#123 In Progress**: Extract shell commands (cd, pwd, ls, help)
+  - Created `commands/pwd.ts` - print working directory
+  - Created `commands/cd.ts` - change directory with path resolution
+  - Created `commands/ls.ts` - list directory contents with sorting (dirs first)
+  - Created `commands/help.ts` - display help for commands (uses CommandRegistry)
+  - Created `commands/index.ts` - exports and `registerBuiltinCommands()` helper
+  - Added 59 tests (181 total)
+  - Mutation scores: pwd 100%, cd 100%, ls 100%, help 93.10%, commands overall 97.53%
 
 ## Key Files
 
@@ -108,6 +116,11 @@ LuaInTheWeb/
 - `packages/shell-core/src/parseCommand.ts` - Command string parser
 - `packages/shell-core/src/CommandRegistry.ts` - Command registration and execution
 - `packages/shell-core/src/createFileSystemAdapter.ts` - External filesystem adapter
+- `packages/shell-core/src/commands/pwd.ts` - pwd command implementation
+- `packages/shell-core/src/commands/cd.ts` - cd command implementation
+- `packages/shell-core/src/commands/ls.ts` - ls command implementation
+- `packages/shell-core/src/commands/help.ts` - help command factory
+- `packages/shell-core/src/commands/index.ts` - Command exports and registration helper
 
 ## Open Questions
 

--- a/packages/shell-core/src/commands/cd.ts
+++ b/packages/shell-core/src/commands/cd.ts
@@ -1,0 +1,52 @@
+/**
+ * cd command - change directory.
+ */
+
+import type { Command, CommandResult, IFileSystem } from '../types'
+import { resolvePath } from '../pathUtils'
+
+/**
+ * cd command implementation.
+ * Changes the current working directory.
+ */
+export const cd: Command = {
+  name: 'cd',
+  description: 'Change the current working directory',
+  usage: 'cd [path]',
+
+  execute(args: string[], fs: IFileSystem): CommandResult {
+    // Default to root if no path provided
+    const targetPath = args[0] ?? '/'
+
+    // Resolve the path relative to current directory
+    const currentDir = fs.getCurrentDirectory()
+    const resolvedPath = resolvePath(currentDir, targetPath)
+
+    // Check if path exists
+    if (!fs.exists(resolvedPath)) {
+      return {
+        exitCode: 1,
+        stdout: '',
+        stderr: `cd: ${resolvedPath}: no such file or directory`,
+      }
+    }
+
+    // Check if path is a directory
+    if (!fs.isDirectory(resolvedPath)) {
+      return {
+        exitCode: 1,
+        stdout: '',
+        stderr: `cd: ${resolvedPath}: not a directory`,
+      }
+    }
+
+    // Change directory
+    fs.setCurrentDirectory(resolvedPath)
+
+    return {
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    }
+  },
+}

--- a/packages/shell-core/src/commands/help.ts
+++ b/packages/shell-core/src/commands/help.ts
@@ -1,0 +1,81 @@
+/**
+ * help command - display help information.
+ */
+
+import type { Command, CommandResult, IFileSystem } from '../types'
+import type { CommandRegistry } from '../CommandRegistry'
+
+/**
+ * Create a help command that has access to the command registry.
+ * @param registry - The command registry to list commands from
+ * @returns A help command instance
+ */
+export function createHelpCommand(registry: CommandRegistry): Command {
+  return {
+    name: 'help',
+    description: 'Display help information for commands',
+    usage: 'help [command]',
+
+    execute(args: string[], _fs: IFileSystem): CommandResult {
+      const commandName = args[0]
+
+      // If a specific command is requested
+      if (commandName) {
+        const command = registry.get(commandName)
+
+        if (!command) {
+          return {
+            exitCode: 1,
+            stdout: '',
+            stderr: `help: command '${commandName}' not found`,
+          }
+        }
+
+        // Show detailed help for the command
+        const output = [
+          `${command.name} - ${command.description}`,
+          '',
+          `Usage: ${command.usage}`,
+        ].join('\n')
+
+        return {
+          exitCode: 0,
+          stdout: output,
+          stderr: '',
+        }
+      }
+
+      // List all commands
+      const commands = registry.list()
+
+      if (commands.length === 0) {
+        return {
+          exitCode: 0,
+          stdout: 'No commands available',
+          stderr: '',
+        }
+      }
+
+      // Sort commands alphabetically
+      const sortedCommands = [...commands].sort((a, b) =>
+        a.name.localeCompare(b.name)
+      )
+
+      // Format output
+      const lines = ['Available commands:', '']
+
+      for (const cmd of sortedCommands) {
+        lines.push(`  ${cmd.name.padEnd(12)} ${cmd.description}`)
+      }
+
+      lines.push('')
+      lines.push('Type "help <command>" for more information.')
+
+      return {
+        exitCode: 0,
+        stdout: lines.join('\n'),
+        stderr: '',
+      }
+    },
+  }
+}

--- a/packages/shell-core/src/commands/index.ts
+++ b/packages/shell-core/src/commands/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Shell commands module.
+ * Exports all built-in commands and a helper to register them.
+ */
+
+import type { CommandRegistry } from '../CommandRegistry'
+import { pwd } from './pwd'
+import { cd } from './cd'
+import { ls } from './ls'
+import { createHelpCommand } from './help'
+
+// Export individual commands
+export { pwd } from './pwd'
+export { cd } from './cd'
+export { ls } from './ls'
+export { createHelpCommand } from './help'
+
+/**
+ * Register all built-in commands with a registry.
+ * @param registry - The command registry to register commands with
+ * @returns The registry for method chaining
+ */
+export function registerBuiltinCommands(registry: CommandRegistry): CommandRegistry {
+  registry.register(pwd)
+  registry.register(cd)
+  registry.register(ls)
+  registry.register(createHelpCommand(registry))
+  return registry
+}
+
+/**
+ * Array of all built-in command instances (except help, which requires a registry).
+ */
+export const builtinCommands = [pwd, cd, ls] as const

--- a/packages/shell-core/src/commands/ls.ts
+++ b/packages/shell-core/src/commands/ls.ts
@@ -1,0 +1,78 @@
+/**
+ * ls command - list directory contents.
+ */
+
+import type { Command, CommandResult, IFileSystem, FileEntry } from '../types'
+import { resolvePath, getBasename } from '../pathUtils'
+
+/**
+ * Sort entries: directories first (alphabetically), then files (alphabetically).
+ */
+function sortEntries(entries: FileEntry[]): FileEntry[] {
+  return [...entries].sort((a, b) => {
+    // Directories come before files
+    if (a.type !== b.type) {
+      return a.type === 'directory' ? -1 : 1
+    }
+    // Within same type, sort alphabetically
+    return a.name.localeCompare(b.name)
+  })
+}
+
+/**
+ * Format an entry for display.
+ * Appends / to directory names.
+ */
+function formatEntry(entry: FileEntry): string {
+  return entry.type === 'directory' ? `${entry.name}/` : entry.name
+}
+
+/**
+ * ls command implementation.
+ * Lists directory contents.
+ */
+export const ls: Command = {
+  name: 'ls',
+  description: 'List directory contents',
+  usage: 'ls [path]',
+
+  execute(args: string[], fs: IFileSystem): CommandResult {
+    // Default to current directory if no path provided
+    const targetPath = args[0] ?? fs.getCurrentDirectory()
+
+    // Resolve the path relative to current directory
+    const currentDir = fs.getCurrentDirectory()
+    const resolvedPath = resolvePath(currentDir, targetPath)
+
+    // Check if path exists
+    if (!fs.exists(resolvedPath)) {
+      return {
+        exitCode: 1,
+        stdout: '',
+        stderr: `ls: ${resolvedPath}: no such file or directory`,
+      }
+    }
+
+    // If path is a file, just show the filename
+    if (fs.isFile(resolvedPath)) {
+      return {
+        exitCode: 0,
+        stdout: getBasename(resolvedPath),
+        stderr: '',
+      }
+    }
+
+    // List directory contents
+    const entries = fs.listDirectory(resolvedPath)
+
+    // Sort and format entries
+    const sortedEntries = sortEntries(entries)
+    const output = sortedEntries.map(formatEntry).join('\n')
+
+    return {
+      exitCode: 0,
+      stdout: output,
+      stderr: '',
+    }
+  },
+}

--- a/packages/shell-core/src/commands/pwd.ts
+++ b/packages/shell-core/src/commands/pwd.ts
@@ -1,0 +1,24 @@
+/**
+ * pwd command - print working directory.
+ */
+
+import type { Command, CommandResult, IFileSystem } from '../types'
+
+/**
+ * pwd command implementation.
+ * Prints the current working directory.
+ */
+export const pwd: Command = {
+  name: 'pwd',
+  description: 'Print the current working directory',
+  usage: 'pwd',
+
+  execute(_args: string[], fs: IFileSystem): CommandResult {
+    const currentDir = fs.getCurrentDirectory()
+    return {
+      exitCode: 0,
+      stdout: currentDir,
+      stderr: '',
+    }
+  },
+}

--- a/packages/shell-core/src/index.ts
+++ b/packages/shell-core/src/index.ts
@@ -36,3 +36,13 @@ export { CommandRegistry } from './CommandRegistry'
 // Filesystem adapter
 export { createFileSystemAdapter } from './createFileSystemAdapter'
 export type { ExternalFileSystem } from './createFileSystemAdapter'
+
+// Built-in commands
+export {
+  pwd,
+  cd,
+  ls,
+  createHelpCommand,
+  registerBuiltinCommands,
+  builtinCommands,
+} from './commands'

--- a/packages/shell-core/tests/commands/cd.test.ts
+++ b/packages/shell-core/tests/commands/cd.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for cd command.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { cd } from '../../src/commands/cd'
+import type { IFileSystem } from '../../src/types'
+
+describe('cd command', () => {
+  let mockFs: IFileSystem
+
+  beforeEach(() => {
+    mockFs = {
+      getCurrentDirectory: vi.fn().mockReturnValue('/home/user'),
+      setCurrentDirectory: vi.fn(),
+      exists: vi.fn().mockReturnValue(true),
+      isDirectory: vi.fn().mockReturnValue(true),
+      isFile: vi.fn().mockReturnValue(false),
+      listDirectory: vi.fn(),
+      readFile: vi.fn(),
+      writeFile: vi.fn(),
+      createDirectory: vi.fn(),
+      delete: vi.fn(),
+    }
+  })
+
+  describe('metadata', () => {
+    it('should have correct name', () => {
+      expect(cd.name).toBe('cd')
+    })
+
+    it('should have a description', () => {
+      expect(cd.description).toBeTruthy()
+      expect(typeof cd.description).toBe('string')
+    })
+
+    it('should have usage information', () => {
+      expect(cd.usage).toBeTruthy()
+      expect(typeof cd.usage).toBe('string')
+    })
+  })
+
+  describe('execute with valid path', () => {
+    it('should change to absolute path', () => {
+      const result = cd.execute(['/var/log'], mockFs)
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toBe('')
+      expect(result.stderr).toBe('')
+      expect(mockFs.setCurrentDirectory).toHaveBeenCalledWith('/var/log')
+    })
+
+    it('should change to relative path', () => {
+      const result = cd.execute(['projects'], mockFs)
+
+      expect(result.exitCode).toBe(0)
+      expect(mockFs.setCurrentDirectory).toHaveBeenCalledWith('/home/user/projects')
+    })
+
+    it('should resolve parent directory (..) correctly', () => {
+      const result = cd.execute(['..'], mockFs)
+
+      expect(result.exitCode).toBe(0)
+      expect(mockFs.setCurrentDirectory).toHaveBeenCalledWith('/home')
+    })
+
+    it('should resolve complex relative paths', () => {
+      const result = cd.execute(['../other/folder'], mockFs)
+
+      expect(result.exitCode).toBe(0)
+      expect(mockFs.setCurrentDirectory).toHaveBeenCalledWith('/home/other/folder')
+    })
+
+    it('should resolve current directory (.) to same path', () => {
+      const result = cd.execute(['.'], mockFs)
+
+      expect(result.exitCode).toBe(0)
+      expect(mockFs.setCurrentDirectory).toHaveBeenCalledWith('/home/user')
+    })
+  })
+
+  describe('execute with no arguments', () => {
+    it('should change to root directory when no args provided', () => {
+      const result = cd.execute([], mockFs)
+
+      expect(result.exitCode).toBe(0)
+      expect(mockFs.setCurrentDirectory).toHaveBeenCalledWith('/')
+    })
+  })
+
+  describe('execute with invalid path', () => {
+    it('should return error when path does not exist', () => {
+      mockFs.exists = vi.fn().mockReturnValue(false)
+
+      const result = cd.execute(['/nonexistent'], mockFs)
+
+      expect(result.exitCode).toBe(1)
+      expect(result.stderr).toContain('no such file or directory')
+      expect(result.stderr).toContain('/nonexistent')
+      expect(result.stdout).toBe('')
+      expect(mockFs.setCurrentDirectory).not.toHaveBeenCalled()
+    })
+
+    it('should return error when path is a file, not directory', () => {
+      mockFs.exists = vi.fn().mockReturnValue(true)
+      mockFs.isDirectory = vi.fn().mockReturnValue(false)
+      mockFs.isFile = vi.fn().mockReturnValue(true)
+
+      const result = cd.execute(['/home/user/file.txt'], mockFs)
+
+      expect(result.exitCode).toBe(1)
+      expect(result.stderr).toContain('not a directory')
+      expect(result.stderr).toContain('/home/user/file.txt')
+      expect(result.stdout).toBe('')
+      expect(mockFs.setCurrentDirectory).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle root directory', () => {
+      mockFs.getCurrentDirectory = vi.fn().mockReturnValue('/')
+
+      const result = cd.execute(['..'], mockFs)
+
+      expect(result.exitCode).toBe(0)
+      // Going up from root stays at root
+      expect(mockFs.setCurrentDirectory).toHaveBeenCalledWith('/')
+    })
+
+    it('should handle multiple slashes in path', () => {
+      const result = cd.execute(['//var///log//'], mockFs)
+
+      expect(result.exitCode).toBe(0)
+      expect(mockFs.setCurrentDirectory).toHaveBeenCalledWith('/var/log')
+    })
+
+    it('should handle backslashes in path', () => {
+      const result = cd.execute(['\\var\\log'], mockFs)
+
+      expect(result.exitCode).toBe(0)
+      expect(mockFs.setCurrentDirectory).toHaveBeenCalledWith('/var/log')
+    })
+
+    it('should ignore extra arguments', () => {
+      const result = cd.execute(['/tmp', 'extra', 'args'], mockFs)
+
+      expect(result.exitCode).toBe(0)
+      expect(mockFs.setCurrentDirectory).toHaveBeenCalledWith('/tmp')
+    })
+  })
+})

--- a/packages/shell-core/tests/commands/help.test.ts
+++ b/packages/shell-core/tests/commands/help.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Tests for help command.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createHelpCommand } from '../../src/commands/help'
+import { CommandRegistry } from '../../src/CommandRegistry'
+import type { IFileSystem, Command } from '../../src/types'
+
+describe('help command', () => {
+  let mockFs: IFileSystem
+  let registry: CommandRegistry
+  let help: Command
+
+  beforeEach(() => {
+    mockFs = {
+      getCurrentDirectory: vi.fn().mockReturnValue('/'),
+      setCurrentDirectory: vi.fn(),
+      exists: vi.fn(),
+      isDirectory: vi.fn(),
+      isFile: vi.fn(),
+      listDirectory: vi.fn(),
+      readFile: vi.fn(),
+      writeFile: vi.fn(),
+      createDirectory: vi.fn(),
+      delete: vi.fn(),
+    }
+
+    registry = new CommandRegistry()
+
+    // Register some test commands
+    registry.register({
+      name: 'test1',
+      description: 'Test command 1',
+      usage: 'test1 [args]',
+      execute: () => ({ exitCode: 0, stdout: '', stderr: '' }),
+    })
+    registry.register({
+      name: 'test2',
+      description: 'Test command 2',
+      usage: 'test2 <required>',
+      execute: () => ({ exitCode: 0, stdout: '', stderr: '' }),
+    })
+
+    help = createHelpCommand(registry)
+  })
+
+  describe('metadata', () => {
+    it('should have correct name', () => {
+      expect(help.name).toBe('help')
+    })
+
+    it('should have a description', () => {
+      expect(help.description).toBeTruthy()
+      expect(typeof help.description).toBe('string')
+    })
+
+    it('should have usage information', () => {
+      expect(help.usage).toBeTruthy()
+      expect(typeof help.usage).toBe('string')
+    })
+  })
+
+  describe('execute with no arguments (list all commands)', () => {
+    it('should list all registered commands', () => {
+      const result = help.execute([], mockFs)
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain('test1')
+      expect(result.stdout).toContain('test2')
+    })
+
+    it('should show descriptions for each command', () => {
+      const result = help.execute([], mockFs)
+
+      expect(result.stdout).toContain('Test command 1')
+      expect(result.stdout).toContain('Test command 2')
+    })
+
+    it('should include help command itself', () => {
+      // Register help command so it shows up
+      registry.register(help)
+
+      const result = help.execute([], mockFs)
+
+      expect(result.stdout).toContain('help')
+    })
+
+    it('should show header message', () => {
+      const result = help.execute([], mockFs)
+
+      expect(result.stdout).toContain('Available commands')
+    })
+  })
+
+  describe('execute with command name argument', () => {
+    it('should show detailed help for specific command', () => {
+      const result = help.execute(['test1'], mockFs)
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain('test1')
+      expect(result.stdout).toContain('Test command 1')
+      expect(result.stdout).toContain('test1 [args]')
+    })
+
+    it('should return error for unknown command', () => {
+      const result = help.execute(['unknown'], mockFs)
+
+      expect(result.exitCode).toBe(1)
+      expect(result.stderr).toContain('unknown')
+      expect(result.stderr).toContain('not found')
+    })
+  })
+
+  describe('output formatting', () => {
+    it('should sort commands alphabetically', () => {
+      // Clear and add commands in non-alphabetical order
+      registry.clear()
+      registry.register({
+        name: 'zebra',
+        description: 'Z command',
+        usage: 'zebra',
+        execute: () => ({ exitCode: 0, stdout: '', stderr: '' }),
+      })
+      registry.register({
+        name: 'alpha',
+        description: 'A command',
+        usage: 'alpha',
+        execute: () => ({ exitCode: 0, stdout: '', stderr: '' }),
+      })
+
+      const result = help.execute([], mockFs)
+      const alphaIndex = result.stdout.indexOf('alpha')
+      const zebraIndex = result.stdout.indexOf('zebra')
+
+      expect(alphaIndex).toBeLessThan(zebraIndex)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle empty registry', () => {
+      registry.clear()
+
+      const result = help.execute([], mockFs)
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain('No commands available')
+      expect(result.stderr).toBe('')
+    })
+
+    it('should ignore extra arguments for specific command help', () => {
+      const result = help.execute(['test1', 'extra', 'args'], mockFs)
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain('test1')
+    })
+  })
+
+  describe('output format details', () => {
+    it('should return empty stderr on success for command list', () => {
+      const result = help.execute([], mockFs)
+
+      expect(result.stderr).toBe('')
+    })
+
+    it('should return empty stderr on success for specific command', () => {
+      const result = help.execute(['test1'], mockFs)
+
+      expect(result.stderr).toBe('')
+    })
+
+    it('should return empty stdout on error', () => {
+      const result = help.execute(['nonexistent'], mockFs)
+
+      expect(result.stdout).toBe('')
+    })
+
+    it('should include footer with usage hint in command list', () => {
+      const result = help.execute([], mockFs)
+
+      expect(result.stdout).toContain('help <command>')
+    })
+
+    it('should have output formatted with newlines between sections', () => {
+      const result = help.execute([], mockFs)
+      const lines = result.stdout.split('\n')
+
+      // Should have header, blank line, commands, blank line, footer
+      expect(lines.length).toBeGreaterThan(3)
+      // Check for proper newline separation
+      expect(lines.some((line) => line === '')).toBe(true)
+    })
+
+    it('should format detailed help with Usage prefix', () => {
+      const result = help.execute(['test1'], mockFs)
+
+      expect(result.stdout).toContain('Usage: test1 [args]')
+    })
+
+    it('should have blank line between description and usage in detailed help', () => {
+      const result = help.execute(['test1'], mockFs)
+      const lines = result.stdout.split('\n')
+
+      // Format is: "name - description", "", "Usage: ..."
+      expect(lines[1]).toBe('')
+    })
+  })
+})

--- a/packages/shell-core/tests/commands/ls.test.ts
+++ b/packages/shell-core/tests/commands/ls.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests for ls command.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ls } from '../../src/commands/ls'
+import type { IFileSystem, FileEntry } from '../../src/types'
+
+describe('ls command', () => {
+  let mockFs: IFileSystem
+
+  beforeEach(() => {
+    mockFs = {
+      getCurrentDirectory: vi.fn().mockReturnValue('/home/user'),
+      setCurrentDirectory: vi.fn(),
+      exists: vi.fn().mockReturnValue(true),
+      isDirectory: vi.fn().mockReturnValue(true),
+      isFile: vi.fn().mockReturnValue(false),
+      listDirectory: vi.fn().mockReturnValue([]),
+      readFile: vi.fn(),
+      writeFile: vi.fn(),
+      createDirectory: vi.fn(),
+      delete: vi.fn(),
+    }
+  })
+
+  describe('metadata', () => {
+    it('should have correct name', () => {
+      expect(ls.name).toBe('ls')
+    })
+
+    it('should have a description', () => {
+      expect(ls.description).toBeTruthy()
+      expect(typeof ls.description).toBe('string')
+    })
+
+    it('should have usage information', () => {
+      expect(ls.usage).toBeTruthy()
+      expect(typeof ls.usage).toBe('string')
+    })
+  })
+
+  describe('execute with no arguments (current directory)', () => {
+    it('should list current directory when no args provided', () => {
+      const entries: FileEntry[] = [
+        { name: 'file.txt', type: 'file', path: '/home/user/file.txt' },
+        { name: 'docs', type: 'directory', path: '/home/user/docs' },
+      ]
+      mockFs.listDirectory = vi.fn().mockReturnValue(entries)
+
+      const result = ls.execute([], mockFs)
+
+      expect(result.exitCode).toBe(0)
+      expect(mockFs.listDirectory).toHaveBeenCalledWith('/home/user')
+    })
+
+    it('should output file names, one per line', () => {
+      const entries: FileEntry[] = [
+        { name: 'file.txt', type: 'file', path: '/home/user/file.txt' },
+        { name: 'docs', type: 'directory', path: '/home/user/docs' },
+      ]
+      mockFs.listDirectory = vi.fn().mockReturnValue(entries)
+
+      const result = ls.execute([], mockFs)
+
+      expect(result.stdout).toContain('file.txt')
+      expect(result.stdout).toContain('docs')
+    })
+
+    it('should return empty string for empty directory', () => {
+      mockFs.listDirectory = vi.fn().mockReturnValue([])
+
+      const result = ls.execute([], mockFs)
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toBe('')
+    })
+  })
+
+  describe('execute with path argument', () => {
+    it('should list specified directory with absolute path', () => {
+      const entries: FileEntry[] = [
+        { name: 'log1.txt', type: 'file', path: '/var/log/log1.txt' },
+      ]
+      mockFs.listDirectory = vi.fn().mockReturnValue(entries)
+
+      const result = ls.execute(['/var/log'], mockFs)
+
+      expect(result.exitCode).toBe(0)
+      expect(mockFs.listDirectory).toHaveBeenCalledWith('/var/log')
+      expect(result.stdout).toContain('log1.txt')
+    })
+
+    it('should list specified directory with relative path', () => {
+      const entries: FileEntry[] = [
+        { name: 'readme.md', type: 'file', path: '/home/user/docs/readme.md' },
+      ]
+      mockFs.listDirectory = vi.fn().mockReturnValue(entries)
+
+      const result = ls.execute(['docs'], mockFs)
+
+      expect(result.exitCode).toBe(0)
+      expect(mockFs.listDirectory).toHaveBeenCalledWith('/home/user/docs')
+      expect(result.stdout).toContain('readme.md')
+    })
+
+    it('should show file info when path is a file', () => {
+      mockFs.isDirectory = vi.fn().mockReturnValue(false)
+      mockFs.isFile = vi.fn().mockReturnValue(true)
+
+      const result = ls.execute(['/home/user/file.txt'], mockFs)
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toBe('file.txt')
+    })
+  })
+
+  describe('execute with invalid path', () => {
+    it('should return error when path does not exist', () => {
+      mockFs.exists = vi.fn().mockReturnValue(false)
+
+      const result = ls.execute(['/nonexistent'], mockFs)
+
+      expect(result.exitCode).toBe(1)
+      expect(result.stderr).toContain('no such file or directory')
+      expect(result.stderr).toContain('/nonexistent')
+      expect(result.stdout).toBe('')
+    })
+  })
+
+  describe('output details', () => {
+    it('should return empty stderr on success for file', () => {
+      mockFs.isDirectory = vi.fn().mockReturnValue(false)
+      mockFs.isFile = vi.fn().mockReturnValue(true)
+
+      const result = ls.execute(['/home/user/file.txt'], mockFs)
+
+      expect(result.stderr).toBe('')
+    })
+
+    it('should return empty stderr on success for directory listing', () => {
+      const entries: FileEntry[] = [
+        { name: 'file.txt', type: 'file', path: '/home/user/file.txt' },
+      ]
+      mockFs.listDirectory = vi.fn().mockReturnValue(entries)
+
+      const result = ls.execute([], mockFs)
+
+      expect(result.stderr).toBe('')
+    })
+  })
+
+  describe('output formatting', () => {
+    it('should sort entries alphabetically', () => {
+      const entries: FileEntry[] = [
+        { name: 'zebra.txt', type: 'file', path: '/home/user/zebra.txt' },
+        { name: 'alpha.txt', type: 'file', path: '/home/user/alpha.txt' },
+        { name: 'beta.txt', type: 'file', path: '/home/user/beta.txt' },
+      ]
+      mockFs.listDirectory = vi.fn().mockReturnValue(entries)
+
+      const result = ls.execute([], mockFs)
+      const lines = result.stdout.split('\n')
+
+      expect(lines[0]).toBe('alpha.txt')
+      expect(lines[1]).toBe('beta.txt')
+      expect(lines[2]).toBe('zebra.txt')
+    })
+
+    it('should list directories before files when sorting', () => {
+      const entries: FileEntry[] = [
+        { name: 'file.txt', type: 'file', path: '/home/user/file.txt' },
+        { name: 'docs', type: 'directory', path: '/home/user/docs' },
+        { name: 'another.txt', type: 'file', path: '/home/user/another.txt' },
+        { name: 'bin', type: 'directory', path: '/home/user/bin' },
+      ]
+      mockFs.listDirectory = vi.fn().mockReturnValue(entries)
+
+      const result = ls.execute([], mockFs)
+      const lines = result.stdout.split('\n')
+
+      // Directories first (sorted), then files (sorted)
+      expect(lines[0]).toBe('bin/')
+      expect(lines[1]).toBe('docs/')
+      expect(lines[2]).toBe('another.txt')
+      expect(lines[3]).toBe('file.txt')
+    })
+
+    it('should append / to directory names', () => {
+      const entries: FileEntry[] = [
+        { name: 'mydir', type: 'directory', path: '/home/user/mydir' },
+      ]
+      mockFs.listDirectory = vi.fn().mockReturnValue(entries)
+
+      const result = ls.execute([], mockFs)
+
+      expect(result.stdout).toBe('mydir/')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle root directory', () => {
+      mockFs.getCurrentDirectory = vi.fn().mockReturnValue('/')
+      const entries: FileEntry[] = [
+        { name: 'home', type: 'directory', path: '/home' },
+        { name: 'var', type: 'directory', path: '/var' },
+      ]
+      mockFs.listDirectory = vi.fn().mockReturnValue(entries)
+
+      const result = ls.execute([], mockFs)
+
+      expect(result.exitCode).toBe(0)
+      expect(mockFs.listDirectory).toHaveBeenCalledWith('/')
+    })
+
+    it('should ignore extra arguments', () => {
+      const entries: FileEntry[] = []
+      mockFs.listDirectory = vi.fn().mockReturnValue(entries)
+
+      const result = ls.execute(['/tmp', 'extra', 'args'], mockFs)
+
+      expect(result.exitCode).toBe(0)
+      expect(mockFs.listDirectory).toHaveBeenCalledWith('/tmp')
+    })
+  })
+})

--- a/packages/shell-core/tests/commands/pwd.test.ts
+++ b/packages/shell-core/tests/commands/pwd.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for pwd command.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { pwd } from '../../src/commands/pwd'
+import type { IFileSystem } from '../../src/types'
+
+describe('pwd command', () => {
+  let mockFs: IFileSystem
+
+  beforeEach(() => {
+    mockFs = {
+      getCurrentDirectory: vi.fn().mockReturnValue('/home/user'),
+      setCurrentDirectory: vi.fn(),
+      exists: vi.fn(),
+      isDirectory: vi.fn(),
+      isFile: vi.fn(),
+      listDirectory: vi.fn(),
+      readFile: vi.fn(),
+      writeFile: vi.fn(),
+      createDirectory: vi.fn(),
+      delete: vi.fn(),
+    }
+  })
+
+  describe('metadata', () => {
+    it('should have correct name', () => {
+      expect(pwd.name).toBe('pwd')
+    })
+
+    it('should have a description', () => {
+      expect(pwd.description).toBeTruthy()
+      expect(typeof pwd.description).toBe('string')
+    })
+
+    it('should have usage information', () => {
+      expect(pwd.usage).toBeTruthy()
+      expect(typeof pwd.usage).toBe('string')
+    })
+  })
+
+  describe('execute', () => {
+    it('should return current directory from filesystem', () => {
+      const result = pwd.execute([], mockFs)
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toBe('/home/user')
+      expect(result.stderr).toBe('')
+    })
+
+    it('should call getCurrentDirectory on filesystem', () => {
+      pwd.execute([], mockFs)
+
+      expect(mockFs.getCurrentDirectory).toHaveBeenCalledTimes(1)
+    })
+
+    it('should return different paths based on filesystem state', () => {
+      mockFs.getCurrentDirectory = vi.fn().mockReturnValue('/var/log')
+
+      const result = pwd.execute([], mockFs)
+
+      expect(result.stdout).toBe('/var/log')
+    })
+
+    it('should return root directory correctly', () => {
+      mockFs.getCurrentDirectory = vi.fn().mockReturnValue('/')
+
+      const result = pwd.execute([], mockFs)
+
+      expect(result.stdout).toBe('/')
+    })
+
+    it('should ignore any arguments passed', () => {
+      const result = pwd.execute(['ignored', 'args'], mockFs)
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toBe('/home/user')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Created pwd command: prints current working directory
- Created cd command: changes directory with path resolution (absolute, relative, .., .)
- Created ls command: lists directory contents with sorting (directories first, then files)
- Created help command: displays help for commands (uses CommandRegistry)
- Added `registerBuiltinCommands()` helper for easy command registration
- Added 59 new tests (181 total), mutation score 97.53% for commands

## Test plan
- [x] All shell-core unit tests pass (181 tests)
- [x] Mutation testing passes for commands (97.53% >= 80%)
- [x] shell-core build succeeds
- [x] lua-learning-website build succeeds  
- [x] Lint passes
- [x] pwd command tests cover: metadata, getCurrentDirectory delegation, ignoring args
- [x] cd command tests cover: absolute/relative paths, .., ., invalid paths, files vs dirs
- [x] ls command tests cover: current dir, specific path, file vs dir, sorting, formatting
- [x] help command tests cover: list all, specific command, unknown command, empty registry

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)