### PR TITLE
feat(#108): MenuBar - Implement Edit menu

### DIFF
--- a/EPIC.md
+++ b/EPIC.md
@@ -1,6 +1,6 @@
 # Epic #82: Create top bar menu - File | Edit | Settings
 
-**Status:** In Progress (2/6 complete)
+**Status:** In Progress (3/6 complete)
 **Branch:** 82-epic-create-top-bar-menu-file-edit-settings
 **Created:** 2025-12-09
 **Last Updated:** 2025-12-10
@@ -42,7 +42,7 @@ Add a top navigation bar with dropdown menus similar to VS Code and other deskto
 |---|-------|--------|--------|-------|
 | #106 | MenuBar: Base component architecture | ✅ Complete | 106-menubar-base-component-architecture | Merged PR #116 |
 | #107 | MenuBar: Implement File menu | ✅ Complete | 107-menubar-implement-file-menu | Merged PR #118 |
-| #108 | MenuBar: Implement Edit menu | ⏳ Pending | - | Phase 2: Menu Implementations |
+| #108 | MenuBar: Implement Edit menu | 🔄 In Progress | 108-menubar-implement-edit-menu | Phase 2: Menu Implementations |
 | #109 | MenuBar: Implement Settings menu | ⏳ Pending | - | Phase 2: Menu Implementations |
 | #110 | MenuBar: Keyboard navigation | ⏳ Pending | - | Phase 3: Polish |
 | #111 | MenuBar: Integration and E2E tests | ⏳ Pending | - | Phase 3: Polish |
@@ -60,6 +60,12 @@ Add a top navigation bar with dropdown menus similar to VS Code and other deskto
 <!-- Updated after each sub-issue completion -->
 
 ### 2025-12-10
+- Working on #108: MenuBar: Implement Edit menu
+  - Created `useEditorCommands` hook (79% mutation score) for Monaco editor integration
+  - Added `onMount` and `onCursorChange` callbacks to CodeEditor component
+  - Wired Edit menu items to actual editor commands (undo, redo, cut, copy, paste, selectAll)
+  - Menu items dynamically enable/disable based on editor state (hasUndo, hasRedo, hasSelection)
+  - Added 5 E2E tests for Edit menu interactions
 - Completed #107: MenuBar: Implement File menu - Merged PR #118
   - Created `useFileExport` hook (80% mutation score)
   - Added "Open File..." placeholder, "Export As..." menu items
@@ -94,6 +100,7 @@ Add a top navigation bar with dropdown menus similar to VS Code and other deskto
 
 **Hooks:**
 - `src/hooks/useMenuBar.ts` - Menu state management
+- `src/hooks/useEditorCommands.ts` - Monaco editor command integration for Edit menu
 
 **Styles:**
 - `src/components/MenuBar/*.module.css` - Theme-aware CSS modules

--- a/lua-learning-website/src/components/CodeEditor/CodeEditor.tsx
+++ b/lua-learning-website/src/components/CodeEditor/CodeEditor.tsx
@@ -1,4 +1,4 @@
-import Editor from '@monaco-editor/react'
+import Editor, { type OnMount } from '@monaco-editor/react'
 import type { CodeEditorProps } from './types'
 import styles from './CodeEditor.module.css'
 import { useTheme } from '../../contexts/useTheme'
@@ -13,6 +13,8 @@ export function CodeEditor({
   height = '400px',
   readOnly = false,
   onRun,
+  onMount,
+  onCursorChange,
 }: CodeEditorProps) {
   const { theme } = useTheme()
   const monacoTheme = theme === 'dark' ? 'vs-dark' : 'vs'
@@ -20,6 +22,18 @@ export function CodeEditor({
   const handleKeyDown = (event: React.KeyboardEvent) => {
     if (event.key === 'Enter' && event.ctrlKey) {
       onRun?.()
+    }
+  }
+
+  const handleEditorMount: OnMount = (editor) => {
+    // Call the onMount callback with the editor instance
+    onMount?.(editor)
+
+    // Set up cursor position change listener
+    if (onCursorChange) {
+      editor.onDidChangeCursorPosition((e) => {
+        onCursorChange(e.position.lineNumber, e.position.column)
+      })
     }
   }
 
@@ -35,6 +49,7 @@ export function CodeEditor({
         value={value}
         theme={monacoTheme}
         onChange={(newValue) => onChange(newValue ?? '')}
+        onMount={handleEditorMount}
         options={{
           readOnly,
           minimap: { enabled: false },

--- a/lua-learning-website/src/components/CodeEditor/types.ts
+++ b/lua-learning-website/src/components/CodeEditor/types.ts
@@ -1,3 +1,5 @@
+import type * as monaco from 'monaco-editor'
+
 /**
  * Props for the CodeEditor component
  */
@@ -14,4 +16,8 @@ export interface CodeEditorProps {
   readOnly?: boolean
   /** Called when Ctrl+Enter is pressed */
   onRun?: () => void
+  /** Called when the Monaco editor mounts with the editor instance */
+  onMount?: (editor: monaco.editor.IStandaloneCodeEditor) => void
+  /** Called when cursor position changes */
+  onCursorChange?: (line: number, column: number) => void
 }

--- a/lua-learning-website/src/components/EditorPanel/EditorPanel.tsx
+++ b/lua-learning-website/src/components/EditorPanel/EditorPanel.tsx
@@ -13,6 +13,8 @@ export function EditorPanel({
   isDirty,
   onRun,
   isRunning = false,
+  onCursorChange,
+  onEditorMount,
   className,
   tabBarProps,
 }: EditorPanelProps) {
@@ -69,6 +71,8 @@ export function EditorPanel({
           language="lua"
           height="100%"
           onRun={onRun}
+          onMount={onEditorMount}
+          onCursorChange={onCursorChange}
         />
       </div>
     </div>

--- a/lua-learning-website/src/components/EditorPanel/types.ts
+++ b/lua-learning-website/src/components/EditorPanel/types.ts
@@ -1,4 +1,5 @@
 import type { TabBarProps } from '../TabBar'
+import type * as monaco from 'monaco-editor'
 
 /**
  * Props for the EditorPanel component
@@ -22,6 +23,8 @@ export interface EditorPanelProps {
   cursorColumn?: number
   /** Called when cursor position changes */
   onCursorChange?: (line: number, column: number) => void
+  /** Called when the Monaco editor mounts with the editor instance */
+  onEditorMount?: (editor: monaco.editor.IStandaloneCodeEditor) => void
   /** Optional additional className */
   className?: string
   /** Props for TabBar when multi-file mode is active */

--- a/lua-learning-website/src/hooks/useEditorCommands.test.ts
+++ b/lua-learning-website/src/hooks/useEditorCommands.test.ts
@@ -1,0 +1,844 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useEditorCommands } from './useEditorCommands'
+import type * as monaco from 'monaco-editor'
+
+// Mock Monaco editor interface
+type MockEditor = {
+  trigger: ReturnType<typeof vi.fn>
+  getModel: ReturnType<typeof vi.fn>
+  getSelection: ReturnType<typeof vi.fn>
+  focus: ReturnType<typeof vi.fn>
+}
+
+function createMockEditor(overrides: Partial<MockEditor> = {}): MockEditor {
+  return {
+    trigger: vi.fn(),
+    getModel: vi.fn(() => ({
+      canUndo: vi.fn(() => true),
+      canRedo: vi.fn(() => true),
+    })),
+    getSelection: vi.fn(() => ({
+      isEmpty: vi.fn(() => false),
+    })),
+    focus: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('useEditorCommands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('initial state', () => {
+    it('should return editor ref initially null', () => {
+      // Arrange & Act
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Assert
+      expect(result.current.editorRef.current).toBeNull()
+    })
+
+    it('should have all commands defined', () => {
+      // Arrange & Act
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Assert
+      expect(result.current.undo).toBeDefined()
+      expect(result.current.redo).toBeDefined()
+      expect(result.current.cut).toBeDefined()
+      expect(result.current.copy).toBeDefined()
+      expect(result.current.paste).toBeDefined()
+      expect(result.current.selectAll).toBeDefined()
+    })
+
+    it('should return disabled state when no editor', () => {
+      // Arrange & Act
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Assert
+      expect(result.current.canUndo).toBe(false)
+      expect(result.current.canRedo).toBe(false)
+      expect(result.current.hasSelection).toBe(false)
+    })
+  })
+
+  describe('undo command', () => {
+    it('should trigger undo on editor', () => {
+      // Arrange
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.undo()
+      })
+
+      // Assert
+      expect(mockEditor.trigger).toHaveBeenCalledWith('menu', 'undo', null)
+      expect(mockEditor.focus).toHaveBeenCalled()
+    })
+
+    it('should not throw when editor is null', () => {
+      // Arrange
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act & Assert
+      expect(() => result.current.undo()).not.toThrow()
+    })
+  })
+
+  describe('redo command', () => {
+    it('should trigger redo on editor', () => {
+      // Arrange
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.redo()
+      })
+
+      // Assert
+      expect(mockEditor.trigger).toHaveBeenCalledWith('menu', 'redo', null)
+      expect(mockEditor.focus).toHaveBeenCalled()
+    })
+
+    it('should not throw when editor is null', () => {
+      // Arrange
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act & Assert
+      expect(() => result.current.redo()).not.toThrow()
+    })
+  })
+
+  describe('cut command', () => {
+    it('should trigger cut on editor', () => {
+      // Arrange
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.cut()
+      })
+
+      // Assert
+      expect(mockEditor.trigger).toHaveBeenCalledWith('menu', 'editor.action.clipboardCutAction', null)
+      expect(mockEditor.focus).toHaveBeenCalled()
+    })
+
+    it('should not throw when editor is null', () => {
+      // Arrange
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act & Assert
+      expect(() => result.current.cut()).not.toThrow()
+    })
+  })
+
+  describe('copy command', () => {
+    it('should trigger copy on editor', () => {
+      // Arrange
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.copy()
+      })
+
+      // Assert
+      expect(mockEditor.trigger).toHaveBeenCalledWith('menu', 'editor.action.clipboardCopyAction', null)
+      expect(mockEditor.focus).toHaveBeenCalled()
+    })
+
+    it('should not throw when editor is null', () => {
+      // Arrange
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act & Assert
+      expect(() => result.current.copy()).not.toThrow()
+    })
+  })
+
+  describe('paste command', () => {
+    it('should trigger paste on editor', () => {
+      // Arrange
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.paste()
+      })
+
+      // Assert
+      expect(mockEditor.trigger).toHaveBeenCalledWith('menu', 'editor.action.clipboardPasteAction', null)
+      expect(mockEditor.focus).toHaveBeenCalled()
+    })
+
+    it('should not throw when editor is null', () => {
+      // Arrange
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act & Assert
+      expect(() => result.current.paste()).not.toThrow()
+    })
+  })
+
+  describe('selectAll command', () => {
+    it('should trigger selectAll on editor', () => {
+      // Arrange
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.selectAll()
+      })
+
+      // Assert
+      expect(mockEditor.trigger).toHaveBeenCalledWith('menu', 'editor.action.selectAll', null)
+      expect(mockEditor.focus).toHaveBeenCalled()
+    })
+
+    it('should not throw when editor is null', () => {
+      // Arrange
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act & Assert
+      expect(() => result.current.selectAll()).not.toThrow()
+    })
+  })
+
+  describe('state tracking', () => {
+    it('should update canUndo when editor model reports undo available', () => {
+      // Arrange
+      const mockEditor = createMockEditor({
+        getModel: vi.fn(() => ({
+          canUndo: vi.fn(() => true),
+          canRedo: vi.fn(() => false),
+        })),
+      })
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.updateState()
+      })
+
+      // Assert
+      expect(result.current.canUndo).toBe(true)
+    })
+
+    it('should update canRedo when editor model reports redo available', () => {
+      // Arrange
+      const mockEditor = createMockEditor({
+        getModel: vi.fn(() => ({
+          canUndo: vi.fn(() => false),
+          canRedo: vi.fn(() => true),
+        })),
+      })
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.updateState()
+      })
+
+      // Assert
+      expect(result.current.canRedo).toBe(true)
+    })
+
+    it('should update hasSelection when editor has non-empty selection', () => {
+      // Arrange
+      const mockEditor = createMockEditor({
+        getSelection: vi.fn(() => ({
+          isEmpty: vi.fn(() => false),
+        })),
+      })
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.updateState()
+      })
+
+      // Assert
+      expect(result.current.hasSelection).toBe(true)
+    })
+
+    it('should return false for hasSelection when selection is empty', () => {
+      // Arrange
+      const mockEditor = createMockEditor({
+        getSelection: vi.fn(() => ({
+          isEmpty: vi.fn(() => true),
+        })),
+      })
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.updateState()
+      })
+
+      // Assert
+      expect(result.current.hasSelection).toBe(false)
+    })
+
+    it('should return false for state when model is null', () => {
+      // Arrange
+      const mockEditor = createMockEditor({
+        getModel: vi.fn(() => null),
+        getSelection: vi.fn(() => null),
+      })
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.updateState()
+      })
+
+      // Assert
+      expect(result.current.canUndo).toBe(false)
+      expect(result.current.canRedo).toBe(false)
+      expect(result.current.hasSelection).toBe(false)
+    })
+  })
+
+  describe('hasEditor', () => {
+    it('should return false when editor is null', () => {
+      // Arrange & Act
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Assert
+      expect(result.current.hasEditor).toBe(false)
+    })
+
+    it('should return true when editor is set', () => {
+      // Arrange
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.updateState()
+      })
+
+      // Assert
+      expect(result.current.hasEditor).toBe(true)
+    })
+  })
+
+  describe('command action string verification', () => {
+    it('should use exact undo action string', () => {
+      // Arrange
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.undo()
+      })
+
+      // Assert - verify exact string to kill string mutants
+      expect(mockEditor.trigger).toHaveBeenCalledWith('menu', 'undo', null)
+      expect(mockEditor.trigger).not.toHaveBeenCalledWith('menu', 'redo', null)
+    })
+
+    it('should use exact redo action string', () => {
+      // Arrange
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.redo()
+      })
+
+      // Assert - verify exact string to kill string mutants
+      expect(mockEditor.trigger).toHaveBeenCalledWith('menu', 'redo', null)
+      expect(mockEditor.trigger).not.toHaveBeenCalledWith('menu', 'undo', null)
+    })
+
+    it('should use exact cut action string', () => {
+      // Arrange
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.cut()
+      })
+
+      // Assert
+      expect(mockEditor.trigger).toHaveBeenCalledWith('menu', 'editor.action.clipboardCutAction', null)
+      expect(mockEditor.trigger).not.toHaveBeenCalledWith('menu', 'editor.action.clipboardCopyAction', null)
+    })
+
+    it('should use exact copy action string', () => {
+      // Arrange
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.copy()
+      })
+
+      // Assert
+      expect(mockEditor.trigger).toHaveBeenCalledWith('menu', 'editor.action.clipboardCopyAction', null)
+      expect(mockEditor.trigger).not.toHaveBeenCalledWith('menu', 'editor.action.clipboardCutAction', null)
+    })
+
+    it('should use exact paste action string', () => {
+      // Arrange
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.paste()
+      })
+
+      // Assert
+      expect(mockEditor.trigger).toHaveBeenCalledWith('menu', 'editor.action.clipboardPasteAction', null)
+      expect(mockEditor.trigger).not.toHaveBeenCalledWith('menu', 'editor.action.selectAll', null)
+    })
+
+    it('should use exact selectAll action string', () => {
+      // Arrange
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.selectAll()
+      })
+
+      // Assert
+      expect(mockEditor.trigger).toHaveBeenCalledWith('menu', 'editor.action.selectAll', null)
+      expect(mockEditor.trigger).not.toHaveBeenCalledWith('menu', 'editor.action.clipboardPasteAction', null)
+    })
+  })
+
+  describe('updateState edge cases', () => {
+    it('should reset hasEditor to false when editor is removed', () => {
+      // Arrange
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      // First set editor
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.updateState()
+      })
+      expect(result.current.hasEditor).toBe(true)
+
+      // Then remove editor
+      act(() => {
+        result.current.editorRef.current = null
+        result.current.updateState()
+      })
+
+      // Assert
+      expect(result.current.hasEditor).toBe(false)
+      expect(result.current.canUndo).toBe(false)
+      expect(result.current.canRedo).toBe(false)
+      expect(result.current.hasSelection).toBe(false)
+    })
+
+    it('should correctly report canUndo as false when model.canUndo returns false', () => {
+      // Arrange
+      const mockEditor = createMockEditor({
+        getModel: vi.fn(() => ({
+          canUndo: vi.fn(() => false),
+          canRedo: vi.fn(() => false),
+        })),
+      })
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.updateState()
+      })
+
+      // Assert
+      expect(result.current.canUndo).toBe(false)
+      expect(result.current.canRedo).toBe(false)
+    })
+
+    it('should call model.canUndo and model.canRedo methods', () => {
+      // Arrange
+      const canUndoMock = vi.fn(() => true)
+      const canRedoMock = vi.fn(() => true)
+      const mockEditor = createMockEditor({
+        getModel: vi.fn(() => ({
+          canUndo: canUndoMock,
+          canRedo: canRedoMock,
+        })),
+      })
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.updateState()
+      })
+
+      // Assert
+      expect(canUndoMock).toHaveBeenCalled()
+      expect(canRedoMock).toHaveBeenCalled()
+    })
+
+    it('should call selection.isEmpty method', () => {
+      // Arrange
+      const isEmptyMock = vi.fn(() => false)
+      const mockEditor = createMockEditor({
+        getSelection: vi.fn(() => ({
+          isEmpty: isEmptyMock,
+        })),
+      })
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.updateState()
+      })
+
+      // Assert
+      expect(isEmptyMock).toHaveBeenCalled()
+    })
+  })
+
+  describe('commands do not trigger focus or action when editor is null', () => {
+    it('undo should not call focus when editor is null', () => {
+      // Arrange
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.undo()
+      })
+
+      // Assert - mock should never have been touched since ref was null
+      expect(mockEditor.focus).not.toHaveBeenCalled()
+      expect(mockEditor.trigger).not.toHaveBeenCalled()
+    })
+
+    it('redo should not call focus when editor is null', () => {
+      // Arrange
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.redo()
+      })
+
+      // Assert
+      expect(mockEditor.focus).not.toHaveBeenCalled()
+      expect(mockEditor.trigger).not.toHaveBeenCalled()
+    })
+
+    it('cut should not call focus when editor is null', () => {
+      // Arrange
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.cut()
+      })
+
+      // Assert
+      expect(mockEditor.focus).not.toHaveBeenCalled()
+      expect(mockEditor.trigger).not.toHaveBeenCalled()
+    })
+
+    it('copy should not call focus when editor is null', () => {
+      // Arrange
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.copy()
+      })
+
+      // Assert
+      expect(mockEditor.focus).not.toHaveBeenCalled()
+      expect(mockEditor.trigger).not.toHaveBeenCalled()
+    })
+
+    it('paste should not call focus when editor is null', () => {
+      // Arrange
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.paste()
+      })
+
+      // Assert
+      expect(mockEditor.focus).not.toHaveBeenCalled()
+      expect(mockEditor.trigger).not.toHaveBeenCalled()
+    })
+
+    it('selectAll should not call focus when editor is null', () => {
+      // Arrange
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.selectAll()
+      })
+
+      // Assert
+      expect(mockEditor.focus).not.toHaveBeenCalled()
+      expect(mockEditor.trigger).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('trigger source parameter', () => {
+    it('should pass menu as source for all commands', () => {
+      // Arrange
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+      })
+
+      // Act - call all commands
+      act(() => {
+        result.current.undo()
+        result.current.redo()
+        result.current.cut()
+        result.current.copy()
+        result.current.paste()
+        result.current.selectAll()
+      })
+
+      // Assert - verify all calls have 'menu' as first arg
+      expect(mockEditor.trigger).toHaveBeenCalledTimes(6)
+      mockEditor.trigger.mock.calls.forEach((call: unknown[]) => {
+        expect(call[0]).toBe('menu')
+      })
+    })
+  })
+
+  describe('state boolean values', () => {
+    it('should set canUndo to true when model.canUndo() returns true', () => {
+      // Arrange - test that the exact boolean value is passed
+      const mockEditor = createMockEditor({
+        getModel: vi.fn(() => ({
+          canUndo: vi.fn(() => true),
+          canRedo: vi.fn(() => false),
+        })),
+        getSelection: vi.fn(() => ({
+          isEmpty: vi.fn(() => true),
+        })),
+      })
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.updateState()
+      })
+
+      // Assert - verify exact boolean
+      expect(result.current.canUndo).toBe(true)
+      expect(result.current.canRedo).toBe(false)
+    })
+
+    it('should set canRedo to true when model.canRedo() returns true', () => {
+      // Arrange
+      const mockEditor = createMockEditor({
+        getModel: vi.fn(() => ({
+          canUndo: vi.fn(() => false),
+          canRedo: vi.fn(() => true),
+        })),
+        getSelection: vi.fn(() => ({
+          isEmpty: vi.fn(() => true),
+        })),
+      })
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Act
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.updateState()
+      })
+
+      // Assert
+      expect(result.current.canUndo).toBe(false)
+      expect(result.current.canRedo).toBe(true)
+    })
+
+    it('should set hasSelection based on negation of isEmpty()', () => {
+      // Test isEmpty() returning false -> hasSelection should be true
+      const mockEditor1 = createMockEditor({
+        getModel: vi.fn(() => ({
+          canUndo: vi.fn(() => false),
+          canRedo: vi.fn(() => false),
+        })),
+        getSelection: vi.fn(() => ({
+          isEmpty: vi.fn(() => false), // not empty means selection exists
+        })),
+      })
+      const { result: result1 } = renderHook(() => useEditorCommands())
+
+      act(() => {
+        result1.current.editorRef.current = mockEditor1 as unknown as monaco.editor.IStandaloneCodeEditor
+        result1.current.updateState()
+      })
+
+      expect(result1.current.hasSelection).toBe(true)
+
+      // Test isEmpty() returning true -> hasSelection should be false
+      const mockEditor2 = createMockEditor({
+        getModel: vi.fn(() => ({
+          canUndo: vi.fn(() => false),
+          canRedo: vi.fn(() => false),
+        })),
+        getSelection: vi.fn(() => ({
+          isEmpty: vi.fn(() => true), // empty means no selection
+        })),
+      })
+      const { result: result2 } = renderHook(() => useEditorCommands())
+
+      act(() => {
+        result2.current.editorRef.current = mockEditor2 as unknown as monaco.editor.IStandaloneCodeEditor
+        result2.current.updateState()
+      })
+
+      expect(result2.current.hasSelection).toBe(false)
+    })
+
+    it('should set hasEditor to true only when editor exists', () => {
+      // Arrange
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      // Initially false
+      expect(result.current.hasEditor).toBe(false)
+
+      // After setting editor
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.updateState()
+      })
+      expect(result.current.hasEditor).toBe(true)
+
+      // After clearing editor
+      act(() => {
+        result.current.editorRef.current = null
+        result.current.updateState()
+      })
+      expect(result.current.hasEditor).toBe(false)
+    })
+  })
+
+  describe('null argument to trigger', () => {
+    it('should pass null as third argument to trigger for undo', () => {
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.undo()
+      })
+
+      expect(mockEditor.trigger).toHaveBeenCalledWith('menu', 'undo', null)
+      expect(mockEditor.trigger.mock.calls[0][2]).toBeNull()
+    })
+
+    it('should pass null as third argument to trigger for redo', () => {
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.redo()
+      })
+
+      expect(mockEditor.trigger.mock.calls[0][2]).toBeNull()
+    })
+
+    it('should pass null as third argument to trigger for cut', () => {
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.cut()
+      })
+
+      expect(mockEditor.trigger.mock.calls[0][2]).toBeNull()
+    })
+
+    it('should pass null as third argument to trigger for copy', () => {
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.copy()
+      })
+
+      expect(mockEditor.trigger.mock.calls[0][2]).toBeNull()
+    })
+
+    it('should pass null as third argument to trigger for paste', () => {
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.paste()
+      })
+
+      expect(mockEditor.trigger.mock.calls[0][2]).toBeNull()
+    })
+
+    it('should pass null as third argument to trigger for selectAll', () => {
+      const mockEditor = createMockEditor()
+      const { result } = renderHook(() => useEditorCommands())
+
+      act(() => {
+        result.current.editorRef.current = mockEditor as unknown as monaco.editor.IStandaloneCodeEditor
+        result.current.selectAll()
+      })
+
+      expect(mockEditor.trigger.mock.calls[0][2]).toBeNull()
+    })
+  })
+})

