### PR TITLE
fix: Correct build order in deploy workflow

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -25,13 +25,13 @@ jobs:
         run: npm run build
         working-directory: packages/shell-core
 
-      - name: Build lua-runtime
-        run: npm run build
-        working-directory: packages/lua-runtime
-
       - name: Build canvas-runtime
         run: npm run build
         working-directory: packages/canvas-runtime
+
+      - name: Build lua-runtime
+        run: npm run build
+        working-directory: packages/lua-runtime
 
       - name: Build website
         run: npm run build


### PR DESCRIPTION
## Summary
- Fix build order in `firebase-deploy.yml`: canvas-runtime must be built before lua-runtime
- `lua-runtime` imports from `@lua-learning/canvas-runtime`, causing deploy failures when built in wrong order

## Root Cause
The deploy workflow was building packages in this order:
1. shell-core
2. lua-runtime ❌ (fails - needs canvas-runtime)
3. canvas-runtime

Correct order (matching `firebase-preview.yml`):
1. shell-core
2. canvas-runtime
3. lua-runtime ✅

## Test plan
- [ ] Merge this PR and verify the deploy workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)