### PR TITLE
feat(#238): io.read() should flush output before blocking for user

### DIFF
--- a/packages/lua-runtime/src/LuaEngineFactory.ts
+++ b/packages/lua-runtime/src/LuaEngineFactory.ts
@@ -213,6 +213,9 @@ io.write = function(...)
   __js_write(output)
 end
 io.read = function(format)
+  -- Flush output buffer before blocking for input
+  -- This ensures prompts like io.write("Enter name: ") appear before waiting
+  __js_flush()
   local input = __js_read_input():await()
   if format == "*n" or format == "*number" then
     return tonumber(input)
@@ -287,6 +290,11 @@ export class LuaEngineFactory {
     engine.global.set('__js_write', (text: string) => {
       outputBuffer.push(text)
       maybeFlush()
+    })
+
+    // Setup flush function for io.read to call before blocking
+    engine.global.set('__js_flush', () => {
+      flushOutput()
     })
 
     // Setup io.read input handler if provided


### PR DESCRIPTION
## Summary
- Added __js_flush function to flush output buffer before io.read() blocks
- Modified Lua io.read() to call flush before waiting for input, ensuring prompts display before blocking

## Test plan
- Added 2 tests for io.read() flush behavior (io.write and print)
- All 148 lua-runtime tests pass
- Mutation score 85.29% (above 80% threshold)
- Lint passes

## Manual Testing
**Config Changes:**
  - [ ] Verify dev server starts correctly
  - [ ] Verify build succeeds

Fixes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)