--- a/lua-learning-website/src/hooks/useEditorCommands.ts
+++ b/lua-learning-website/src/hooks/useEditorCommands.ts
@@ -1,0 +1,127 @@
+import { useRef, useState, useCallback } from 'react'
+import type * as monaco from 'monaco-editor'
+
+interface UseEditorCommandsReturn {
+  /** Reference to the Monaco editor instance */
+  editorRef: React.MutableRefObject<monaco.editor.IStandaloneCodeEditor | null>
+  /** Whether an editor is currently mounted */
+  hasEditor: boolean
+  /** Whether undo is available */
+  canUndo: boolean
+  /** Whether redo is available */
+  canRedo: boolean
+  /** Whether there is a text selection */
+  hasSelection: boolean
+  /** Undo the last action */
+  undo: () => void
+  /** Redo the last undone action */
+  redo: () => void
+  /** Cut selected text */
+  cut: () => void
+  /** Copy selected text */
+  copy: () => void
+  /** Paste from clipboard */
+  paste: () => void
+  /** Select all text */
+  selectAll: () => void
+  /** Update state from editor (call when editor state might have changed) */
+  updateState: () => void
+}
+
+/**
+ * Hook for interacting with Monaco editor commands
+ * Provides edit operations and state tracking for menu integration
+ */
+export function useEditorCommands(): UseEditorCommandsReturn {
+  const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null)
+  const [hasEditor, setHasEditor] = useState(false)
+  const [canUndo, setCanUndo] = useState(false)
+  const [canRedo, setCanRedo] = useState(false)
+  const [hasSelection, setHasSelection] = useState(false)
+
+  const updateState = useCallback(() => {
+    const editor = editorRef.current
+    if (!editor) {
+      setHasEditor(false)
+      setCanUndo(false)
+      setCanRedo(false)
+      setHasSelection(false)
+      return
+    }
+
+    setHasEditor(true)
+
+    const model = editor.getModel()
+    if (model) {
+      setCanUndo(model.canUndo())
+      setCanRedo(model.canRedo())
+    } else {
+      setCanUndo(false)
+      setCanRedo(false)
+    }
+
+    const selection = editor.getSelection()
+    if (selection) {
+      setHasSelection(!selection.isEmpty())
+    } else {
+      setHasSelection(false)
+    }
+  }, [])
+
+  const undo = useCallback(() => {
+    const editor = editorRef.current
+    if (!editor) return
+    editor.trigger('menu', 'undo', null)
+    editor.focus()
+  }, [])
+
+  const redo = useCallback(() => {
+    const editor = editorRef.current
+    if (!editor) return
+    editor.trigger('menu', 'redo', null)
+    editor.focus()
+  }, [])
+
+  const cut = useCallback(() => {
+    const editor = editorRef.current
+    if (!editor) return
+    editor.trigger('menu', 'editor.action.clipboardCutAction', null)
+    editor.focus()
+  }, [])
+
+  const copy = useCallback(() => {
+    const editor = editorRef.current
+    if (!editor) return
+    editor.trigger('menu', 'editor.action.clipboardCopyAction', null)
+    editor.focus()
+  }, [])
+
+  const paste = useCallback(() => {
+    const editor = editorRef.current
+    if (!editor) return
+    editor.trigger('menu', 'editor.action.clipboardPasteAction', null)
+    editor.focus()
+  }, [])
+
+  const selectAll = useCallback(() => {
+    const editor = editorRef.current
+    if (!editor) return
+    editor.trigger('menu', 'editor.action.selectAll', null)
+    editor.focus()
+  }, [])
+
+  return {
+    editorRef,
+    hasEditor,
+    canUndo,
+    canRedo,
+    hasSelection,
+    undo,
+    redo,
+    cut,
+    copy,
+    paste,
+    selectAll,
+    updateState,
+  }
+}


