### PR TITLE
feat(#171): Process Control UI

### DIFF
--- a/EPIC.md
+++ b/EPIC.md
@@ -3,7 +3,7 @@
 **Status:** In Progress (1/4 complete)
 **Branch:** epic-140
 **Created:** 2025-12-12
-**Last Updated:** 2025-12-12 04:40
+**Last Updated:** 2025-12-12 04:59
 
 ## Overview
 
@@ -47,7 +47,7 @@ packages/
 | # | Title | Status | Branch | Notes |
 |---|-------|--------|--------|-------|
 | #170 | Shell Interface Design | ✅ Complete | 170-shell-interface-design | Merged in PR #174 |
-| #171 | Process Control UI | ⏳ Pending | - | Depends on #170 |
+| #171 | Process Control UI | 🔄 In Progress | 171-process-control-ui | Started 2025-12-12 |
 | #172 | Lua Runtime Package | ⏳ Pending | - | Depends on #170 |
 | #173 | Remove Legacy UI Components | ⏳ Pending | - | Depends on #171, #172 |
 
@@ -65,6 +65,20 @@ packages/
 ## Progress Log
 
 <!-- Updated after each sub-issue completion -->
+
+### 2025-12-12 04:59
+- Completed #171: Process Control UI
+- Created useProcessManager hook for React state management
+- Added StopButton component with stop icon
+- Integrated stop button into ShellTerminal (visible when process running)
+- Implemented input routing to processes
+- Implemented Ctrl+C to stop running process
+- All unit tests pass, mutation score 77.78% (surviving mutants are equivalent)
+- Ready for PR
+
+### 2025-12-12 04:47
+- Started work on #171: Process Control UI
+- Created branch `171-process-control-ui` from `epic-140`
 
 ### 2025-12-12 04:40
 - Merged PR #174 to `epic-140`
@@ -101,6 +115,11 @@ packages/
 ### Updated
 - `packages/shell-core/src/CommandRegistry.ts` - Added ICommand support and executeWithContext
 - `packages/shell-core/src/index.ts` - Exports new interfaces and classes
+
+### UI Components (from #171)
+- `lua-learning-website/src/hooks/useProcessManager.ts` - React hook wrapping ProcessManager
+- `lua-learning-website/src/components/StopButton/StopButton.tsx` - Stop button component
+- `lua-learning-website/src/components/ShellTerminal/ShellTerminal.tsx` - Updated with process control
 
 ## Open Questions
 

--- a/lua-learning-website/src/components/BashTerminal/BashTerminal.module.css
+++ b/lua-learning-website/src/components/BashTerminal/BashTerminal.module.css
@@ -3,6 +3,7 @@
   flex-direction: column;
   height: 100%;
   min-height: 500px;
+  position: relative;
 }
 
 .containerEmbedded {
@@ -20,6 +21,13 @@
   margin: 0;
   color: var(--theme-accent-primary);
   font-size: 1.1rem;
+}
+
+.processControls {
+  position: absolute;
+  top: 4px;
+  right: 8px;
+  z-index: 10;
 }
 
 .terminal {

--- a/lua-learning-website/src/components/ShellTerminal/ShellTerminal.test.tsx
+++ b/lua-learning-website/src/components/ShellTerminal/ShellTerminal.test.tsx
@@ -92,6 +92,22 @@ vi.mock('../../hooks/useShell', () => ({
   useShell: () => mockUseShell,
 }))
 
+// Mock useProcessManager with mutable state for testing
+const mockStopProcess = vi.fn()
+const mockHandleInput = vi.fn().mockReturnValue(false)
+
+const mockUseProcessManager = {
+  isProcessRunning: false,
+  hasForegroundProcess: vi.fn().mockReturnValue(false),
+  startProcess: vi.fn(),
+  stopProcess: mockStopProcess,
+  handleInput: mockHandleInput,
+}
+
+vi.mock('../../hooks/useProcessManager', () => ({
+  useProcessManager: () => mockUseProcessManager,
+}))
+
 describe('ShellTerminal', () => {
   const createMockFileSystem = (): UseFileSystemReturn => ({
     createFile: vi.fn(),
@@ -313,6 +329,218 @@ describe('ShellTerminal', () => {
       // Count how many times 'ls' appears
       const lsCount = writeCalls.filter((c) => c === 'ls').length
       expect(lsCount).toBe(1) // Should only appear once
+    })
+  })
+
+  describe('process control', () => {
+    beforeEach(() => {
+      // Reset process manager mock state
+      mockUseProcessManager.isProcessRunning = false
+      mockUseProcessManager.hasForegroundProcess.mockReturnValue(false)
+      mockHandleInput.mockReturnValue(false)
+      mockStopProcess.mockClear()
+      mockHandleInput.mockClear()
+    })
+
+    describe('stop button', () => {
+      it('should show stop button when process is running', () => {
+        mockUseProcessManager.isProcessRunning = true
+
+        render(<ShellTerminal fileSystem={mockFileSystem} />)
+
+        const stopButton = screen.queryByRole('button', { name: /stop/i })
+        expect(stopButton).toBeInTheDocument()
+      })
+
+      it('should not show stop button when no process is running', () => {
+        mockUseProcessManager.isProcessRunning = false
+
+        render(<ShellTerminal fileSystem={mockFileSystem} />)
+
+        const stopButton = screen.queryByRole('button', { name: /stop/i })
+        expect(stopButton).not.toBeInTheDocument()
+      })
+
+      it('should call stopProcess when stop button clicked', async () => {
+        mockUseProcessManager.isProcessRunning = true
+
+        render(<ShellTerminal fileSystem={mockFileSystem} />)
+
+        const stopButton = screen.getByRole('button', { name: /stop/i })
+        await act(async () => {
+          stopButton.click()
+        })
+
+        expect(mockStopProcess).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('input routing', () => {
+      it('should route Enter input to process when process is running', async () => {
+        mockUseProcessManager.isProcessRunning = true
+        mockUseProcessManager.hasForegroundProcess.mockReturnValue(true)
+        mockHandleInput.mockReturnValue(true)
+
+        render(<ShellTerminal fileSystem={mockFileSystem} />)
+
+        const terminal = terminalInstances[0]
+        const onDataHandler = terminal.onData.mock.calls[0][0]
+
+        // Type some text
+        await act(async () => {
+          onDataHandler('h')
+        })
+        await act(async () => {
+          onDataHandler('i')
+        })
+
+        // Press Enter - should route to process
+        await act(async () => {
+          onDataHandler('\r')
+        })
+
+        // Verify handleInput was called with the typed text
+        expect(mockHandleInput).toHaveBeenCalledWith('hi')
+      })
+
+      it('should execute command normally when no process is running', async () => {
+        mockUseProcessManager.isProcessRunning = false
+        mockUseProcessManager.hasForegroundProcess.mockReturnValue(false)
+        mockHandleInput.mockReturnValue(false)
+
+        render(<ShellTerminal fileSystem={mockFileSystem} />)
+
+        const terminal = terminalInstances[0]
+        const onDataHandler = terminal.onData.mock.calls[0][0]
+
+        // Type and execute a command
+        await act(async () => {
+          onDataHandler('l')
+        })
+        await act(async () => {
+          onDataHandler('s')
+        })
+        await act(async () => {
+          onDataHandler('\r')
+        })
+
+        // Verify command was executed normally
+        expect(mockExecuteCommand).toHaveBeenCalledWith('ls')
+        expect(mockHandleInput).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('Ctrl+C handling', () => {
+      it('should stop process when Ctrl+C pressed and process is running', async () => {
+        mockUseProcessManager.isProcessRunning = true
+        mockUseProcessManager.hasForegroundProcess.mockReturnValue(true)
+
+        render(<ShellTerminal fileSystem={mockFileSystem} />)
+
+        const terminal = terminalInstances[0]
+        const onDataHandler = terminal.onData.mock.calls[0][0]
+
+        // Press Ctrl+C (char code 3)
+        await act(async () => {
+          onDataHandler('\x03')
+        })
+
+        expect(mockStopProcess).toHaveBeenCalledTimes(1)
+      })
+
+      it('should clear line but not stop anything when Ctrl+C pressed with no process', async () => {
+        mockUseProcessManager.isProcessRunning = false
+        mockUseProcessManager.hasForegroundProcess.mockReturnValue(false)
+
+        render(<ShellTerminal fileSystem={mockFileSystem} />)
+
+        const terminal = terminalInstances[0]
+        const onDataHandler = terminal.onData.mock.calls[0][0]
+
+        // Press Ctrl+C (char code 3)
+        await act(async () => {
+          onDataHandler('\x03')
+        })
+
+        // stopProcess should not be called
+        expect(mockStopProcess).not.toHaveBeenCalled()
+
+        // Should write ^C to terminal
+        const writeCalls = terminal.write.mock.calls.map((c) => c[0])
+        expect(writeCalls).toContain('^C')
+      })
+    })
+
+    describe('character input routing', () => {
+      it('should buffer characters when process is running', async () => {
+        mockUseProcessManager.isProcessRunning = true
+        mockUseProcessManager.hasForegroundProcess.mockReturnValue(true)
+
+        render(<ShellTerminal fileSystem={mockFileSystem} />)
+
+        const terminal = terminalInstances[0]
+        const onDataHandler = terminal.onData.mock.calls[0][0]
+
+        terminal.write.mockClear()
+
+        // Type characters while process is running
+        await act(async () => {
+          onDataHandler('a')
+        })
+        await act(async () => {
+          onDataHandler('b')
+        })
+
+        // Characters should be echoed to terminal
+        const writeCalls = terminal.write.mock.calls.map((c) => c[0])
+        expect(writeCalls.some((c) => c.includes('a'))).toBe(true)
+        expect(writeCalls.some((c) => c.includes('b'))).toBe(true)
+      })
+    })
+
+    describe('prompt state', () => {
+      it('should not show prompt when process is running', async () => {
+        mockUseProcessManager.isProcessRunning = true
+        mockUseProcessManager.hasForegroundProcess.mockReturnValue(true)
+        mockHandleInput.mockReturnValue(true)
+
+        render(<ShellTerminal fileSystem={mockFileSystem} />)
+
+        const terminal = terminalInstances[0]
+        const onDataHandler = terminal.onData.mock.calls[0][0]
+
+        terminal.write.mockClear()
+
+        // Type and enter while process is running
+        await act(async () => {
+          onDataHandler('t')
+        })
+        await act(async () => {
+          onDataHandler('e')
+        })
+        await act(async () => {
+          onDataHandler('s')
+        })
+        await act(async () => {
+          onDataHandler('t')
+        })
+        await act(async () => {
+          onDataHandler('\r')
+        })
+
+        // Input should be routed to process
+        expect(mockHandleInput).toHaveBeenCalledWith('test')
+
+        // Prompt should not be shown (since process is still running)
+        const writeCalls = terminal.write.mock.calls.map((c) => c[0])
+        // Check that we don't write a new prompt after input
+        // The prompt contains '$'
+        const promptsAfterInput = writeCalls.filter(
+          (c) => c.includes('$') && writeCalls.indexOf(c) > 0
+        )
+        // Should not have new prompts written (or very few from initial setup)
+        expect(promptsAfterInput.length).toBeLessThanOrEqual(1)
+      })
     })
   })
 })

--- a/lua-learning-website/src/components/StopButton/StopButton.module.css
+++ b/lua-learning-website/src/components/StopButton/StopButton.module.css
@@ -1,0 +1,30 @@
+.stopButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 4px;
+  border: none;
+  border-radius: 4px;
+  background-color: var(--danger-color, #dc3545);
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.stopButton:hover:not(:disabled) {
+  background-color: var(--danger-hover-color, #c82333);
+}
+
+.stopButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.stopIcon {
+  display: block;
+  width: 10px;
+  height: 10px;
+  background-color: white;
+  border-radius: 1px;
+}

--- a/lua-learning-website/src/components/StopButton/StopButton.test.tsx
+++ b/lua-learning-website/src/components/StopButton/StopButton.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { StopButton } from './StopButton'
+
+describe('StopButton', () => {
+  describe('rendering', () => {
+    it('should render a stop button with accessible label', () => {
+      render(<StopButton onStop={vi.fn()} />)
+
+      const button = screen.getByRole('button', { name: /stop/i })
+      expect(button).toBeInTheDocument()
+    })
+
+    it('should show stop icon', () => {
+      render(<StopButton onStop={vi.fn()} />)
+
+      // Check for stop icon (square shape)
+      const button = screen.getByRole('button', { name: /stop/i })
+      expect(button).toBeInTheDocument()
+    })
+
+    it('should apply custom className when provided', () => {
+      render(<StopButton onStop={vi.fn()} className="custom-class" />)
+
+      const button = screen.getByRole('button', { name: /stop/i })
+      expect(button.className).toContain('custom-class')
+    })
+  })
+
+  describe('interaction', () => {
+    it('should call onStop when clicked', () => {
+      const onStop = vi.fn()
+      render(<StopButton onStop={onStop} />)
+
+      const button = screen.getByRole('button', { name: /stop/i })
+      fireEvent.click(button)
+
+      expect(onStop).toHaveBeenCalledTimes(1)
+    })
+
+    it('should be disabled when disabled prop is true', () => {
+      render(<StopButton onStop={vi.fn()} disabled />)
+
+      const button = screen.getByRole('button', { name: /stop/i })
+      expect(button).toBeDisabled()
+    })
+
+    it('should not call onStop when disabled and clicked', () => {
+      const onStop = vi.fn()
+      render(<StopButton onStop={onStop} disabled />)
+
+      const button = screen.getByRole('button', { name: /stop/i })
+      fireEvent.click(button)
+
+      expect(onStop).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('tooltip', () => {
+    it('should have title attribute for tooltip', () => {
+      render(<StopButton onStop={vi.fn()} />)
+
+      const button = screen.getByRole('button', { name: /stop/i })
+      expect(button).toHaveAttribute('title', 'Stop process (Ctrl+C)')
+    })
+  })
+})

--- a/lua-learning-website/src/components/StopButton/StopButton.tsx
+++ b/lua-learning-website/src/components/StopButton/StopButton.tsx
@@ -1,0 +1,33 @@
+import styles from './StopButton.module.css'
+
+export interface StopButtonProps {
+  /** Called when the stop button is clicked */
+  onStop: () => void
+  /** Whether the button is disabled */
+  disabled?: boolean
+  /** Additional CSS class */
+  className?: string
+}
+
+/**
+ * Stop button for interrupting running processes.
+ * Displays a stop icon (square) and calls onStop when clicked.
+ */
+export function StopButton({ onStop, disabled = false, className }: StopButtonProps) {
+  const buttonClassName = className
+    ? `${styles.stopButton} ${className}`
+    : styles.stopButton
+
+  return (
+    <button
+      type="button"
+      className={buttonClassName}
+      onClick={onStop}
+      disabled={disabled}
+      aria-label="Stop process"
+      title="Stop process (Ctrl+C)"
+    >
+      <span className={styles.stopIcon} aria-hidden="true" />
+    </button>
+  )
+}

--- a/lua-learning-website/src/components/StopButton/index.ts
+++ b/lua-learning-website/src/components/StopButton/index.ts
@@ -1,0 +1,2 @@
+export { StopButton } from './StopButton'
+export type { StopButtonProps } from './StopButton'

--- a/lua-learning-website/src/hooks/useProcessManager.test.ts
+++ b/lua-learning-website/src/hooks/useProcessManager.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useProcessManager } from './useProcessManager'
+import type { IProcess } from '@lua-learning/shell-core'
+
+/**
+ * Creates a mock process for testing
+ */
+function createMockProcess(overrides: Partial<IProcess> = {}): IProcess {
+  return {
+    start: vi.fn(),
+    stop: vi.fn(),
+    isRunning: vi.fn().mockReturnValue(false),
+    handleInput: vi.fn(),
+    onOutput: vi.fn(),
+    onError: vi.fn(),
+    onExit: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('useProcessManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('initial state', () => {
+    it('should have no running process initially', () => {
+      const { result } = renderHook(() => useProcessManager())
+
+      expect(result.current.isProcessRunning).toBe(false)
+      expect(result.current.hasForegroundProcess()).toBe(false)
+    })
+  })
+
+  describe('startProcess', () => {
+    it('should start a process and update isProcessRunning', () => {
+      const { result } = renderHook(() => useProcessManager())
+      const mockProcess = createMockProcess()
+
+      act(() => {
+        result.current.startProcess(mockProcess)
+      })
+
+      expect(mockProcess.start).toHaveBeenCalledTimes(1)
+      expect(result.current.isProcessRunning).toBe(true)
+      expect(result.current.hasForegroundProcess()).toBe(true)
+    })
+
+    it('should stop existing process before starting new one', () => {
+      const { result } = renderHook(() => useProcessManager())
+      const process1 = createMockProcess()
+      const process2 = createMockProcess()
+
+      act(() => {
+        result.current.startProcess(process1)
+      })
+
+      act(() => {
+        result.current.startProcess(process2)
+      })
+
+      expect(process1.stop).toHaveBeenCalledTimes(1)
+      expect(process2.start).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('stopProcess', () => {
+    it('should stop the running process and update isProcessRunning', () => {
+      const { result } = renderHook(() => useProcessManager())
+      const mockProcess = createMockProcess()
+
+      act(() => {
+        result.current.startProcess(mockProcess)
+      })
+
+      act(() => {
+        result.current.stopProcess()
+      })
+
+      expect(mockProcess.stop).toHaveBeenCalledTimes(1)
+      expect(result.current.isProcessRunning).toBe(false)
+    })
+
+    it('should do nothing if no process is running', () => {
+      const { result } = renderHook(() => useProcessManager())
+
+      // Should not throw
+      act(() => {
+        result.current.stopProcess()
+      })
+
+      expect(result.current.isProcessRunning).toBe(false)
+    })
+  })
+
+  describe('handleInput', () => {
+    it('should route input to running process', () => {
+      const { result } = renderHook(() => useProcessManager())
+      const mockProcess = createMockProcess()
+
+      act(() => {
+        result.current.startProcess(mockProcess)
+      })
+
+      const handled = result.current.handleInput('test input')
+
+      expect(mockProcess.handleInput).toHaveBeenCalledWith('test input')
+      expect(handled).toBe(true)
+    })
+
+    it('should return false if no process is running', () => {
+      const { result } = renderHook(() => useProcessManager())
+
+      const handled = result.current.handleInput('test input')
+
+      expect(handled).toBe(false)
+    })
+  })
+
+  describe('process exit', () => {
+    it('should update isProcessRunning when process exits naturally', () => {
+      const { result } = renderHook(() => useProcessManager())
+      const mockProcess = createMockProcess()
+
+      act(() => {
+        result.current.startProcess(mockProcess)
+      })
+
+      expect(result.current.isProcessRunning).toBe(true)
+
+      // Simulate process exit by calling the onExit callback
+      act(() => {
+        mockProcess.onExit(0)
+      })
+
+      expect(result.current.isProcessRunning).toBe(false)
+    })
+
+    it('should call onProcessExit callback when process exits', () => {
+      const onProcessExit = vi.fn()
+      const { result } = renderHook(() => useProcessManager({ onProcessExit }))
+      const mockProcess = createMockProcess()
+
+      act(() => {
+        result.current.startProcess(mockProcess)
+      })
+
+      act(() => {
+        mockProcess.onExit(42)
+      })
+
+      expect(onProcessExit).toHaveBeenCalledWith(42)
+    })
+  })
+
+  describe('output and error callbacks', () => {
+    it('should forward process output to onOutput callback', () => {
+      const onOutput = vi.fn()
+      const { result } = renderHook(() => useProcessManager({ onOutput }))
+      const mockProcess = createMockProcess()
+
+      act(() => {
+        result.current.startProcess(mockProcess)
+      })
+
+      // Simulate process output
+      act(() => {
+        mockProcess.onOutput('hello world')
+      })
+
+      expect(onOutput).toHaveBeenCalledWith('hello world')
+    })
+
+    it('should forward process errors to onError callback', () => {
+      const onError = vi.fn()
+      const { result } = renderHook(() => useProcessManager({ onError }))
+      const mockProcess = createMockProcess()
+
+      act(() => {
+        result.current.startProcess(mockProcess)
+      })
+
+      // Simulate process error
+      act(() => {
+        mockProcess.onError('error message')
+      })
+
+      expect(onError).toHaveBeenCalledWith('error message')
+    })
+  })
+})

--- a/lua-learning-website/src/hooks/useProcessManager.ts
+++ b/lua-learning-website/src/hooks/useProcessManager.ts
@@ -1,0 +1,94 @@
+import { useState, useCallback, useRef } from 'react'
+import { ProcessManager, type IProcess } from '@lua-learning/shell-core'
+
+export interface UseProcessManagerOptions {
+  /** Callback when a process exits */
+  onProcessExit?: (code: number) => void
+  /** Callback for process output */
+  onOutput?: (text: string) => void
+  /** Callback for process errors */
+  onError?: (text: string) => void
+}
+
+export interface UseProcessManagerReturn {
+  /** Whether a process is currently running */
+  isProcessRunning: boolean
+  /** Check if there is a foreground process */
+  hasForegroundProcess: () => boolean
+  /** Start a process */
+  startProcess: (process: IProcess) => void
+  /** Stop the current process */
+  stopProcess: () => void
+  /** Route input to the current process */
+  handleInput: (input: string) => boolean
+}
+
+/**
+ * React hook wrapping ProcessManager with state management.
+ * Provides reactive isProcessRunning state and callbacks for process events.
+ */
+export function useProcessManager(
+  options: UseProcessManagerOptions = {}
+): UseProcessManagerReturn {
+  const { onProcessExit, onOutput, onError } = options
+
+  const [isProcessRunning, setIsProcessRunning] = useState(false)
+  const processManagerRef = useRef<ProcessManager>(new ProcessManager())
+
+  // Keep callback refs up to date
+  const onProcessExitRef = useRef(onProcessExit)
+  const onOutputRef = useRef(onOutput)
+  const onErrorRef = useRef(onError)
+  onProcessExitRef.current = onProcessExit
+  onOutputRef.current = onOutput
+  onErrorRef.current = onError
+
+  const hasForegroundProcess = useCallback((): boolean => {
+    return processManagerRef.current.hasForegroundProcess()
+  }, [])
+
+  const startProcess = useCallback((process: IProcess): void => {
+    const pm = processManagerRef.current
+
+    // Wire up output/error callbacks before starting
+    process.onOutput = (text: string) => {
+      if (onOutputRef.current) {
+        onOutputRef.current(text)
+      }
+    }
+
+    process.onError = (text: string) => {
+      if (onErrorRef.current) {
+        onErrorRef.current(text)
+      }
+    }
+
+    // Set up process exit handler to update React state
+    pm.onProcessExit = (code: number) => {
+      setIsProcessRunning(false)
+      if (onProcessExitRef.current) {
+        onProcessExitRef.current(code)
+      }
+    }
+
+    pm.startProcess(process)
+    setIsProcessRunning(true)
+  }, [])
+
+  const stopProcess = useCallback((): void => {
+    processManagerRef.current.stopProcess()
+    setIsProcessRunning(false)
+  }, [])
+
+  const handleInput = useCallback((input: string): boolean => {
+    return processManagerRef.current.handleInput(input)
+  }, [])
+
+  return {
+    isProcessRunning,
+    hasForegroundProcess,
+    startProcess,
+    stopProcess,
+    handleInput,
+  }
+}


### PR DESCRIPTION
## Summary

- Created `useProcessManager` hook wrapping ProcessManager with React state
- Added `StopButton` component with accessible stop icon
- Integrated stop button into ShellTerminal (visible when process running)
- Implemented input routing to foreground process when running
- Implemented Ctrl+C to stop running processes
- Added process output/error handling to display in terminal
- Added process exit handling to restore shell prompt

## Test plan

- [x] All 1135 unit tests pass
- [x] Lint passes
- [x] Build succeeds
- [x] Scoped mutation tests: 77.78% (surviving mutants are equivalent - empty useCallback deps)
- [x] StopButton component: 100% mutation score
- [ ] E2E tests deferred to #172 (requires actual processes to test)

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)