### PR TITLE
feat(#162): Default to dark mode for new users

### DIFF
--- a/lua-learning-website/src/contexts/ThemeContext.test.tsx
+++ b/lua-learning-website/src/contexts/ThemeContext.test.tsx
@@ -129,30 +129,8 @@ describe('ThemeContext', () => {
       expect(result.current.theme).toBe('dark')
     })
 
-    it('should respect system preference for dark mode on first visit', () => {
-      // Arrange
-      matchMediaMock.mockImplementation((query: string) => ({
-        matches: query === '(prefers-color-scheme: dark)',
-        media: query,
-        onchange: null,
-        addListener: vi.fn(),
-        removeListener: vi.fn(),
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-        dispatchEvent: vi.fn(),
-      }))
-
-      // Act
-      const { result } = renderHook(() => useTheme(), {
-        wrapper: ({ children }) => <ThemeProvider>{children}</ThemeProvider>,
-      })
-
-      // Assert
-      expect(result.current.theme).toBe('dark')
-    })
-
-    it('should respect system preference for light mode on first visit', () => {
-      // Arrange
+    it('should default to dark when no saved preference exists (ignores system preference)', () => {
+      // Arrange - system prefers light, but we should still default to dark
       matchMediaMock.mockImplementation((query: string) => ({
         matches: query === '(prefers-color-scheme: light)',
         media: query,
@@ -169,8 +147,8 @@ describe('ThemeContext', () => {
         wrapper: ({ children }) => <ThemeProvider>{children}</ThemeProvider>,
       })
 
-      // Assert
-      expect(result.current.theme).toBe('light')
+      // Assert - should be dark regardless of system preference
+      expect(result.current.theme).toBe('dark')
     })
 
     it('should load saved theme from localStorage', () => {

--- a/lua-learning-website/src/contexts/ThemeContext.tsx
+++ b/lua-learning-website/src/contexts/ThemeContext.tsx
@@ -4,17 +4,6 @@ import type { Theme, ThemeContextValue } from './types'
 
 const STORAGE_KEY = 'lua-ide-theme'
 
-function getSystemPreference(): Theme {
-  try {
-    if (window.matchMedia('(prefers-color-scheme: light)').matches) {
-      return 'light'
-    }
-  } catch {
-    // matchMedia not available
-  }
-  return 'dark'
-}
-
 function getStoredTheme(): Theme | null {
   try {
     const stored = localStorage.getItem(STORAGE_KEY)
@@ -45,12 +34,8 @@ interface ThemeProviderProps {
 
 export function ThemeProvider({ children }: ThemeProviderProps) {
   const [theme, setThemeState] = useState<Theme>(() => {
-    // Priority: localStorage > system preference > default (dark)
-    const stored = getStoredTheme()
-    if (stored) {
-      return stored
-    }
-    return getSystemPreference()
+    // Priority: localStorage > default (dark)
+    return getStoredTheme() ?? 'dark'
   })
 
   // Apply theme to document on mount and when theme changes


### PR DESCRIPTION
## Summary
- Remove `getSystemPreference()` function from ThemeContext
- Update theme initialization to default directly to 'dark' when no stored preference exists
- New users now see dark mode on first visit regardless of system settings
- Existing users with saved preferences are unaffected

Closes #162

## Test plan
- [x] Unit tests updated and passing (19/19)
- [x] Mutation testing: ThemeContext.tsx at 85.71% (exceeds 80% threshold)
- [x] Build passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)