### PR TITLE
feat(#226): Only show autocomplete options if user presses Ctrl + Space

### DIFF
--- a/lua-learning-website/e2e/autocomplete.spec.ts
+++ b/lua-learning-website/e2e/autocomplete.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from '@playwright/test'
+
+// Helper to create and open a file so Monaco editor is visible
+async function createAndOpenFile(page: import('@playwright/test').Page) {
+  const sidebar = page.getByTestId('sidebar-panel')
+
+  // First, expand the workspace folder by clicking its chevron
+  const workspaceChevron = page.getByTestId('folder-chevron').first()
+  await workspaceChevron.click()
+  await page.waitForTimeout(200) // Wait for expansion animation
+
+  // Now click New File button - the file will be created inside the expanded workspace
+  await sidebar.getByRole('button', { name: /new file/i }).click()
+
+  const input = sidebar.getByRole('textbox')
+  await expect(input).toBeVisible({ timeout: 5000 }) // Wait for rename input to appear
+  await input.press('Enter') // Accept default name
+  await expect(input).not.toBeVisible({ timeout: 5000 }) // Wait for rename to complete
+
+  // Click the newly created file to open it (should be second treeitem after workspace)
+  const fileItems = page.getByRole('treeitem')
+  const count = await fileItems.count()
+  if (count > 1) {
+    await fileItems.nth(1).click() // Click the file inside the workspace
+  } else {
+    // Fallback: click first item
+    await fileItems.first().click()
+  }
+  await page.waitForTimeout(200)
+}
+
+test.describe('IDE Editor - Autocomplete Behavior', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/editor')
+    await expect(page.locator('[data-testid="ide-layout"]')).toBeVisible()
+    // Create and open a file so Monaco editor is visible
+    await createAndOpenFile(page)
+    // Wait for Monaco to load
+    await expect(page.locator('.monaco-editor')).toBeVisible({ timeout: 10000 })
+  })
+
+  test('autocomplete does not appear automatically while typing', async ({ page }) => {
+    // Click on the editor to focus it
+    const monacoEditor = page.locator('.monaco-editor')
+    await monacoEditor.click()
+
+    // Type a Lua keyword prefix that would trigger autocomplete if enabled
+    await page.keyboard.type('pri')
+
+    // Wait a moment for potential autocomplete popup
+    await page.waitForTimeout(500)
+
+    // Autocomplete popup (suggest-widget) should NOT be visible
+    const suggestWidget = page.locator('.monaco-editor .suggest-widget')
+    await expect(suggestWidget).not.toBeVisible()
+  })
+
+  test('autocomplete appears when Ctrl+Space is pressed', async ({ page }) => {
+    // Click on the editor to focus it
+    const monacoEditor = page.locator('.monaco-editor')
+    await monacoEditor.click()
+
+    // Type some text first
+    await page.keyboard.type('pri')
+    await page.waitForTimeout(200)
+
+    // Press Ctrl+Space to trigger autocomplete
+    await page.keyboard.press('Control+Space')
+
+    // Wait for autocomplete popup to appear
+    await page.waitForTimeout(500)
+
+    // Autocomplete popup (suggest-widget) should be visible
+    const suggestWidget = page.locator('.monaco-editor .suggest-widget.visible')
+    await expect(suggestWidget).toBeVisible({ timeout: 5000 })
+  })
+
+  test('autocomplete does not appear on trigger characters like dot', async ({ page }) => {
+    // Click on the editor to focus it
+    const monacoEditor = page.locator('.monaco-editor')
+    await monacoEditor.click()
+
+    // Type something that would trigger autocomplete on '.' if enabled
+    await page.keyboard.type('string.')
+
+    // Wait a moment for potential autocomplete popup
+    await page.waitForTimeout(500)
+
+    // Autocomplete popup should NOT be visible (since suggestOnTriggerCharacters is false)
+    const suggestWidget = page.locator('.monaco-editor .suggest-widget')
+    await expect(suggestWidget).not.toBeVisible()
+  })
+})

--- a/lua-learning-website/src/components/CodeEditor/CodeEditor.test.tsx
+++ b/lua-learning-website/src/components/CodeEditor/CodeEditor.test.tsx
@@ -7,6 +7,7 @@ import type { Theme } from '../../contexts/types'
 const mockState = vi.hoisted(() => ({
   lastMonacoTheme: null as string | null,
   theme: 'dark' as Theme,
+  lastOptions: null as Record<string, unknown> | null,
 }))
 
 // Mock Monaco Editor - it doesn't work in jsdom
@@ -21,8 +22,9 @@ interface MockMonacoProps {
 
 vi.mock('@monaco-editor/react', () => ({
   default: ({ value, onChange, options, loading, theme }: MockMonacoProps) => {
-    // Capture the theme prop
+    // Capture the theme prop and options
     mockState.lastMonacoTheme = theme ?? null
+    mockState.lastOptions = options ?? null
     // If loading is provided, we're simulating the loading state
     if (loading && value === '__loading__') {
       return <div data-testid="monaco-loading">{loading}</div>
@@ -55,6 +57,7 @@ describe('CodeEditor', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockState.lastMonacoTheme = null
+    mockState.lastOptions = null
     mockState.theme = 'dark'
   })
 
@@ -142,6 +145,17 @@ describe('CodeEditor', () => {
 
       // Assert
       expect(mockState.lastMonacoTheme).toBe('vs')
+    })
+  })
+
+  describe('autocomplete behavior', () => {
+    it('should disable automatic suggestions (only show on Ctrl+Space)', () => {
+      // Arrange & Act
+      render(<CodeEditor value="" onChange={() => {}} />)
+
+      // Assert - quickSuggestions and suggestOnTriggerCharacters should be false
+      expect(mockState.lastOptions?.quickSuggestions).toBe(false)
+      expect(mockState.lastOptions?.suggestOnTriggerCharacters).toBe(false)
     })
   })
 })

--- a/lua-learning-website/src/components/CodeEditor/CodeEditor.tsx
+++ b/lua-learning-website/src/components/CodeEditor/CodeEditor.tsx
@@ -95,6 +95,8 @@ export function CodeEditor({
           scrollBeyondLastLine: false,
           automaticLayout: true,
           formatOnType: true, // Enable auto-dedent for end/else/elseif/until
+          quickSuggestions: false, // Only show autocomplete on Ctrl+Space
+          suggestOnTriggerCharacters: false, // Don't auto-suggest on '.' etc.
         }}
         loading={<div className={styles.loading}>Loading editor...</div>}
       />


### PR DESCRIPTION
## Summary
Configure Monaco editor to disable automatic autocomplete suggestions. Users can still invoke autocomplete manually with Ctrl+Space (Windows/Linux) or Cmd+Space (Mac).

Changes:
- Added `quickSuggestions: false` to disable automatic suggestions while typing
- Added `suggestOnTriggerCharacters: false` to disable suggestions on trigger characters like '.'
- Added unit test verifying the Monaco options are set correctly
- Added E2E tests verifying autocomplete only appears on Ctrl+Space

## Test plan
- [ ] Open the editor and start typing Lua code - verify autocomplete popup does NOT appear automatically
- [ ] Press Ctrl+Space (or Cmd+Space on Mac) while typing - verify autocomplete popup appears
- [ ] Type a dot after a variable (e.g., `string.`) - verify autocomplete popup does NOT appear automatically
- [ ] Verify autocomplete suggestions work correctly when manually invoked

## Manual Testing
**UI Changes:**
  - [ ] Verify `CodeEditor` renders correctly

Fixes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)