### PR TITLE
feat(#193): Add Output Throttling to Print Callback

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -74,7 +74,8 @@
       "Bash(python update-pr.py:*)",
       "Bash(node scripts/capture-screenshots.js:*)",
       "Bash(SCREENSHOT_SERVER_TIMEOUT=60000 node scripts/capture-screenshots.js:*)",
-      "Bash(wc:*)"
+      "Bash(wc:*)",
+      "Bash(git checkout:*)"
     ],
     "deny": [
       "Bash(npm run dev)",

--- a/EPIC.md
+++ b/EPIC.md
@@ -38,7 +38,7 @@ Infinite or long-running Lua loops (e.g., `while i > 0 do i = i + 1; print(i) en
 | # | Title | Status | Dependencies | Notes |
 |---|-------|--------|--------------|-------|
 | #192 | Add Execution Control Infrastructure to LuaEngineFactory | ✅ Complete | - | Merged PR #203 |
-| #193 | Add Output Throttling to Print Callback | ⏳ Pending | - | - |
+| #193 | Add Output Throttling to Print Callback | 🔄 In Progress | - | Branch: 193-add-output-throttling-to-print-callback |
 | #194 | Integrate Stop Request and Continuation Prompt into Processes | ⏳ Pending | #192 | - |
 | #195 | Add Comprehensive Tests for Execution Control | ⏳ Pending | #192, #193, #194 | - |
 
@@ -56,6 +56,7 @@ Infinite or long-running Lua loops (e.g., `while i > 0 do i = i + 1; print(i) en
 - Epic started
 - Started work on #192: Add Execution Control Infrastructure to LuaEngineFactory
 - Completed #192: Merged PR #203 to epic-183
+- Started work on #193: Add Output Throttling to Print Callback
 
 ## Key Files
 

--- a/packages/lua-runtime/src/LuaReplProcess.ts
+++ b/packages/lua-runtime/src/LuaReplProcess.ts
@@ -326,6 +326,9 @@ export class LuaReplProcess implements IProcess {
 
     const result = await LuaEngineFactory.executeCode(this.engine, code, callbacks)
 
+    // Flush any buffered output from the execution
+    LuaEngineFactory.flushOutput(this.engine)
+
     // If expression returned a value (including nil), output it with newline
     // undefined means it was a statement (no return value)
     // 'nil' means the expression evaluated to nil (e.g., undefined variable)

--- a/packages/lua-runtime/src/LuaScriptProcess.ts
+++ b/packages/lua-runtime/src/LuaScriptProcess.ts
@@ -149,11 +149,18 @@ export class LuaScriptProcess implements IProcess {
       // Execute the script
       await this.engine.doString(scriptContent)
 
+      // Flush any buffered output from the execution
+      LuaEngineFactory.flushOutput(this.engine)
+
       // Script completed successfully
       if (this.running) {
         this.exitWithCode(this.hasError ? 1 : 0)
       }
     } catch (error) {
+      // Flush any buffered output before reporting error
+      if (this.engine) {
+        LuaEngineFactory.flushOutput(this.engine)
+      }
       // Script failed with error
       const errorMsg = error instanceof Error ? error.message : String(error)
       this.onError(formatLuaError(errorMsg) + '\n')

--- a/packages/lua-runtime/tests/LuaEngineFactory.outputThrottling.test.ts
+++ b/packages/lua-runtime/tests/LuaEngineFactory.outputThrottling.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  LuaEngineFactory,
+  type LuaEngineCallbacks,
+  FLUSH_INTERVAL_MS,
+  MAX_BUFFER_SIZE,
+} from '../src/LuaEngineFactory'
+
+describe('LuaEngineFactory - Output Throttling', () => {
+  let callbacks: LuaEngineCallbacks
+
+  beforeEach(() => {
+    callbacks = {
+      onOutput: vi.fn(),
+      onError: vi.fn(),
+      onReadInput: vi.fn(),
+    }
+  })
+
+  describe('constants', () => {
+    it('should export FLUSH_INTERVAL_MS constant (~60fps)', () => {
+      expect(FLUSH_INTERVAL_MS).toBe(16)
+    })
+
+    it('should export MAX_BUFFER_SIZE constant', () => {
+      expect(MAX_BUFFER_SIZE).toBe(1000)
+    })
+  })
+
+  describe('print output buffering', () => {
+    it('should buffer print outputs instead of calling callback immediately', async () => {
+      const engine = await LuaEngineFactory.create(callbacks)
+
+      await engine.doString('print("hello")')
+
+      // Output should NOT be called immediately due to buffering
+      // It will be flushed on close or when time/size threshold is met
+      expect(callbacks.onOutput).not.toHaveBeenCalled()
+
+      LuaEngineFactory.close(engine)
+    })
+
+    it('should flush buffer when time threshold is exceeded on next output', async () => {
+      const engine = await LuaEngineFactory.create(callbacks)
+
+      await engine.doString('print("first")')
+      expect(callbacks.onOutput).not.toHaveBeenCalled()
+
+      // Wait for more than FLUSH_INTERVAL_MS
+      await new Promise((resolve) => setTimeout(resolve, FLUSH_INTERVAL_MS + 5))
+
+      // Next print should trigger flush (including the new output in the batch)
+      await engine.doString('print("second")')
+
+      // Both outputs should be flushed together (add-then-flush behavior)
+      expect(callbacks.onOutput).toHaveBeenCalledWith('first\nsecond\n')
+
+      LuaEngineFactory.close(engine)
+    })
+
+    it('should batch rapid prints within flush interval', async () => {
+      const engine = await LuaEngineFactory.create(callbacks)
+
+      // Rapid prints within same interval should be batched
+      await engine.doString('print("one"); print("two"); print("three")')
+
+      // Nothing flushed yet (all within same interval)
+      expect(callbacks.onOutput).not.toHaveBeenCalled()
+
+      // Close should flush all batched output
+      LuaEngineFactory.close(engine)
+
+      expect(callbacks.onOutput).toHaveBeenCalledTimes(1)
+      expect(callbacks.onOutput).toHaveBeenCalledWith('one\ntwo\nthree\n')
+    })
+
+    it('should flush immediately when buffer exceeds MAX_BUFFER_SIZE', async () => {
+      const engine = await LuaEngineFactory.create(callbacks)
+
+      // Generate enough outputs to exceed buffer size
+      await engine.doString(`
+        for i = 1, ${MAX_BUFFER_SIZE + 1} do
+          print(i)
+        end
+      `)
+
+      // Should have flushed at least once due to size threshold
+      expect(callbacks.onOutput).toHaveBeenCalled()
+
+      LuaEngineFactory.close(engine)
+    })
+
+    it('should flush when buffer reaches exactly MAX_BUFFER_SIZE', async () => {
+      const engine = await LuaEngineFactory.create(callbacks)
+
+      // Generate exactly MAX_BUFFER_SIZE outputs
+      await engine.doString(`
+        for i = 1, ${MAX_BUFFER_SIZE} do
+          print(i)
+        end
+      `)
+
+      // Should have flushed when reaching exactly MAX_BUFFER_SIZE
+      expect(callbacks.onOutput).toHaveBeenCalled()
+
+      LuaEngineFactory.close(engine)
+    })
+  })
+
+  describe('io.write output buffering', () => {
+    it('should buffer io.write outputs', async () => {
+      const engine = await LuaEngineFactory.create(callbacks)
+
+      await engine.doString('io.write("hello")')
+
+      // Should be buffered
+      expect(callbacks.onOutput).not.toHaveBeenCalled()
+
+      // Close should flush
+      LuaEngineFactory.close(engine)
+
+      expect(callbacks.onOutput).toHaveBeenCalledWith('hello')
+    })
+
+    it('should batch io.write and print outputs together', async () => {
+      const engine = await LuaEngineFactory.create(callbacks)
+
+      await engine.doString('io.write("hello "); print("world")')
+
+      // Buffered together
+      expect(callbacks.onOutput).not.toHaveBeenCalled()
+
+      // Close should flush both in single call
+      LuaEngineFactory.close(engine)
+
+      expect(callbacks.onOutput).toHaveBeenCalledTimes(1)
+      expect(callbacks.onOutput).toHaveBeenCalledWith('hello world\n')
+    })
+  })
+
+  describe('flush on close', () => {
+    it('should flush remaining buffer when close() is called', async () => {
+      const engine = await LuaEngineFactory.create(callbacks)
+
+      await engine.doString('print("buffered")')
+      expect(callbacks.onOutput).not.toHaveBeenCalled()
+
+      // Close should flush the buffer
+      LuaEngineFactory.close(engine)
+
+      expect(callbacks.onOutput).toHaveBeenCalledWith('buffered\n')
+    })
+
+    it('should flush remaining buffer when closeDeferred() is called', async () => {
+      const engine = await LuaEngineFactory.create(callbacks)
+
+      await engine.doString('print("deferred")')
+      expect(callbacks.onOutput).not.toHaveBeenCalled()
+
+      // closeDeferred should flush immediately (before the setTimeout)
+      LuaEngineFactory.closeDeferred(engine)
+
+      expect(callbacks.onOutput).toHaveBeenCalledWith('deferred\n')
+    })
+
+    it('should not error when closing with empty buffer', async () => {
+      const engine = await LuaEngineFactory.create(callbacks)
+
+      // Close without any output
+      expect(() => LuaEngineFactory.close(engine)).not.toThrow()
+      expect(callbacks.onOutput).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle empty print calls', async () => {
+      const engine = await LuaEngineFactory.create(callbacks)
+
+      await engine.doString('print()')
+
+      // Flush on close
+      LuaEngineFactory.close(engine)
+
+      // Empty print should produce just newline
+      expect(callbacks.onOutput).toHaveBeenCalledWith('\n')
+    })
+
+    it('should handle nil values in print', async () => {
+      const engine = await LuaEngineFactory.create(callbacks)
+
+      await engine.doString('print(nil)')
+
+      LuaEngineFactory.close(engine)
+
+      expect(callbacks.onOutput).toHaveBeenCalledWith('nil\n')
+    })
+
+    it('should preserve output order across multiple flushes', async () => {
+      const engine = await LuaEngineFactory.create(callbacks)
+
+      // First batch - will exceed buffer size to force flush
+      await engine.doString(`
+        for i = 1, ${MAX_BUFFER_SIZE + 1} do
+          print("batch1-" .. i)
+        end
+      `)
+
+      const firstCallCount = (callbacks.onOutput as ReturnType<typeof vi.fn>).mock.calls.length
+      expect(firstCallCount).toBeGreaterThan(0)
+
+      // Second batch
+      await engine.doString('print("final")')
+
+      LuaEngineFactory.close(engine)
+
+      // Verify final output was flushed
+      const lastCall = (callbacks.onOutput as ReturnType<typeof vi.fn>).mock.calls.at(-1)
+      expect(lastCall?.[0]).toContain('final')
+    })
+
+    it('should handle multiple engines with separate buffers', async () => {
+      const callbacks1: LuaEngineCallbacks = {
+        onOutput: vi.fn(),
+        onError: vi.fn(),
+      }
+      const callbacks2: LuaEngineCallbacks = {
+        onOutput: vi.fn(),
+        onError: vi.fn(),
+      }
+
+      const engine1 = await LuaEngineFactory.create(callbacks1)
+      const engine2 = await LuaEngineFactory.create(callbacks2)
+
+      await engine1.doString('print("engine1")')
+      await engine2.doString('print("engine2")')
+
+      // Neither should be flushed yet
+      expect(callbacks1.onOutput).not.toHaveBeenCalled()
+      expect(callbacks2.onOutput).not.toHaveBeenCalled()
+
+      // Close engine1 - should only flush engine1's buffer
+      LuaEngineFactory.close(engine1)
+
+      expect(callbacks1.onOutput).toHaveBeenCalledWith('engine1\n')
+      expect(callbacks2.onOutput).not.toHaveBeenCalled()
+
+      // Close engine2
+      LuaEngineFactory.close(engine2)
+
+      expect(callbacks2.onOutput).toHaveBeenCalledWith('engine2\n')
+    })
+  })
+})

--- a/packages/lua-runtime/tests/LuaEngineFactory.test.ts
+++ b/packages/lua-runtime/tests/LuaEngineFactory.test.ts
@@ -27,9 +27,10 @@ describe('LuaEngineFactory', () => {
 
       await engine.doString('print("hello world")')
 
-      expect(callbacks.onOutput).toHaveBeenCalledWith('hello world\n')
+      // Flush buffered output
+      LuaEngineFactory.close(engine)
 
-      engine.global.close()
+      expect(callbacks.onOutput).toHaveBeenCalledWith('hello world\n')
     })
 
     it('should concatenate multiple print arguments with tabs', async () => {
@@ -37,9 +38,10 @@ describe('LuaEngineFactory', () => {
 
       await engine.doString('print("a", "b", "c")')
 
-      expect(callbacks.onOutput).toHaveBeenCalledWith('a\tb\tc\n')
+      // Flush buffered output
+      LuaEngineFactory.close(engine)
 
-      engine.global.close()
+      expect(callbacks.onOutput).toHaveBeenCalledWith('a\tb\tc\n')
     })
 
     it('should convert nil values to string "nil" in print', async () => {
@@ -47,9 +49,10 @@ describe('LuaEngineFactory', () => {
 
       await engine.doString('print(nil)')
 
-      expect(callbacks.onOutput).toHaveBeenCalledWith('nil\n')
+      // Flush buffered output
+      LuaEngineFactory.close(engine)
 
-      engine.global.close()
+      expect(callbacks.onOutput).toHaveBeenCalledWith('nil\n')
     })
 
     it('should provide io.write function that outputs without newline', async () => {
@@ -57,9 +60,10 @@ describe('LuaEngineFactory', () => {
 
       await engine.doString('io.write("hello")')
 
-      expect(callbacks.onOutput).toHaveBeenCalledWith('hello')
+      // Flush buffered output
+      LuaEngineFactory.close(engine)
 
-      engine.global.close()
+      expect(callbacks.onOutput).toHaveBeenCalledWith('hello')
     })
 
     it('should use default empty string handler when onReadInput is not provided', async () => {
@@ -97,9 +101,10 @@ describe('LuaEngineFactory', () => {
 
       await engine.doString('print(42)')
 
-      expect(callbacks.onOutput).toHaveBeenCalledWith('42\n')
+      // Flush buffered output
+      LuaEngineFactory.close(engine)
 
-      engine.global.close()
+      expect(callbacks.onOutput).toHaveBeenCalledWith('42\n')
     })
 
     it('should convert booleans in print', async () => {
@@ -107,9 +112,10 @@ describe('LuaEngineFactory', () => {
 
       await engine.doString('print(true, false)')
 
-      expect(callbacks.onOutput).toHaveBeenCalledWith('true\tfalse\n')
+      // Flush buffered output
+      LuaEngineFactory.close(engine)
 
-      engine.global.close()
+      expect(callbacks.onOutput).toHaveBeenCalledWith('true\tfalse\n')
     })
   })
 
@@ -121,9 +127,11 @@ describe('LuaEngineFactory', () => {
 
       // Verify by printing the value
       await engine.doString('print(x)')
-      expect(callbacks.onOutput).toHaveBeenCalledWith('42\n')
 
-      engine.global.close()
+      // Flush buffered output
+      LuaEngineFactory.close(engine)
+
+      expect(callbacks.onOutput).toHaveBeenCalledWith('42\n')
     })
 
     it('should evaluate expressions and return formatted result', async () => {


### PR DESCRIPTION
## Summary

Add output buffering to `LuaEngineFactory` to prevent DOM pressure from high-frequency print calls in tight loops.

- Add `FLUSH_INTERVAL_MS` (16ms ~60fps) and `MAX_BUFFER_SIZE` (1000) constants
- Buffer `print()` and `io.write()` outputs instead of immediate callback
- Flush buffer when time threshold exceeded OR buffer size reached  
- Add `flushOutput()` method for explicit flushing after code execution
- Update `close()` and `closeDeferred()` to flush remaining buffer
- Update `LuaReplProcess` and `LuaScriptProcess` to flush after execution

Part of Epic #183.

Closes #193

## Test plan

- [x] Unit tests verify buffering behavior (16 output throttling tests)
- [x] Unit tests verify flush on time threshold
- [x] Unit tests verify flush on size threshold (MAX_BUFFER_SIZE)
- [x] Unit tests verify flush on close() and closeDeferred()
- [x] Unit tests verify multiple engines have separate buffers
- [x] Existing REPL tests pass with flushing after execution
- [x] Existing script tests pass with flushing after execution
- [x] All 1100+ project tests pass
- [x] Lint passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)