### PR TITLE
feat(#224): Fix Lua engine test failures: thread_handle called on non-main thread

### DIFF
--- a/lua-learning-website/src/components/LuaRepl/LuaRepl.test.tsx
+++ b/lua-learning-website/src/components/LuaRepl/LuaRepl.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { vi } from 'vitest'
 
 // Mock BashTerminal since it uses xterm which doesn't work in jsdom
@@ -43,73 +43,111 @@ describe('LuaRepl', () => {
     vi.clearAllMocks()
   })
 
+  // Helper to wait for engine initialization to complete
+  const waitForEngineInit = async () => {
+    // Give time for the async engine initialization to complete
+    await waitFor(() => {}, { timeout: 50 })
+  }
+
   describe('standalone mode (default)', () => {
-    it('should render Interactive REPL header by default', () => {
+    it('should render Interactive REPL header by default', async () => {
       // Arrange & Act
-      render(<LuaRepl />)
+      const { unmount } = render(<LuaRepl />)
 
       // Assert
       expect(screen.getByRole('heading', { name: /interactive repl/i })).toBeInTheDocument()
+
+      // Wait for async operations to complete before unmount
+      await waitForEngineInit()
+      unmount()
     })
 
-    it('should render Clear button by default', () => {
+    it('should render Clear button by default', async () => {
       // Arrange & Act
-      render(<LuaRepl />)
+      const { unmount } = render(<LuaRepl />)
 
       // Assert
       expect(screen.getByRole('button', { name: /clear/i })).toBeInTheDocument()
+
+      // Wait for async operations to complete before unmount
+      await waitForEngineInit()
+      unmount()
     })
 
-    it('should render Tips section by default', () => {
+    it('should render Tips section by default', async () => {
       // Arrange & Act
-      render(<LuaRepl />)
+      const { unmount } = render(<LuaRepl />)
 
       // Assert
       expect(screen.getByText(/tips:/i)).toBeInTheDocument()
+
+      // Wait for async operations to complete before unmount
+      await waitForEngineInit()
+      unmount()
     })
 
-    it('should pass embedded=false to BashTerminal by default', () => {
+    it('should pass embedded=false to BashTerminal by default', async () => {
       // Arrange & Act
-      render(<LuaRepl />)
+      const { unmount } = render(<LuaRepl />)
 
       // Assert
       const terminal = screen.getByTestId('bash-terminal')
       expect(terminal).toHaveAttribute('data-embedded', 'false')
+
+      // Wait for async operations to complete before unmount
+      await waitForEngineInit()
+      unmount()
     })
   })
 
   describe('embedded mode', () => {
-    it('should not render Interactive REPL header when embedded', () => {
+    it('should not render Interactive REPL header when embedded', async () => {
       // Arrange & Act
-      render(<LuaRepl embedded />)
+      const { unmount } = render(<LuaRepl embedded />)
 
       // Assert
       expect(screen.queryByRole('heading', { name: /interactive repl/i })).not.toBeInTheDocument()
+
+      // Wait for async operations to complete before unmount
+      await waitForEngineInit()
+      unmount()
     })
 
-    it('should not render Clear button when embedded (use clear() command instead)', () => {
+    it('should not render Clear button when embedded (use clear() command instead)', async () => {
       // Arrange & Act
-      render(<LuaRepl embedded />)
+      const { unmount } = render(<LuaRepl embedded />)
 
       // Assert
       expect(screen.queryByRole('button', { name: /clear/i })).not.toBeInTheDocument()
+
+      // Wait for async operations to complete before unmount
+      await waitForEngineInit()
+      unmount()
     })
 
-    it('should not render Tips section when embedded', () => {
+    it('should not render Tips section when embedded', async () => {
       // Arrange & Act
-      render(<LuaRepl embedded />)
+      const { unmount } = render(<LuaRepl embedded />)
 
       // Assert
       expect(screen.queryByText(/tips:/i)).not.toBeInTheDocument()
+
+      // Wait for async operations to complete before unmount
+      await waitForEngineInit()
+      unmount()
     })
 
-    it('should pass embedded=true to BashTerminal when embedded', () => {
+    it('should pass embedded=true to BashTerminal when embedded', async () => {
       // Arrange & Act
-      render(<LuaRepl embedded />)
+      const { unmount } = render(<LuaRepl embedded />)
 
       // Assert
       const terminal = screen.getByTestId('bash-terminal')
       expect(terminal).toHaveAttribute('data-embedded', 'true')
+
+      // Wait for async operations to complete before unmount
+      await waitForEngineInit()
+      unmount()
     })
   })
 })

--- a/lua-learning-website/src/components/LuaRepl/useLuaRepl.test.ts
+++ b/lua-learning-website/src/components/LuaRepl/useLuaRepl.test.ts
@@ -34,12 +34,16 @@ describe('useLuaRepl', () => {
   })
 
   // Cycle 1: Hook returns isReady=false initially
-  it('should return isReady=false initially', () => {
+  it('should return isReady=false initially', async () => {
     // Arrange & Act
-    const { result } = renderHook(() => useLuaRepl({}))
+    const { result, unmount } = renderHook(() => useLuaRepl({}))
 
     // Assert
     expect(result.current.isReady).toBe(false)
+
+    // Wait for any pending state updates before unmounting
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+    unmount()
   })
 
   // Cycle 2: Hook becomes ready after initialization
@@ -104,7 +108,7 @@ describe('useLuaRepl', () => {
     // Cycle 6: Execute before ready returns early
     it('should not execute when engine is not ready', async () => {
       // Arrange
-      const { result } = renderHook(() => useLuaRepl({}))
+      const { result, unmount } = renderHook(() => useLuaRepl({}))
       // Don't wait for ready
       expect(result.current.isReady).toBe(false)
 
@@ -115,6 +119,10 @@ describe('useLuaRepl', () => {
 
       // Assert - doString should not have been called with our code
       expect(mockDoString).not.toHaveBeenCalledWith('print("test")')
+
+      // Wait for engine initialization to complete before unmounting
+      await waitFor(() => expect(result.current.isReady).toBe(true))
+      unmount()
     })
 
     // Cycle 7: Statement fails, fallback to expression evaluation with formatting


### PR DESCRIPTION
## Summary
- Fixed act(...) warnings in Lua engine test files by ensuring async engine initialization completes before test cleanup
- Tests that check initial state now properly wait for async operations before unmounting
- Note: The thread_handle errors mentioned in the issue were not present - the original issue appears to have been resolved by previous changes

## Test plan
- All 1108 tests pass with no act(...) warnings
- Lint passes
- Build succeeds

## Manual Testing
- [ ] Test-only changes - verify tests pass, minimal manual testing needed

Fixes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)