### PR TITLE
feat(#306): Canvas Image Support: Core Types & ImageCache

### DIFF
--- a/EPIC-305.md
+++ b/EPIC-305.md
@@ -1,0 +1,104 @@
+# Epic #305: Canvas Image Support
+
+**Status:** In Progress (0/5 complete)
+**Branch:** epic-305
+**Created:** 2025-12-17
+**Last Updated:** 2025-12-17T11:05:00Z
+
+## Overview
+
+Add image drawing support to the canvas Lua API with a preloaded asset manifest system.
+
+### Problem
+
+Users cannot load and draw images in their canvas programs. This limits creative possibilities for games and visual projects.
+
+### Solution
+
+Add a `canvas.assets` sub-library for defining assets before `canvas.start()`, which preloads them into memory. This solves the worker canvas filesystem limitation and provides deterministic loading.
+
+### Proposed API
+
+```lua
+-- Define assets before starting (setup phase)
+canvas.assets.image("player", "sprites/player.png")
+canvas.assets.image("enemy", "/my-files/sprites/enemy.png")
+
+-- Start loads all assets, throws if any fail
+canvas.start()
+
+-- Use assets by name (synchronous, already loaded)
+canvas.tick(function()
+    canvas.draw_image("player", x, y)
+    canvas.draw_image("enemy", ex, ey, 64, 64)  -- with scaling
+end)
+
+-- Query dimensions
+local w = canvas.assets.get_width("player")
+local h = canvas.assets.get_height("player")
+```
+
+## Architecture Decisions
+
+<!-- Document key decisions as work progresses -->
+
+(none yet)
+
+## Sub-Issues
+
+| # | Title | Status | Branch | Notes |
+|---|-------|--------|--------|-------|
+| #306 | Core Types & ImageCache | 🔄 In Progress | 306-core-types-imagecache | No dependencies |
+| #307 | Asset Loading Infrastructure | ⏳ Pending | - | Depends on #306 |
+| #308 | Worker Canvas Implementation | ⏳ Pending | - | Depends on #306, #307 |
+| #309 | Shell Canvas Implementation | ⏳ Pending | - | Depends on #306, #307 |
+| #310 | Process Integration & E2E Testing | ⏳ Pending | - | Depends on #306, #307, #308, #309 |
+
+### Dependency Graph
+
+```
+#306 (Types & Cache)
+  │
+  v
+#307 (Asset Loading)
+  │
+  ├──────────────┐
+  v              v
+#308 (Worker)  #309 (Shell)
+  │              │
+  └──────┬───────┘
+         v
+#310 (Integration & E2E)
+```
+
+**Status Legend:**
+- ⏳ Pending - Not yet started
+- 🔄 In Progress - Currently being worked on
+- ✅ Complete - Merged to epic branch
+- ❌ Blocked - Has unresolved blockers
+
+## Progress Log
+
+<!-- Updated after each sub-issue completion -->
+
+### 2025-12-17
+- Epic started
+- Started work on #306: Core Types & ImageCache
+
+## Key Files
+
+<!-- Populated as files are created/modified -->
+
+- `packages/canvas-runtime/src/shared/types.ts` - AssetDefinition, AssetManifest, DrawImageCommand types
+- `packages/canvas-runtime/src/renderer/ImageCache.ts` - Image cache class for storing loaded images
+- `packages/canvas-runtime/tests/renderer/ImageCache.test.ts` - ImageCache unit tests
+
+## Open Questions
+
+<!-- Questions that arise during implementation -->
+
+(none)
+
+## Blockers
+
+(none)

--- a/packages/canvas-runtime/src/renderer/ImageCache.ts
+++ b/packages/canvas-runtime/src/renderer/ImageCache.ts
@@ -1,0 +1,45 @@
+/**
+ * Cache for storing loaded HTMLImageElement instances by asset name.
+ * Used by the canvas renderer to efficiently draw preloaded images.
+ */
+export class ImageCache {
+  private cache: Map<string, HTMLImageElement>;
+
+  constructor() {
+    this.cache = new Map();
+  }
+
+  /**
+   * Store an image in the cache by name.
+   * @param name - The asset name to store the image under
+   * @param image - The HTMLImageElement to store
+   */
+  set(name: string, image: HTMLImageElement): void {
+    this.cache.set(name, image);
+  }
+
+  /**
+   * Retrieve an image from the cache by name.
+   * @param name - The asset name to look up
+   * @returns The stored HTMLImageElement, or undefined if not found
+   */
+  get(name: string): HTMLImageElement | undefined {
+    return this.cache.get(name);
+  }
+
+  /**
+   * Check if an image exists in the cache.
+   * @param name - The asset name to check
+   * @returns true if the asset exists, false otherwise
+   */
+  has(name: string): boolean {
+    return this.cache.has(name);
+  }
+
+  /**
+   * Remove all images from the cache.
+   */
+  clear(): void {
+    this.cache.clear();
+  }
+}

--- a/packages/canvas-runtime/src/renderer/index.ts
+++ b/packages/canvas-runtime/src/renderer/index.ts
@@ -2,3 +2,4 @@ export { CanvasRenderer } from './CanvasRenderer.js';
 export { InputCapture } from './InputCapture.js';
 export { GameLoopController } from './GameLoopController.js';
 export type { FrameCallback } from './GameLoopController.js';
+export { ImageCache } from './ImageCache.js';

--- a/packages/canvas-runtime/src/shared/types.ts
+++ b/packages/canvas-runtime/src/shared/types.ts
@@ -11,7 +11,8 @@ export type DrawCommandType =
   | 'circle'
   | 'fillCircle'
   | 'line'
-  | 'text';
+  | 'text'
+  | 'drawImage';
 
 /**
  * Base interface for all draw commands.
@@ -119,6 +120,23 @@ export interface TextCommand extends DrawCommandBase {
 }
 
 /**
+ * Draw an image from the asset cache.
+ */
+export interface DrawImageCommand extends DrawCommandBase {
+  type: 'drawImage';
+  /** Name of the asset to draw */
+  name: string;
+  /** X position to draw at */
+  x: number;
+  /** Y position to draw at */
+  y: number;
+  /** Optional width to scale image to */
+  width?: number;
+  /** Optional height to scale image to */
+  height?: number;
+}
+
+/**
  * Union type of all draw commands.
  */
 export type DrawCommand =
@@ -131,7 +149,8 @@ export type DrawCommand =
   | CircleCommand
   | FillCircleCommand
   | LineCommand
-  | TextCommand;
+  | TextCommand
+  | DrawImageCommand;
 
 /**
  * Mouse button identifiers.
@@ -193,3 +212,20 @@ export function createDefaultTimingInfo(): TimingInfo {
     frameNumber: 0,
   };
 }
+
+/**
+ * Definition of an asset to be loaded.
+ */
+export interface AssetDefinition {
+  /** Unique name to reference this asset */
+  name: string;
+  /** Path to the asset file (relative or absolute) */
+  path: string;
+  /** Type of asset */
+  type: 'image';
+}
+
+/**
+ * Map of asset names to their definitions.
+ */
+export type AssetManifest = Map<string, AssetDefinition>;

--- a/packages/canvas-runtime/tests/renderer/ImageCache.test.ts
+++ b/packages/canvas-runtime/tests/renderer/ImageCache.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ImageCache } from '../../src/renderer/ImageCache.js';
+
+describe('ImageCache', () => {
+  let cache: ImageCache;
+
+  beforeEach(() => {
+    cache = new ImageCache();
+  });
+
+  describe('constructor', () => {
+    it('should create an empty cache', () => {
+      expect(cache).toBeDefined();
+      expect(cache.has('nonexistent')).toBe(false);
+    });
+  });
+
+  describe('set', () => {
+    it('should store an image by name', () => {
+      const img = new Image();
+      cache.set('player', img);
+      expect(cache.has('player')).toBe(true);
+    });
+
+    it('should overwrite existing image with same name', () => {
+      const img1 = new Image();
+      img1.src = 'first.png';
+      const img2 = new Image();
+      img2.src = 'second.png';
+
+      cache.set('sprite', img1);
+      cache.set('sprite', img2);
+
+      expect(cache.get('sprite')).toBe(img2);
+    });
+  });
+
+  describe('get', () => {
+    it('should return stored image by name', () => {
+      const img = new Image();
+      cache.set('enemy', img);
+      expect(cache.get('enemy')).toBe(img);
+    });
+
+    it('should return undefined for non-existent name', () => {
+      expect(cache.get('missing')).toBeUndefined();
+    });
+  });
+
+  describe('has', () => {
+    it('should return true for existing asset', () => {
+      const img = new Image();
+      cache.set('background', img);
+      expect(cache.has('background')).toBe(true);
+    });
+
+    it('should return false for non-existent asset', () => {
+      expect(cache.has('nothing')).toBe(false);
+    });
+  });
+
+  describe('clear', () => {
+    it('should remove all stored images', () => {
+      const img1 = new Image();
+      const img2 = new Image();
+      cache.set('a', img1);
+      cache.set('b', img2);
+
+      cache.clear();
+
+      expect(cache.has('a')).toBe(false);
+      expect(cache.has('b')).toBe(false);
+    });
+
+    it('should work on empty cache', () => {
+      expect(() => cache.clear()).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Add foundational types and ImageCache class for canvas image support.

- Added AssetDefinition interface and AssetManifest type to types.ts
- Added DrawImageCommand interface with x, y, width?, height? properties
- Updated DrawCommandType and DrawCommand union to include 'drawImage'
- Created ImageCache class with set, get, has, clear methods
- Exported ImageCache from renderer index
- 100% mutation test coverage on ImageCache

## Test plan
- [x] Verify ImageCache.set() stores images by name
- [x] Verify ImageCache.get() retrieves stored images
- [x] Verify ImageCache.get() returns undefined for non-existent names
- [x] Verify ImageCache.has() returns correct boolean
- [x] Verify ImageCache.clear() removes all entries
- [x] Run all canvas-runtime tests (216 tests pass)
- [x] Run scoped mutation tests (100% score)

Closes #306

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)