### PR TITLE
docs(#165): Add Blocked status to workflow documentation

### DIFF
--- a/.claude/workflow.md
+++ b/.claude/workflow.md
@@ -13,6 +13,7 @@ All work is tracked in the [GitHub Project Board](https://github.com/users/jcoll
 |--------|---------|--------------|
 | **Concept** | Idea needs research/definition before it's actionable | Manual |
 | **Todo** | Well-defined, ready to be worked on | `/issue <n> eval` |
+| **Blocked** | Waiting on dependencies or external factors | Manual |
 | **In Progress** | Actively being worked on | `worktree-create.py` |
 | **Needs Review** | PR created, awaiting review | `/issue <n> review` |
 | **Done** | Completed and merged | `/pr-review <n> accept` |


### PR DESCRIPTION
## Summary

- Adds `Blocked` status to the Status Definitions table in `.claude/workflow.md`
- Positioned between `Todo` and `In Progress` as specified
- Documents the new project board status for issues waiting on dependencies or external factors

## Changes

| File | Change |
|------|--------|
| `.claude/workflow.md` | Added 1 row to Status Definitions table |

## Acceptance Criteria

- [x] Workflow.md Status Definitions table includes Blocked status
- [x] Position is between Todo and In Progress

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)