### PR TITLE
docs: Add --project flag to gh issue create commands

### DIFF
--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -145,6 +145,7 @@ When `/pr-review <n> accept` is run, it will prompt to create issues for any tec
 ```bash
 gh issue create --title "[Tech Debt] <file>: <brief description>" \
   --label "tech-debt" \
+  --project "LuaInTheWeb" \
   --body "<!-- tech-debt-id: <unique-id> -->
 
 ## Description

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -460,6 +460,7 @@ If user confirms, create issues and add them to the project board:
 ```bash
 gh issue create --title "[Tech Debt] <brief description>" \
   --label "tech-debt" \
+  --project "LuaInTheWeb" \
   --body "<!-- tech-debt-id: <unique-id> -->
 
 ## Description

--- a/.claude/workflow.md
+++ b/.claude/workflow.md
@@ -447,6 +447,8 @@ Running visual verification...
 
 Tech debt follows a **identify → decide → create** flow:
 
+> **IMPORTANT:** All issues created by agents must include `--project "LuaInTheWeb"` to ensure they appear on the [GitHub Project Board](https://github.com/users/jcollard/projects/3).
+
 | Phase | What Happens |
 |-------|--------------|
 | `/code-review` | Tech debt identified and listed in output |


### PR DESCRIPTION
## Summary
- Updated `gh issue create` commands in code-review.md and pr-review.md to include `--project "LuaInTheWeb"` flag
- Added documentation note in workflow.md stating all agent-created issues must include the project flag

## Test plan
- [x] Verified `--project` flag syntax with `gh issue create --help`
- [x] Confirmed project title is "LuaInTheWeb" via `gh project list`

Fixes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)