### PR TITLE
feat(#177): Add build info to console on launch to help debug

### DIFF
--- a/lua-learning-website/src/build-info.d.ts
+++ b/lua-learning-website/src/build-info.d.ts
@@ -1,0 +1,5 @@
+declare const __BUILD_COMMIT__: string
+declare const __BUILD_BRANCH__: string
+declare const __BUILD_TIMESTAMP__: string
+declare const __BUILD_ENV__: string
+declare const __BUILD_VERSION__: string

--- a/lua-learning-website/src/main.tsx
+++ b/lua-learning-website/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import { ThemeProvider } from './contexts/ThemeContext'
+import { logBuildInfo } from './utils/buildInfo'
 import './styles/themes.css'
 import './index.css'
 import App from './App.tsx'
+
+logBuildInfo()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/lua-learning-website/src/utils/buildInfo.test.ts
+++ b/lua-learning-website/src/utils/buildInfo.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Type for global build constants
+interface BuildGlobals {
+  __BUILD_COMMIT__?: string
+  __BUILD_BRANCH__?: string
+  __BUILD_TIMESTAMP__?: string
+  __BUILD_ENV__?: string
+  __BUILD_VERSION__?: string
+}
+
+const globals = globalThis as unknown as BuildGlobals
+
+describe('buildInfo', () => {
+  const originalGlobals = {
+    __BUILD_COMMIT__: globals.__BUILD_COMMIT__,
+    __BUILD_BRANCH__: globals.__BUILD_BRANCH__,
+    __BUILD_TIMESTAMP__: globals.__BUILD_TIMESTAMP__,
+    __BUILD_ENV__: globals.__BUILD_ENV__,
+    __BUILD_VERSION__: globals.__BUILD_VERSION__,
+  }
+
+  beforeEach(() => {
+    // Set mock values for build constants
+    ;(globalThis as Record<string, unknown>).__BUILD_COMMIT__ = 'abc1234'
+    ;(globalThis as Record<string, unknown>).__BUILD_BRANCH__ = 'main'
+    ;(globalThis as Record<string, unknown>).__BUILD_TIMESTAMP__ =
+      '2025-01-15T10:30:00.000Z'
+    ;(globalThis as Record<string, unknown>).__BUILD_ENV__ = 'production'
+    ;(globalThis as Record<string, unknown>).__BUILD_VERSION__ = '1.2.3'
+    vi.spyOn(console, 'info').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    // Restore original globals
+    Object.assign(globalThis, originalGlobals)
+    vi.restoreAllMocks()
+    // Reset module cache to allow re-import
+    vi.resetModules()
+  })
+
+  describe('logBuildInfo', () => {
+    it('should log build info to console', async () => {
+      const { logBuildInfo } = await import('./buildInfo')
+      logBuildInfo()
+      expect(console.info).toHaveBeenCalled()
+    })
+
+    it('should include commit hash in output', async () => {
+      const { logBuildInfo } = await import('./buildInfo')
+      logBuildInfo()
+      const call = vi.mocked(console.info).mock.calls[0][0] as string
+      expect(call).toContain('abc1234')
+    })
+
+    it('should include branch name in output', async () => {
+      const { logBuildInfo } = await import('./buildInfo')
+      logBuildInfo()
+      const call = vi.mocked(console.info).mock.calls[0][0] as string
+      expect(call).toContain('main')
+    })
+
+    it('should include environment in output', async () => {
+      const { logBuildInfo } = await import('./buildInfo')
+      logBuildInfo()
+      const call = vi.mocked(console.info).mock.calls[0][0] as string
+      expect(call).toContain('production')
+    })
+
+    it('should include version in output', async () => {
+      const { logBuildInfo } = await import('./buildInfo')
+      logBuildInfo()
+      const call = vi.mocked(console.info).mock.calls[0][0] as string
+      expect(call).toContain('1.2.3')
+    })
+
+    it('should include build timestamp in output', async () => {
+      const { logBuildInfo } = await import('./buildInfo')
+      logBuildInfo()
+      const call = vi.mocked(console.info).mock.calls[0][0] as string
+      expect(call).toContain('2025-01-15')
+    })
+
+    it('should truncate timestamp to remove milliseconds', async () => {
+      const { logBuildInfo } = await import('./buildInfo')
+      logBuildInfo()
+      const call = vi.mocked(console.info).mock.calls[0][0] as string
+      // Verify milliseconds are NOT in output
+      expect(call).not.toContain('.000Z')
+      // Verify truncated timestamp IS in output
+      expect(call).toContain('2025-01-15T10:30:00')
+    })
+  })
+
+  describe('getBuildInfo', () => {
+    it('should return build info object', async () => {
+      const { getBuildInfo } = await import('./buildInfo')
+      const info = getBuildInfo()
+      expect(info).toEqual({
+        commit: 'abc1234',
+        branch: 'main',
+        timestamp: '2025-01-15T10:30:00.000Z',
+        env: 'production',
+        version: '1.2.3',
+      })
+    })
+  })
+})

--- a/lua-learning-website/src/utils/buildInfo.ts
+++ b/lua-learning-website/src/utils/buildInfo.ts
@@ -1,0 +1,32 @@
+export interface BuildInfo {
+  commit: string
+  branch: string
+  timestamp: string
+  env: string
+  version: string
+}
+
+export function getBuildInfo(): BuildInfo {
+  return {
+    commit: __BUILD_COMMIT__,
+    branch: __BUILD_BRANCH__,
+    timestamp: __BUILD_TIMESTAMP__,
+    env: __BUILD_ENV__,
+    version: __BUILD_VERSION__,
+  }
+}
+
+export function logBuildInfo(): void {
+  const info = getBuildInfo()
+  const message = `
+╔══════════════════════════════════════╗
+║           Build Information          ║
+╠══════════════════════════════════════╣
+║ Version:   ${info.version.padEnd(25)}║
+║ Commit:    ${info.commit.padEnd(25)}║
+║ Branch:    ${info.branch.padEnd(25)}║
+║ Env:       ${info.env.padEnd(25)}║
+║ Built:     ${info.timestamp.substring(0, 19).padEnd(25)}║
+╚══════════════════════════════════════╝`
+  console.info(message)
+}

--- a/lua-learning-website/vite.config.ts
+++ b/lua-learning-website/vite.config.ts
@@ -1,9 +1,40 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { execSync } from 'child_process'
+import { readFileSync } from 'fs'
+
+function getGitInfo(command: string, fallback: string): string {
+  try {
+    return execSync(command, { encoding: 'utf-8' }).trim()
+  } catch {
+    return fallback
+  }
+}
+
+function getPackageVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
+    return pkg.version || 'unknown'
+  } catch {
+    return 'unknown'
+  }
+}
+
+const gitCommit = getGitInfo('git rev-parse --short HEAD', 'unknown')
+const gitBranch = getGitInfo('git rev-parse --abbrev-ref HEAD', 'unknown')
+const buildTimestamp = new Date().toISOString()
+const packageVersion = getPackageVersion()
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [react()],
+  define: {
+    __BUILD_COMMIT__: JSON.stringify(gitCommit),
+    __BUILD_BRANCH__: JSON.stringify(gitBranch),
+    __BUILD_TIMESTAMP__: JSON.stringify(buildTimestamp),
+    __BUILD_ENV__: JSON.stringify(mode),
+    __BUILD_VERSION__: JSON.stringify(packageVersion),
+  },
   build: {
     rollupOptions: {
       output: {
@@ -20,4 +51,4 @@ export default defineConfig({
       },
     },
   },
-})
+}))


### PR DESCRIPTION
## Summary
Add build information display to browser console on application launch.

Changes:
- Configure Vite to inject build-time constants (commit hash, branch, timestamp, environment, version) using the `define` option
- Create TypeScript type declarations for the build constants
- Create `buildInfo.ts` utility with `logBuildInfo()` and `getBuildInfo()` functions
- Call `logBuildInfo()` from main.tsx to display build info on startup
- Build info is displayed as a formatted table in the browser console

## Test plan
- Run `npm run dev` and open browser developer console
- Verify build info table appears with Version, Commit, Branch, Env, and Built fields
- Verify timestamp is truncated (no milliseconds)
- Run `npm run build && npm run preview` and verify production build shows correct environment

## Manual Testing
**Config Changes:**
  - [ ] Verify dev server starts correctly
  - [ ] Verify build succeeds

Fixes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)