### PR TITLE
feat: Add raw key input handling for shell processes (#178)

### DIFF
--- a/EPIC.md
+++ b/EPIC.md
@@ -3,7 +3,7 @@
 **Status:** In Progress (3/4 complete)
 **Branch:** epic-140
 **Created:** 2025-12-12
-**Last Updated:** 2025-12-12 07:19
+**Last Updated:** 2025-12-12 07:41
 
 ## Overview
 
@@ -49,7 +49,7 @@ packages/
 | #170 | Shell Interface Design | ✅ Complete | 170-shell-interface-design | Merged in PR #174 |
 | #171 | Process Control UI | ✅ Complete | 171-process-control-ui | Merged in PR #175 |
 | #172 | Lua Runtime Package | ✅ Complete | 172-lua-runtime-package | Merged in PR #176 |
-| #178 | Process Raw Input Handling | ⏳ Pending | - | Depends on #172 |
+| #178 | Process Raw Input Handling | 🔄 In Progress | 178-process-raw-input-handling | Started 2025-12-12 |
 | #179 | REPL Multi-line Input Support | ⏳ Pending | - | Depends on #172 |
 | #173 | Remove Legacy UI Components | ⏳ Pending | - | Depends on #178, #179 |
 
@@ -67,6 +67,10 @@ packages/
 ## Progress Log
 
 <!-- Updated after each sub-issue completion -->
+
+### 2025-12-12 07:25
+- Started work on #178: Process Raw Input Handling
+- Created branch `178-process-raw-input-handling` from `epic-140`
 
 ### 2025-12-12 07:19
 - Merged PR #176 to `epic-140`
@@ -165,6 +169,13 @@ packages/
 
 ### Integration (from #172)
 - `lua-learning-website/src/hooks/useShell.ts` - Updated with LuaCommand registration and executeCommandWithContext
+
+### Process Key Handling (from #178)
+- `packages/shell-core/src/interfaces/IProcess.ts` - Added KeyModifiers type, supportsRawInput, handleKey
+- `packages/shell-core/src/ProcessManager.ts` - Added supportsRawInput() and handleKey() methods
+- `packages/lua-runtime/src/LuaReplProcess.ts` - Implemented command history and handleKey() for arrow navigation
+- `lua-learning-website/src/hooks/useProcessManager.ts` - Added supportsRawInput() and handleKey()
+- `lua-learning-website/src/components/ShellTerminal/ShellTerminal.tsx` - Routes arrow keys to process
 
 ## Open Questions
 

--- a/lua-learning-website/src/components/ShellTerminal/ShellTerminal.processKeys.test.tsx
+++ b/lua-learning-website/src/components/ShellTerminal/ShellTerminal.processKeys.test.tsx
@@ -1,0 +1,229 @@
+/**
+ * Tests for ShellTerminal process key routing.
+ * These tests verify that arrow keys are correctly forwarded to processes
+ * when they support raw key input.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, act } from '@testing-library/react'
+import { ShellTerminal } from './ShellTerminal'
+import type { UseFileSystemReturn } from '../../hooks/useFileSystem'
+
+// Store terminal instances for testing
+let terminalInstances: Array<{
+  write: ReturnType<typeof vi.fn>
+  writeln: ReturnType<typeof vi.fn>
+  onData: ReturnType<typeof vi.fn>
+}> = []
+
+// Store FitAddon instances for testing
+let fitAddonInstances: Array<{
+  fit: ReturnType<typeof vi.fn>
+}> = []
+
+// Store ResizeObserver callbacks for testing
+let resizeObserverCallbacks: Array<ResizeObserverCallback> = []
+
+// Mock ResizeObserver
+class MockResizeObserver {
+  constructor(callback: ResizeObserverCallback) {
+    resizeObserverCallbacks.push(callback)
+  }
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+}
+
+vi.stubGlobal('ResizeObserver', MockResizeObserver)
+
+// Mock xterm.js
+vi.mock('@xterm/xterm', () => {
+  const MockTerminal = vi.fn().mockImplementation(function (
+    this: Record<string, unknown>
+  ) {
+    this.loadAddon = vi.fn()
+    this.open = vi.fn()
+    this.write = vi.fn()
+    this.writeln = vi.fn()
+    this.onData = vi.fn()
+    this.dispose = vi.fn()
+    this.clear = vi.fn()
+    this.refresh = vi.fn()
+    this.rows = 24
+    this.options = {}
+    terminalInstances.push({
+      write: this.write as ReturnType<typeof vi.fn>,
+      writeln: this.writeln as ReturnType<typeof vi.fn>,
+      onData: this.onData as ReturnType<typeof vi.fn>,
+    })
+  })
+  return { Terminal: MockTerminal }
+})
+
+vi.mock('@xterm/addon-fit', () => {
+  const MockFitAddon = vi.fn().mockImplementation(function (
+    this: Record<string, unknown>
+  ) {
+    this.fit = vi.fn()
+    fitAddonInstances.push({
+      fit: this.fit as ReturnType<typeof vi.fn>,
+    })
+  })
+  return { FitAddon: MockFitAddon }
+})
+
+// Mock contexts
+vi.mock('../../contexts/useTheme', () => ({
+  useTheme: () => ({ theme: 'dark', toggleTheme: vi.fn() }),
+}))
+
+vi.mock('../BashTerminal/terminalTheme', () => ({
+  getTerminalTheme: vi.fn().mockReturnValue({}),
+}))
+
+// Mock useShell
+const mockUseShell = {
+  executeCommand: vi.fn().mockReturnValue({ exitCode: 0, stdout: '', stderr: '', cwd: '/' }),
+  executeCommandWithContext: vi.fn().mockReturnValue({ cwd: '/' }),
+  cwd: '/',
+  history: [] as string[],
+  clearHistory: vi.fn(),
+  commandNames: ['help', 'ls', 'cd', 'pwd', 'cat', 'echo', 'clear', 'lua'],
+  getPathCompletionsForTab: vi.fn().mockReturnValue([]),
+}
+
+vi.mock('../../hooks/useShell', () => ({
+  useShell: () => mockUseShell,
+}))
+
+// Mock useProcessManager
+const mockSupportsRawInput = vi.fn().mockReturnValue(false)
+const mockHandleKey = vi.fn().mockReturnValue(false)
+
+const mockUseProcessManager = {
+  isProcessRunning: false,
+  hasForegroundProcess: vi.fn().mockReturnValue(false),
+  startProcess: vi.fn(),
+  stopProcess: vi.fn(),
+  handleInput: vi.fn().mockReturnValue(false),
+  supportsRawInput: mockSupportsRawInput,
+  handleKey: mockHandleKey,
+}
+
+vi.mock('../../hooks/useProcessManager', () => ({
+  useProcessManager: () => mockUseProcessManager,
+}))
+
+describe('ShellTerminal - Process Key Routing', () => {
+  const createMockFileSystem = (): UseFileSystemReturn => ({
+    createFile: vi.fn(),
+    readFile: vi.fn().mockReturnValue(null),
+    writeFile: vi.fn(),
+    deleteFile: vi.fn(),
+    renameFile: vi.fn(),
+    moveFile: vi.fn(),
+    createFolder: vi.fn(),
+    deleteFolder: vi.fn(),
+    renameFolder: vi.fn(),
+    exists: vi.fn().mockReturnValue(true),
+    isDirectory: vi.fn().mockReturnValue(true),
+    listDirectory: vi.fn().mockReturnValue([]),
+    getTree: vi.fn().mockReturnValue([]),
+  })
+
+  let mockFileSystem: UseFileSystemReturn
+
+  beforeEach(() => {
+    mockFileSystem = createMockFileSystem()
+    terminalInstances = []
+    fitAddonInstances = []
+    resizeObserverCallbacks = []
+    mockUseShell.history = []
+    mockUseProcessManager.isProcessRunning = false
+    mockSupportsRawInput.mockReturnValue(false)
+    vi.clearAllMocks()
+  })
+
+  describe('arrow key routing', () => {
+    it('should forward ArrowUp to process when it supports raw input', async () => {
+      mockUseProcessManager.isProcessRunning = true
+      mockSupportsRawInput.mockReturnValue(true)
+
+      render(<ShellTerminal fileSystem={mockFileSystem} />)
+
+      const terminal = terminalInstances[0]
+      const onDataHandler = terminal.onData.mock.calls[0][0]
+
+      mockHandleKey.mockClear()
+
+      await act(async () => {
+        onDataHandler('\x1b[A')
+      })
+
+      expect(mockHandleKey).toHaveBeenCalledWith('ArrowUp', {
+        ctrl: false,
+        alt: false,
+        shift: false,
+      })
+    })
+
+    it('should forward ArrowDown to process when it supports raw input', async () => {
+      mockUseProcessManager.isProcessRunning = true
+      mockSupportsRawInput.mockReturnValue(true)
+
+      render(<ShellTerminal fileSystem={mockFileSystem} />)
+
+      const terminal = terminalInstances[0]
+      const onDataHandler = terminal.onData.mock.calls[0][0]
+
+      mockHandleKey.mockClear()
+
+      await act(async () => {
+        onDataHandler('\x1b[B')
+      })
+
+      expect(mockHandleKey).toHaveBeenCalledWith('ArrowDown', {
+        ctrl: false,
+        alt: false,
+        shift: false,
+      })
+    })
+
+    it('should NOT forward ArrowUp to process when it does not support raw input', async () => {
+      mockUseProcessManager.isProcessRunning = true
+      mockSupportsRawInput.mockReturnValue(false)
+      mockUseShell.history = ['previous command']
+
+      render(<ShellTerminal fileSystem={mockFileSystem} />)
+
+      const terminal = terminalInstances[0]
+      const onDataHandler = terminal.onData.mock.calls[0][0]
+
+      mockHandleKey.mockClear()
+
+      await act(async () => {
+        onDataHandler('\x1b[A')
+      })
+
+      expect(mockHandleKey).not.toHaveBeenCalled()
+    })
+
+    it('should NOT forward ArrowUp to process when no process is running', async () => {
+      mockUseProcessManager.isProcessRunning = false
+      mockSupportsRawInput.mockReturnValue(true)
+      mockUseShell.history = ['previous command']
+
+      render(<ShellTerminal fileSystem={mockFileSystem} />)
+
+      const terminal = terminalInstances[0]
+      const onDataHandler = terminal.onData.mock.calls[0][0]
+
+      mockHandleKey.mockClear()
+
+      await act(async () => {
+        onDataHandler('\x1b[A')
+      })
+
+      expect(mockHandleKey).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/lua-learning-website/src/components/ShellTerminal/ShellTerminal.test.tsx
+++ b/lua-learning-website/src/components/ShellTerminal/ShellTerminal.test.tsx
@@ -102,6 +102,8 @@ vi.mock('../../hooks/useShell', () => ({
 // Mock useProcessManager with mutable state for testing
 const mockStopProcess = vi.fn()
 const mockHandleInput = vi.fn().mockReturnValue(false)
+const mockSupportsRawInput = vi.fn().mockReturnValue(false)
+const mockHandleKey = vi.fn().mockReturnValue(false)
 
 const mockUseProcessManager = {
   isProcessRunning: false,
@@ -109,6 +111,8 @@ const mockUseProcessManager = {
   startProcess: vi.fn(),
   stopProcess: mockStopProcess,
   handleInput: mockHandleInput,
+  supportsRawInput: mockSupportsRawInput,
+  handleKey: mockHandleKey,
 }
 
 vi.mock('../../hooks/useProcessManager', () => ({
@@ -630,5 +634,7 @@ describe('ShellTerminal', () => {
         expect(promptsAfterInput.length).toBeLessThanOrEqual(1)
       })
     })
+
+    // Arrow key routing to process tests are in ShellTerminal.processKeys.test.tsx
   })
 })

--- a/lua-learning-website/src/components/ShellTerminal/ShellTerminal.tsx
+++ b/lua-learning-website/src/components/ShellTerminal/ShellTerminal.tsx
@@ -127,6 +127,8 @@ export function ShellTerminal({
     startProcess,
     stopProcess,
     handleInput: handleProcessInput,
+    supportsRawInput,
+    handleKey: handleProcessKey,
   } = useProcessManager({
     onOutput: handleProcessOutput,
     onError: handleProcessError,
@@ -138,13 +140,17 @@ export function ShellTerminal({
   const startProcessRef = useRef(startProcess)
   const stopProcessRef = useRef(stopProcess)
   const handleProcessInputRef = useRef(handleProcessInput)
+  const supportsRawInputRef = useRef(supportsRawInput)
+  const handleProcessKeyRef = useRef(handleProcessKey)
 
   useEffect(() => {
     isProcessRunningRef.current = isProcessRunning
     startProcessRef.current = startProcess
     stopProcessRef.current = stopProcess
     handleProcessInputRef.current = handleProcessInput
-  }, [isProcessRunning, startProcess, stopProcess, handleProcessInput])
+    supportsRawInputRef.current = supportsRawInput
+    handleProcessKeyRef.current = handleProcessKey
+  }, [isProcessRunning, startProcess, stopProcess, handleProcessInput, supportsRawInput, handleProcessKey])
 
   // Handle command execution
   const handleCommand = useCallback((input: string) => {
@@ -299,6 +305,11 @@ export function ShellTerminal({
 
       // Handle Arrow Up (history)
       if (data === '\x1b[A') {
+        // If a process is running and supports raw input, forward the key
+        if (isProcessRunningRef.current && supportsRawInputRef.current()) {
+          handleProcessKeyRef.current('ArrowUp', { ctrl: false, alt: false, shift: false })
+          return
+        }
         commands = handlers.handleArrowUp()
         if (commands.length > 0) {
           // Clear line, show prompt, then write history command
@@ -314,6 +325,11 @@ export function ShellTerminal({
 
       // Handle Arrow Down (history)
       if (data === '\x1b[B') {
+        // If a process is running and supports raw input, forward the key
+        if (isProcessRunningRef.current && supportsRawInputRef.current()) {
+          handleProcessKeyRef.current('ArrowDown', { ctrl: false, alt: false, shift: false })
+          return
+        }
         commands = handlers.handleArrowDown()
         // Clear line, show prompt, then write history command (if any)
         terminal.write('\r\x1b[K')

--- a/lua-learning-website/src/hooks/useProcessManager.ts
+++ b/lua-learning-website/src/hooks/useProcessManager.ts
@@ -1,5 +1,9 @@
 import { useState, useCallback, useRef } from 'react'
-import { ProcessManager, type IProcess } from '@lua-learning/shell-core'
+import {
+  ProcessManager,
+  type IProcess,
+  type KeyModifiers,
+} from '@lua-learning/shell-core'
 
 export interface UseProcessManagerOptions {
   /** Callback when a process exits */
@@ -21,6 +25,10 @@ export interface UseProcessManagerReturn {
   stopProcess: () => void
   /** Route input to the current process */
   handleInput: (input: string) => boolean
+  /** Check if the current process supports raw key input */
+  supportsRawInput: () => boolean
+  /** Route a key event to the current process */
+  handleKey: (key: string, modifiers?: KeyModifiers) => boolean
 }
 
 /**
@@ -84,11 +92,24 @@ export function useProcessManager(
     return processManagerRef.current.handleInput(input)
   }, [])
 
+  const supportsRawInput = useCallback((): boolean => {
+    return processManagerRef.current.supportsRawInput()
+  }, [])
+
+  const handleKey = useCallback(
+    (key: string, modifiers?: KeyModifiers): boolean => {
+      return processManagerRef.current.handleKey(key, modifiers)
+    },
+    []
+  )
+
   return {
     isProcessRunning,
     hasForegroundProcess,
     startProcess,
     stopProcess,
     handleInput,
+    supportsRawInput,
+    handleKey,
   }
 }

--- a/packages/shell-core/src/ProcessManager.ts
+++ b/packages/shell-core/src/ProcessManager.ts
@@ -3,7 +3,7 @@
  * Handles process lifecycle, input routing, and exit notifications.
  */
 
-import type { IProcess } from './interfaces/IProcess'
+import type { IProcess, KeyModifiers } from './interfaces/IProcess'
 
 /**
  * Manages the current foreground process.
@@ -80,6 +80,29 @@ export class ProcessManager {
   handleInput(input: string): boolean {
     if (this.currentProcess) {
       this.currentProcess.handleInput(input)
+      return true
+    }
+    return false
+  }
+
+  /**
+   * Check if the current process supports raw key input.
+   * @returns True if a process is running and supports raw input
+   */
+  supportsRawInput(): boolean {
+    return this.currentProcess?.supportsRawInput === true
+  }
+
+  /**
+   * Route a key event to the foreground process.
+   * Only works if the process supports raw input (supportsRawInput === true).
+   * @param key - The key identifier (e.g., 'ArrowUp', 'ArrowDown')
+   * @param modifiers - Optional modifier key state
+   * @returns True if key was handled by a process, false otherwise
+   */
+  handleKey(key: string, modifiers?: KeyModifiers): boolean {
+    if (this.currentProcess?.supportsRawInput && this.currentProcess.handleKey) {
+      this.currentProcess.handleKey(key, modifiers)
       return true
     }
     return false

--- a/packages/shell-core/src/index.ts
+++ b/packages/shell-core/src/index.ts
@@ -19,7 +19,7 @@ export type {
 
 // New interfaces for process-based command execution
 export type { ShellContext } from './interfaces/ShellContext'
-export type { IProcess } from './interfaces/IProcess'
+export type { IProcess, KeyModifiers } from './interfaces/IProcess'
 export type { ICommand } from './interfaces/ICommand'
 
 // Path utilities

--- a/packages/shell-core/src/interfaces/IProcess.ts
+++ b/packages/shell-core/src/interfaces/IProcess.ts
@@ -4,6 +4,18 @@
  */
 
 /**
+ * Key modifier state for raw key input handling.
+ */
+export interface KeyModifiers {
+  /** Ctrl key is pressed */
+  ctrl: boolean
+  /** Alt key is pressed */
+  alt: boolean
+  /** Shift key is pressed */
+  shift: boolean
+}
+
+/**
  * A long-running process that can be started, stopped, and receive input.
  * Used for interactive commands like REPLs or scripts that take time to execute.
  */
@@ -50,4 +62,22 @@ export interface IProcess {
    * @param code - Exit code (0 for success, non-zero for errors)
    */
   onExit: (code: number) => void
+
+  /**
+   * Whether this process supports raw key input handling.
+   * When true, the shell should forward raw key events to handleKey().
+   * When false/undefined, only line-based input via handleInput() is used.
+   * @optional
+   */
+  supportsRawInput?: boolean
+
+  /**
+   * Handle a raw key input event.
+   * Called when the user presses a key while this process is running
+   * and supportsRawInput is true.
+   * @param key - The key identifier (e.g., 'ArrowUp', 'ArrowDown', 'Tab')
+   * @param modifiers - Optional modifier key state
+   * @optional
+   */
+  handleKey?(key: string, modifiers?: KeyModifiers): void
 }

--- a/packages/shell-core/src/interfaces/index.ts
+++ b/packages/shell-core/src/interfaces/index.ts
@@ -4,5 +4,5 @@
  */
 
 export type { ShellContext } from './ShellContext'
-export type { IProcess } from './IProcess'
+export type { IProcess, KeyModifiers } from './IProcess'
 export type { ICommand } from './ICommand'

--- a/packages/shell-core/tests/interfaces/IProcess.test.ts
+++ b/packages/shell-core/tests/interfaces/IProcess.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import type { IProcess } from '../../src/interfaces/IProcess'
+import type { IProcess, KeyModifiers } from '../../src/interfaces/IProcess'
 
 describe('IProcess interface', () => {
   /**
@@ -76,6 +76,69 @@ describe('IProcess interface', () => {
       process.onExit = callback
       process.onExit(1)
       expect(callback).toHaveBeenCalledWith(1)
+    })
+  })
+
+  describe('raw key input handling (optional)', () => {
+    /**
+     * Helper to create a mock process with raw key handling support.
+     */
+    function createMockProcessWithKeySupport(): IProcess {
+      return {
+        start: vi.fn(),
+        stop: vi.fn(),
+        isRunning: vi.fn(() => false),
+        handleInput: vi.fn(),
+        onOutput: vi.fn(),
+        onError: vi.fn(),
+        onExit: vi.fn(),
+        supportsRawInput: true,
+        handleKey: vi.fn(),
+      }
+    }
+
+    it('should define optional supportsRawInput property', () => {
+      const process = createMockProcessWithKeySupport()
+      expect(process.supportsRawInput).toBe(true)
+    })
+
+    it('should define optional handleKey method', () => {
+      const process = createMockProcessWithKeySupport()
+      expect(process.handleKey).toBeDefined()
+      expect(typeof process.handleKey).toBe('function')
+    })
+
+    it('should call handleKey with key string and optional modifiers', () => {
+      const process = createMockProcessWithKeySupport()
+      const modifiers: KeyModifiers = { ctrl: false, alt: false, shift: false }
+
+      process.handleKey!('ArrowUp', modifiers)
+
+      expect(process.handleKey).toHaveBeenCalledWith('ArrowUp', modifiers)
+    })
+
+    it('should allow process without raw key support', () => {
+      const process = createMockProcess()
+      // Process without supportsRawInput should work (defaults to false/undefined)
+      expect(process.supportsRawInput).toBeUndefined()
+      expect(process.handleKey).toBeUndefined()
+    })
+  })
+
+  describe('KeyModifiers type', () => {
+    it('should allow creating KeyModifiers with ctrl modifier', () => {
+      const modifiers: KeyModifiers = { ctrl: true, alt: false, shift: false }
+      expect(modifiers.ctrl).toBe(true)
+    })
+
+    it('should allow creating KeyModifiers with alt modifier', () => {
+      const modifiers: KeyModifiers = { ctrl: false, alt: true, shift: false }
+      expect(modifiers.alt).toBe(true)
+    })
+
+    it('should allow creating KeyModifiers with shift modifier', () => {
+      const modifiers: KeyModifiers = { ctrl: false, alt: false, shift: true }
+      expect(modifiers.shift).toBe(true)
     })
   })
 })


### PR DESCRIPTION
## Summary
- Extended IProcess interface with optional handleKey() method and KeyModifiers type
- Added supportsRawInput flag to indicate process can handle raw key events
- Implemented ProcessManager.handleKey() to forward keys to processes
- Implemented command history storage and arrow key navigation in LuaReplProcess
- Updated ShellTerminal to route arrow keys to process when running

## Test Plan
### Unit Tests
- IProcess interface tests for optional handleKey and supportsRawInput (15 tests)
- ProcessManager tests for handleKey and supportsRawInput methods (24 tests)
- useProcessManager hook tests for key handling (17 tests)
- LuaReplProcess tests for history storage and navigation (34 tests)
- ShellTerminal tests for process key routing (27 tests)

### Manual Testing
1. Start lua REPL with `lua` command in shell
2. Enter several commands (e.g., `x = 1`, `y = 2`, `print(x + y)`)
3. Press Arrow Up - should show previous command
4. Press Arrow Up multiple times - should navigate through history
5. Press Arrow Down - should navigate to newer commands
6. Press Arrow Down past newest - should clear line
7. Verify shell history still works when no process is running

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)