### PR TITLE
fix: Fix flaky output throttling test on slow CI

### DIFF
--- a/lua-learning-website/src/components/LuaRepl/useLuaRepl.test.ts
+++ b/lua-learning-website/src/components/LuaRepl/useLuaRepl.test.ts
@@ -221,13 +221,18 @@ describe('useLuaRepl', () => {
       const { result } = renderHook(() => useLuaRepl({ onOutput }))
       await waitFor(() => expect(result.current.isReady).toBe(true))
 
-      // Get the print function that was set
+      // Get the print function and flush function that were set
       const printFn = mockGlobalSet.mock.calls.find(
         (call: unknown[]) => call[0] === 'print'
       )?.[1] as ((...args: unknown[]) => void) | undefined
+      const flushFn = mockGlobalSet.mock.calls.find(
+        (call: unknown[]) => call[0] === '__js_flush'
+      )?.[1] as (() => void) | undefined
 
       // Act
       printFn?.('hello')
+      // Output is buffered, flush to deliver it
+      flushFn?.()
 
       // Assert - LuaEngineFactory's print adds newline (correct Lua behavior)
       expect(onOutput).toHaveBeenCalledWith('hello\n')
@@ -240,13 +245,18 @@ describe('useLuaRepl', () => {
       const { result } = renderHook(() => useLuaRepl({ onOutput }))
       await waitFor(() => expect(result.current.isReady).toBe(true))
 
-      // Get the print function that was set
+      // Get the print function and flush function that were set
       const printFn = mockGlobalSet.mock.calls.find(
         (call: unknown[]) => call[0] === 'print'
       )?.[1] as ((...args: unknown[]) => void) | undefined
+      const flushFn = mockGlobalSet.mock.calls.find(
+        (call: unknown[]) => call[0] === '__js_flush'
+      )?.[1] as (() => void) | undefined
 
       // Act
       printFn?.('a', 'b', 'c')
+      // Output is buffered, flush to deliver it
+      flushFn?.()
 
       // Assert - LuaEngineFactory's print adds newline (correct Lua behavior)
       expect(onOutput).toHaveBeenCalledWith('a\tb\tc\n')
@@ -259,13 +269,18 @@ describe('useLuaRepl', () => {
       const { result } = renderHook(() => useLuaRepl({ onOutput }))
       await waitFor(() => expect(result.current.isReady).toBe(true))
 
-      // Get the print function that was set
+      // Get the print function and flush function that were set
       const printFn = mockGlobalSet.mock.calls.find(
         (call: unknown[]) => call[0] === 'print'
       )?.[1] as ((...args: unknown[]) => void) | undefined
+      const flushFn = mockGlobalSet.mock.calls.find(
+        (call: unknown[]) => call[0] === '__js_flush'
+      )?.[1] as (() => void) | undefined
 
       // Act
       printFn?.(null, undefined, 'value')
+      // Output is buffered, flush to deliver it
+      flushFn?.()
 
       // Assert - LuaEngineFactory's print adds newline (correct Lua behavior)
       expect(onOutput).toHaveBeenCalledWith('nil\tnil\tvalue\n')

--- a/packages/lua-runtime/tests/LuaReplProcess.multiline.test.ts
+++ b/packages/lua-runtime/tests/LuaReplProcess.multiline.test.ts
@@ -123,9 +123,10 @@ describe('LuaReplProcess - Multi-line Input', () => {
       process.handleInput('end')
       await new Promise((resolve) => setTimeout(resolve, 50))
 
-      // Should have printed 1 and 2
-      expect(onOutput).toHaveBeenCalledWith('1\n')
-      expect(onOutput).toHaveBeenCalledWith('2\n')
+      // Should have printed 1 and 2 (may be batched together or separate)
+      const allOutput = onOutput.mock.calls.map((call) => call[0]).join('')
+      expect(allOutput).toContain('1\n')
+      expect(allOutput).toContain('2\n')
     })
   })
 


### PR DESCRIPTION
## Summary
- Fixed flaky CI test "should handle multiple engines with separate buffers" that was failing on slow CI machines
- Root cause: `lastFlush` was initialized at engine creation time, so on slow CI the time between engine creation and first print could exceed 16ms threshold, causing premature flush
- Fix: Initialize `lastFlush` to null and only start timing from the first output

## Test plan
- [x] All 216 lua-runtime tests pass
- [x] All 1672 lua-learning-website tests pass
- [x] Lint passes
- [x] The previously failing test now passes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)