### PR DESCRIPTION
## Summary
- Implements Edit menu functionality for the MenuBar component (part of Epic #82)
- Creates `useEditorCommands` hook to integrate with Monaco editor
- Edit menu items now perform actual editor operations (undo, redo, cut, copy, paste, select all)
- Menu items dynamically enable/disable based on editor state

## Changes
- **New**: `useEditorCommands` hook - exposes Monaco editor commands and state tracking
- **Modified**: CodeEditor - added `onMount` and `onCursorChange` callbacks
- **Modified**: EditorPanel - wires through editor mount callback
- **Modified**: IDELayout - integrates Edit menu with editor commands
- **Added**: 5 E2E tests for Edit menu interactions
- **Added**: 49 unit tests for useEditorCommands hook

## Test plan
- [x] Unit tests pass (1116 tests)
- [x] E2E tests pass for Edit menu (5 new tests)
- [x] Lint passes
- [x] Build succeeds
- [x] Manual testing: Edit menu items enable/disable correctly based on editor state
- [x] Mutation testing: 79% score for useEditorCommands hook

## Implementation Details

### Edit Menu Items
| Item | Shortcut | Enabled When |
|------|----------|--------------|
| Undo | Ctrl+Z | Editor has undo history |
| Redo | Ctrl+Y | Editor has redo history |
| Cut | Ctrl+X | Editor has text selection |
| Copy | Ctrl+C | Editor has text selection |
| Paste | Ctrl+V | Editor is open |
| Select All | Ctrl+A | Editor is open |

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)