### PR TITLE
feat(#309): Canvas Image Support: Shell Canvas Implementation

### DIFF
--- a/EPIC-305.md
+++ b/EPIC-305.md
@@ -1,9 +1,9 @@
 # Epic #305: Canvas Image Support
 
-**Status:** In Progress (3/5 complete)
+**Status:** In Progress (4/5 complete)
 **Branch:** epic-305
 **Created:** 2025-12-17
-**Last Updated:** 2025-12-17T15:21:00-07:00
+**Last Updated:** 2025-12-17T15:42:00-07:00
 
 ## Overview
 
@@ -65,7 +65,7 @@ local h = canvas.assets.get_height("player")
 | #306 | Core Types & ImageCache | ✅ Complete | 306-core-types-imagecache | Merged in PR #312 |
 | #307 | Asset Loading Infrastructure | ✅ Complete | 307-asset-loading-infrastructure | Merged in PR #314 |
 | #308 | Worker Canvas Implementation | ✅ Complete | 308-worker-canvas-implementation | Merged in PR #317 |
-| #309 | Shell Canvas Implementation | ⏳ Pending | - | Depends on #306, #307 |
+| #309 | Shell Canvas Implementation | 🔄 In Progress | 309-shell-canvas-implementation | Started 2025-12-17 |
 | #310 | Process Integration & E2E Testing | ⏳ Pending | - | Depends on #306, #307, #308, #309 |
 
 ### Dependency Graph
@@ -106,6 +106,7 @@ local h = canvas.assets.get_height("player")
 - Started work on #308: Worker Canvas Implementation
 - PR created for #308: Worker Canvas Implementation (PR #317)
 - Completed #308: Worker Canvas Implementation - Merged PR #317 to epic-305
+- Started work on #309: Shell Canvas Implementation
 
 ## Key Files
 
@@ -119,6 +120,8 @@ local h = canvas.assets.get_height("player")
 - `packages/canvas-runtime/src/worker/WorkerMessages.ts` - SerializedAsset type for worker communication
 - `packages/canvas-runtime/src/worker/LuaCanvasRuntime.ts` - Asset API bindings (canvas.assets.*, canvas.draw_image)
 - `packages/canvas-runtime/src/renderer/CanvasRenderer.ts` - drawImage command with ImageCache support
+- `packages/lua-runtime/src/CanvasController.ts` - Shell canvas: registerAsset, loadAssets, drawImage, getAssetWidth/Height
+- `packages/lua-runtime/src/setupCanvasAPI.ts` - Shell canvas: canvas.assets.image, canvas.draw_image, canvas.assets.get_width/height
 
 ## Open Questions
 

--- a/packages/canvas-runtime/src/index.ts
+++ b/packages/canvas-runtime/src/index.ts
@@ -9,13 +9,17 @@ export type {
   FillCircleCommand,
   LineCommand,
   TextCommand,
+  DrawImageCommand,
   DrawCommand,
   MouseButton,
   InputState,
   TimingInfo,
+  AssetDefinition,
+  AssetManifest,
+  LoadedAsset,
 } from './shared/index.js';
 
-export { createEmptyInputState, createDefaultTimingInfo } from './shared/index.js';
+export { createEmptyInputState, createDefaultTimingInfo, AssetLoader } from './shared/index.js';
 
 // Channel interfaces
 export type {
@@ -46,6 +50,7 @@ export {
   CanvasRenderer,
   InputCapture,
   GameLoopController,
+  ImageCache,
 } from './renderer/index.js';
 
 export type { FrameCallback } from './renderer/index.js';

--- a/packages/lua-runtime/src/CanvasController.ts
+++ b/packages/lua-runtime/src/CanvasController.ts
@@ -14,8 +14,19 @@ import {
   CanvasRenderer,
   InputCapture,
   GameLoopController,
+  ImageCache,
+  AssetLoader,
 } from '@lua-learning/canvas-runtime'
-import type { DrawCommand, InputState, TimingInfo } from '@lua-learning/canvas-runtime'
+import type {
+  DrawCommand,
+  InputState,
+  TimingInfo,
+  AssetManifest,
+} from '@lua-learning/canvas-runtime'
+import type { IFileSystem } from '@lua-learning/shell-core'
+
+/** Valid image extensions for canvas.assets.image() */
+const VALID_IMAGE_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.gif', '.webp']
 
 /**
  * Callbacks for canvas tab management.
@@ -53,6 +64,18 @@ export class CanvasController {
   // onDraw callback from Lua
   private onDrawCallback: (() => void) | null = null
 
+  // Track whether start() has been called (prevents adding assets after start)
+  private started = false
+
+  // Asset manifest: registered asset definitions
+  private assetManifest: AssetManifest = new Map()
+
+  // Image cache for loaded images
+  private imageCache: ImageCache | null = null
+
+  // Asset dimensions: width/height for each loaded asset
+  private assetDimensions: Map<string, { width: number; height: number }> = new Map()
+
   constructor(callbacks: CanvasCallbacks, canvasId = 'canvas-main') {
     this.callbacks = callbacks
     this.canvasId = canvasId
@@ -81,11 +104,14 @@ export class CanvasController {
       throw new Error('Canvas is already running. Call canvas.stop() first.')
     }
 
+    // Mark as started (prevents adding new assets)
+    this.started = true
+
     // Request canvas tab from UI
     this.canvas = await this.callbacks.onRequestCanvasTab(this.canvasId)
 
-    // Initialize renderer, input capture, and game loop
-    this.renderer = new CanvasRenderer(this.canvas)
+    // Initialize renderer with image cache (if assets were loaded), input capture, and game loop
+    this.renderer = new CanvasRenderer(this.canvas, this.imageCache ?? undefined)
     this.inputCapture = new InputCapture(this.canvas)
     this.gameLoop = new GameLoopController(this.onFrame.bind(this))
 
@@ -146,6 +172,13 @@ export class CanvasController {
    */
   addDrawCommand(command: DrawCommand): void {
     this.frameCommands.push(command)
+  }
+
+  /**
+   * Get the accumulated frame commands (for testing).
+   */
+  getFrameCommands(): DrawCommand[] {
+    return this.frameCommands
   }
 
   /**
@@ -327,6 +360,153 @@ export class CanvasController {
    */
   getHeight(): number {
     return this.canvas?.height ?? 0
+  }
+
+  // --- Asset API ---
+
+  /**
+   * Register an image asset to be loaded when canvas.start() is called.
+   * @param name - Unique name to reference this asset
+   * @param path - Path to the image file (relative or absolute)
+   * @throws Error if called after canvas.start() or if file extension is invalid
+   */
+  registerAsset(name: string, path: string): void {
+    // Check if started
+    if (this.started) {
+      throw new Error('Cannot define assets after canvas.start()')
+    }
+
+    // Validate image extension
+    const lowerPath = path.toLowerCase()
+    const hasValidExtension = VALID_IMAGE_EXTENSIONS.some((ext) =>
+      lowerPath.endsWith(ext)
+    )
+    if (!hasValidExtension) {
+      throw new Error(
+        `Cannot load '${path}': unsupported format (expected PNG, JPG, GIF, or WebP)`
+      )
+    }
+
+    // Register the asset definition
+    this.assetManifest.set(name, { name, path, type: 'image' })
+  }
+
+  /**
+   * Get the asset manifest (definitions registered via registerAsset).
+   */
+  getAssetManifest(): AssetManifest {
+    return this.assetManifest
+  }
+
+  /**
+   * Load all registered assets from the filesystem.
+   * Must be called before start() for assets to be available.
+   *
+   * @param fileSystem - The filesystem to load assets from
+   * @param scriptDirectory - The directory containing the script (for relative paths)
+   * @throws Error if any asset fails to load
+   */
+  async loadAssets(fileSystem: IFileSystem, scriptDirectory: string): Promise<void> {
+    // Skip if no assets registered
+    if (this.assetManifest.size === 0) {
+      return
+    }
+
+    // Create loader and cache
+    const loader = new AssetLoader(fileSystem, scriptDirectory)
+    this.imageCache = new ImageCache()
+
+    // Load each asset
+    for (const definition of this.assetManifest.values()) {
+      const loadedAsset = await loader.loadAsset(definition)
+
+      // Store dimensions
+      if (loadedAsset.width !== undefined && loadedAsset.height !== undefined) {
+        this.assetDimensions.set(definition.name, {
+          width: loadedAsset.width,
+          height: loadedAsset.height,
+        })
+      }
+
+      // Convert ArrayBuffer to HTMLImageElement and store in cache
+      const image = await this.createImageFromData(loadedAsset.data, loadedAsset.mimeType)
+      this.imageCache.set(definition.name, image)
+    }
+  }
+
+  /**
+   * Draw an image asset at the specified position.
+   * @param name - Name of the asset to draw
+   * @param x - X position
+   * @param y - Y position
+   * @param width - Optional width (for scaling)
+   * @param height - Optional height (for scaling)
+   * @throws Error if asset is unknown
+   */
+  drawImage(name: string, x: number, y: number, width?: number, height?: number): void {
+    // Verify asset is registered
+    if (!this.assetDimensions.has(name)) {
+      throw new Error(`Unknown asset '${name}' - did you call canvas.assets.image()?`)
+    }
+
+    const command: DrawCommand = { type: 'drawImage', name, x, y }
+    if (width !== undefined && height !== undefined) {
+      (command as { type: 'drawImage'; name: string; x: number; y: number; width?: number; height?: number }).width = width;
+      (command as { type: 'drawImage'; name: string; x: number; y: number; width?: number; height?: number }).height = height
+    }
+    this.addDrawCommand(command)
+  }
+
+  /**
+   * Get the width of a loaded asset.
+   * @param name - Name of the asset
+   * @returns Width in pixels
+   * @throws Error if asset is unknown
+   */
+  getAssetWidth(name: string): number {
+    const dims = this.assetDimensions.get(name)
+    if (!dims) {
+      throw new Error(`Unknown asset '${name}' - did you call canvas.assets.image()?`)
+    }
+    return dims.width
+  }
+
+  /**
+   * Get the height of a loaded asset.
+   * @param name - Name of the asset
+   * @returns Height in pixels
+   * @throws Error if asset is unknown
+   */
+  getAssetHeight(name: string): number {
+    const dims = this.assetDimensions.get(name)
+    if (!dims) {
+      throw new Error(`Unknown asset '${name}' - did you call canvas.assets.image()?`)
+    }
+    return dims.height
+  }
+
+  /**
+   * Create an HTMLImageElement from binary data.
+   * @param data - The image binary data
+   * @param mimeType - The MIME type of the image
+   * @returns Promise resolving to the loaded HTMLImageElement
+   */
+  private createImageFromData(data: ArrayBuffer, mimeType?: string): Promise<HTMLImageElement> {
+    return new Promise((resolve, reject) => {
+      const blob = new Blob([data], { type: mimeType ?? 'image/png' })
+      const url = URL.createObjectURL(blob)
+
+      const image = new Image()
+      image.onload = () => {
+        URL.revokeObjectURL(url)
+        resolve(image)
+      }
+      image.onerror = () => {
+        URL.revokeObjectURL(url)
+        reject(new Error('Failed to load image'))
+      }
+      image.src = url
+    })
   }
 
   // --- Internal ---

--- a/packages/lua-runtime/src/setupCanvasAPI.ts
+++ b/packages/lua-runtime/src/setupCanvasAPI.ts
@@ -135,6 +135,23 @@ export function setupCanvasAPI(
     return getController()?.isMouseButtonPressed(button) ?? false
   })
 
+  // --- Asset functions ---
+  engine.global.set('__canvas_assets_image', (name: string, path: string) => {
+    getController()?.registerAsset(name, path)
+  })
+
+  engine.global.set('__canvas_drawImage', (name: string, x: number, y: number, width?: number | null, height?: number | null) => {
+    getController()?.drawImage(name, x, y, width ?? undefined, height ?? undefined)
+  })
+
+  engine.global.set('__canvas_assets_getWidth', (name: string) => {
+    return getController()?.getAssetWidth(name) ?? 0
+  })
+
+  engine.global.set('__canvas_assets_getHeight', (name: string) => {
+    return getController()?.getAssetHeight(name) ?? 0
+  })
+
   // --- Set up Lua-side canvas table ---
   // Canvas is NOT a global - it must be accessed via require('canvas')
   engine.doStringSync(`
@@ -220,6 +237,26 @@ export function setupCanvasAPI(
 
     function _canvas.draw_text(x, y, text)
       __canvas_text(x, y, text)
+    end
+
+    -- Image drawing
+    function _canvas.draw_image(name, x, y, width, height)
+      __canvas_drawImage(name, x, y, width, height)
+    end
+
+    -- Asset management
+    _canvas.assets = {}
+
+    function _canvas.assets.image(name, path)
+      __canvas_assets_image(name, path)
+    end
+
+    function _canvas.assets.get_width(name)
+      return __canvas_assets_getWidth(name)
+    end
+
+    function _canvas.assets.get_height(name)
+      return __canvas_assets_getHeight(name)
     end
 
     -- Timing

--- a/packages/lua-runtime/tests/CanvasController.test.ts
+++ b/packages/lua-runtime/tests/CanvasController.test.ts
@@ -6,6 +6,21 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { CanvasController, type CanvasCallbacks } from '../src/CanvasController'
+import type { IFileSystem } from '@lua-learning/shell-core'
+
+// Store mock ImageCache instance for testing
+let mockImageCacheInstance: {
+  set: ReturnType<typeof vi.fn>
+  get: ReturnType<typeof vi.fn>
+  has: ReturnType<typeof vi.fn>
+  clear: ReturnType<typeof vi.fn>
+} | null = null
+
+// Store mock AssetLoader instance for testing
+let mockAssetLoaderInstance: {
+  loadAsset: ReturnType<typeof vi.fn>
+  resolvePath: ReturnType<typeof vi.fn>
+} | null = null
 
 // Mock the canvas-runtime imports using classes
 vi.mock('@lua-learning/canvas-runtime', () => {
@@ -37,6 +52,30 @@ vi.mock('@lua-learning/canvas-runtime', () => {
       dispose = vi.fn()
       constructor(_callback: () => void) {}
     },
+    ImageCache: class MockImageCache {
+      set = vi.fn()
+      get = vi.fn()
+      has = vi.fn()
+      clear = vi.fn()
+      constructor() {
+        // eslint-disable-next-line @typescript-eslint/no-this-alias
+        mockImageCacheInstance = this
+      }
+    },
+    AssetLoader: class MockAssetLoader {
+      loadAsset = vi.fn().mockResolvedValue({
+        name: 'test',
+        data: new ArrayBuffer(8),
+        width: 64,
+        height: 64,
+        mimeType: 'image/png',
+      })
+      resolvePath = vi.fn((path: string) => path.startsWith('/') ? path : `/test/${path}`)
+      constructor(_fs: IFileSystem, _scriptDir: string) {
+        // eslint-disable-next-line @typescript-eslint/no-this-alias
+        mockAssetLoaderInstance = this
+      }
+    },
   }
 })
 
@@ -44,6 +83,7 @@ describe('CanvasController', () => {
   let controller: CanvasController
   let mockCallbacks: CanvasCallbacks
   let mockCanvas: HTMLCanvasElement
+  let originalImage: typeof Image
 
   beforeEach(() => {
     // Create mock canvas element
@@ -58,10 +98,26 @@ describe('CanvasController', () => {
     }
 
     controller = new CanvasController(mockCallbacks)
+
+    // Mock the Image class to simulate immediate loading
+    originalImage = global.Image
+    global.Image = class MockImage {
+      onload: (() => void) | null = null
+      onerror: (() => void) | null = null
+      src = ''
+
+      constructor() {
+        // Simulate async image load completion
+        setTimeout(() => {
+          if (this.onload) this.onload()
+        }, 0)
+      }
+    } as unknown as typeof Image
   })
 
   afterEach(() => {
     vi.clearAllMocks()
+    global.Image = originalImage
   })
 
   describe('isActive', () => {
@@ -135,55 +191,104 @@ describe('CanvasController', () => {
   })
 
   describe('drawing methods', () => {
-    it('should add clear command', () => {
+    it('should add clear command to frame commands', () => {
       controller.clear()
-      // Internal implementation - just verify no error
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({ type: 'clear' })
     })
 
-    it('should add setColor command', () => {
+    it('should add setColor command with RGB values', () => {
       controller.setColor(255, 0, 0)
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({ type: 'setColor', r: 255, g: 0, b: 0 })
+    })
+
+    it('should add setColor command with alpha value', () => {
       controller.setColor(0, 255, 0, 128)
-      // Internal implementation - just verify no error
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({ type: 'setColor', r: 0, g: 255, b: 0, a: 128 })
     })
 
     it('should add setLineWidth command', () => {
       controller.setLineWidth(2)
-      // Internal implementation - just verify no error
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({ type: 'setLineWidth', width: 2 })
     })
 
     it('should add setSize command', () => {
       controller.setSize(800, 600)
-      // Internal implementation - just verify no error
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({ type: 'setSize', width: 800, height: 600 })
     })
 
     it('should add rect command', () => {
       controller.drawRect(10, 20, 100, 50)
-      // Internal implementation - just verify no error
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({ type: 'rect', x: 10, y: 20, width: 100, height: 50 })
     })
 
     it('should add fillRect command', () => {
       controller.fillRect(10, 20, 100, 50)
-      // Internal implementation - just verify no error
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({ type: 'fillRect', x: 10, y: 20, width: 100, height: 50 })
     })
 
     it('should add circle command', () => {
       controller.drawCircle(50, 50, 25)
-      // Internal implementation - just verify no error
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({ type: 'circle', x: 50, y: 50, radius: 25 })
     })
 
     it('should add fillCircle command', () => {
       controller.fillCircle(50, 50, 25)
-      // Internal implementation - just verify no error
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({ type: 'fillCircle', x: 50, y: 50, radius: 25 })
     })
 
     it('should add line command', () => {
       controller.drawLine(0, 0, 100, 100)
-      // Internal implementation - just verify no error
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({ type: 'line', x1: 0, y1: 0, x2: 100, y2: 100 })
     })
 
     it('should add text command', () => {
       controller.drawText(10, 20, 'Hello')
-      // Internal implementation - just verify no error
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({ type: 'text', x: 10, y: 20, text: 'Hello' })
+    })
+
+    it('should accumulate multiple commands', () => {
+      controller.clear()
+      controller.setColor(255, 0, 0)
+      controller.fillRect(10, 20, 100, 50)
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(3)
+      expect(commands[0].type).toBe('clear')
+      expect(commands[1].type).toBe('setColor')
+      expect(commands[2].type).toBe('fillRect')
     })
   })
 
@@ -250,6 +355,253 @@ describe('CanvasController', () => {
 
     it('should return 0 for getHeight when not running', () => {
       expect(controller.getHeight()).toBe(0)
+    })
+  })
+
+  describe('asset registration', () => {
+    it('should register an asset with valid image extension', () => {
+      controller.registerAsset('player', 'sprites/player.png')
+
+      const manifest = controller.getAssetManifest()
+      expect(manifest.has('player')).toBe(true)
+      expect(manifest.get('player')).toEqual({
+        name: 'player',
+        path: 'sprites/player.png',
+        type: 'image',
+      })
+    })
+
+    it('should accept various valid image extensions', () => {
+      const extensions = ['png', 'jpg', 'jpeg', 'gif', 'webp']
+      extensions.forEach((ext) => {
+        controller.registerAsset(ext, `image.${ext}`)
+      })
+
+      const manifest = controller.getAssetManifest()
+      expect(manifest.size).toBe(5)
+      extensions.forEach((ext) => {
+        expect(manifest.has(ext)).toBe(true)
+      })
+    })
+
+    it('should throw for unsupported file extensions', () => {
+      expect(() => controller.registerAsset('data', 'file.txt')).toThrow(
+        "Cannot load 'file.txt': unsupported format (expected PNG, JPG, GIF, or WebP)"
+      )
+    })
+
+    it('should throw for files without extension', () => {
+      expect(() => controller.registerAsset('noext', 'noextension')).toThrow(
+        "Cannot load 'noextension': unsupported format (expected PNG, JPG, GIF, or WebP)"
+      )
+    })
+
+    it('should throw if called after start', async () => {
+      const startPromise = controller.start()
+
+      // Wait for start to initialize
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(() => controller.registerAsset('player', 'sprites/player.png')).toThrow(
+        'Cannot define assets after canvas.start()'
+      )
+
+      // Clean up
+      controller.stop()
+      await startPromise
+    })
+
+    it('should allow registering multiple assets with same name (overwrite)', () => {
+      controller.registerAsset('player', 'old.png')
+      controller.registerAsset('player', 'new.png')
+
+      const manifest = controller.getAssetManifest()
+      expect(manifest.size).toBe(1)
+      expect(manifest.get('player')?.path).toBe('new.png')
+    })
+
+    it('should return the asset manifest', () => {
+      controller.registerAsset('player', 'sprites/player.png')
+      controller.registerAsset('enemy', '/my-files/enemy.gif')
+
+      const manifest = controller.getAssetManifest()
+
+      expect(manifest.size).toBe(2)
+      expect(manifest.get('player')).toEqual({
+        name: 'player',
+        path: 'sprites/player.png',
+        type: 'image',
+      })
+      expect(manifest.get('enemy')).toEqual({
+        name: 'enemy',
+        path: '/my-files/enemy.gif',
+        type: 'image',
+      })
+    })
+  })
+
+  describe('asset loading', () => {
+    let mockFileSystem: IFileSystem
+
+    beforeEach(() => {
+      // Reset mock instances
+      mockImageCacheInstance = null
+      mockAssetLoaderInstance = null
+
+      // Create mock filesystem
+      mockFileSystem = {
+        exists: vi.fn().mockReturnValue(true),
+        isFile: vi.fn().mockReturnValue(true),
+        isDirectory: vi.fn().mockReturnValue(false),
+        readFile: vi.fn().mockReturnValue(''),
+        writeFile: vi.fn(),
+        deleteFile: vi.fn(),
+        createDirectory: vi.fn(),
+        deleteDirectory: vi.fn(),
+        listDirectory: vi.fn().mockReturnValue([]),
+        readBinaryFile: vi.fn().mockReturnValue(new Uint8Array([1, 2, 3])),
+        writeBinaryFile: vi.fn(),
+        copyFile: vi.fn(),
+        moveFile: vi.fn(),
+        rename: vi.fn(),
+      }
+    })
+
+    it('should load assets using AssetLoader', async () => {
+      controller.registerAsset('player', 'sprites/player.png')
+
+      await controller.loadAssets(mockFileSystem, '/game')
+
+      // AssetLoader should have been created and loadAsset called
+      expect(mockAssetLoaderInstance).not.toBeNull()
+      expect(mockAssetLoaderInstance!.loadAsset).toHaveBeenCalledWith({
+        name: 'player',
+        path: 'sprites/player.png',
+        type: 'image',
+      })
+    })
+
+    it('should not throw if no assets registered', async () => {
+      // No assets registered
+      await expect(controller.loadAssets(mockFileSystem, '/game')).resolves.not.toThrow()
+    })
+
+    it('should store loaded images in ImageCache', async () => {
+      controller.registerAsset('player', 'sprites/player.png')
+
+      await controller.loadAssets(mockFileSystem, '/game')
+
+      // ImageCache should have been created and set called with the asset name
+      expect(mockImageCacheInstance).not.toBeNull()
+      expect(mockImageCacheInstance!.set).toHaveBeenCalledWith('player', expect.any(Object))
+    })
+  })
+
+  describe('drawImage', () => {
+    let mockFileSystem: IFileSystem
+
+    beforeEach(async () => {
+      mockFileSystem = {
+        exists: vi.fn().mockReturnValue(true),
+        isFile: vi.fn().mockReturnValue(true),
+        isDirectory: vi.fn().mockReturnValue(false),
+        readFile: vi.fn().mockReturnValue(''),
+        writeFile: vi.fn(),
+        deleteFile: vi.fn(),
+        createDirectory: vi.fn(),
+        deleteDirectory: vi.fn(),
+        listDirectory: vi.fn().mockReturnValue([]),
+        readBinaryFile: vi.fn().mockReturnValue(new Uint8Array([1, 2, 3])),
+        writeBinaryFile: vi.fn(),
+        copyFile: vi.fn(),
+        moveFile: vi.fn(),
+        rename: vi.fn(),
+      }
+    })
+
+    it('should add drawImage command to frame commands', async () => {
+      controller.registerAsset('player', 'sprites/player.png')
+      await controller.loadAssets(mockFileSystem, '/game')
+
+      controller.drawImage('player', 100, 200)
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({ type: 'drawImage', name: 'player', x: 100, y: 200 })
+    })
+
+    it('should add drawImage command with explicit dimensions', async () => {
+      controller.registerAsset('player', 'sprites/player.png')
+      await controller.loadAssets(mockFileSystem, '/game')
+
+      controller.drawImage('player', 100, 200, 128, 128)
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({
+        type: 'drawImage',
+        name: 'player',
+        x: 100,
+        y: 200,
+        width: 128,
+        height: 128,
+      })
+    })
+
+    it('should throw for unknown asset', async () => {
+      // No assets loaded
+      expect(() => controller.drawImage('unknown', 0, 0)).toThrow(
+        "Unknown asset 'unknown' - did you call canvas.assets.image()?"
+      )
+    })
+  })
+
+  describe('asset dimensions', () => {
+    let mockFileSystem: IFileSystem
+
+    beforeEach(async () => {
+      mockFileSystem = {
+        exists: vi.fn().mockReturnValue(true),
+        isFile: vi.fn().mockReturnValue(true),
+        isDirectory: vi.fn().mockReturnValue(false),
+        readFile: vi.fn().mockReturnValue(''),
+        writeFile: vi.fn(),
+        deleteFile: vi.fn(),
+        createDirectory: vi.fn(),
+        deleteDirectory: vi.fn(),
+        listDirectory: vi.fn().mockReturnValue([]),
+        readBinaryFile: vi.fn().mockReturnValue(new Uint8Array([1, 2, 3])),
+        writeBinaryFile: vi.fn(),
+        copyFile: vi.fn(),
+        moveFile: vi.fn(),
+        rename: vi.fn(),
+      }
+    })
+
+    it('should return asset width after loading', async () => {
+      controller.registerAsset('player', 'sprites/player.png')
+      await controller.loadAssets(mockFileSystem, '/game')
+
+      expect(controller.getAssetWidth('player')).toBe(64)
+    })
+
+    it('should return asset height after loading', async () => {
+      controller.registerAsset('player', 'sprites/player.png')
+      await controller.loadAssets(mockFileSystem, '/game')
+
+      expect(controller.getAssetHeight('player')).toBe(64)
+    })
+
+    it('should throw for unknown asset width', () => {
+      expect(() => controller.getAssetWidth('unknown')).toThrow(
+        "Unknown asset 'unknown' - did you call canvas.assets.image()?"
+      )
+    })
+
+    it('should throw for unknown asset height', () => {
+      expect(() => controller.getAssetHeight('unknown')).toThrow(
+        "Unknown asset 'unknown' - did you call canvas.assets.image()?"
+      )
     })
   })
 })

--- a/packages/lua-runtime/tests/setupCanvasAPI.test.ts
+++ b/packages/lua-runtime/tests/setupCanvasAPI.test.ts
@@ -57,6 +57,13 @@ describe('setupCanvasAPI', () => {
         mouseButtonsDown: [],
         mouseButtonsPressed: [],
       }),
+      // Asset API methods
+      registerAsset: vi.fn(),
+      getAssetManifest: vi.fn().mockReturnValue(new Map()),
+      loadAssets: vi.fn().mockResolvedValue(undefined),
+      drawImage: vi.fn(),
+      getAssetWidth: vi.fn().mockReturnValue(64),
+      getAssetHeight: vi.fn().mockReturnValue(64),
     } as unknown as CanvasController
   }
 
@@ -313,6 +320,127 @@ describe('setupCanvasAPI', () => {
       expect(mockController.isKeyDown).toHaveBeenCalledWith('KeyW')
       expect(mockController.isKeyDown).toHaveBeenCalledWith('ArrowUp')
       expect(mockController.isKeyDown).toHaveBeenCalledWith('Space')
+    })
+  })
+
+  describe('asset API', () => {
+    it('should expose canvas.assets table via require', async () => {
+      const mockController = createMockController()
+      setupCanvasAPI(engine, () => mockController)
+
+      const result = await engine.doString(`
+        local canvas = require('canvas')
+        return type(canvas.assets)
+      `)
+      expect(result).toBe('table')
+    })
+
+    it('should expose canvas.assets.image function', async () => {
+      const mockController = createMockController()
+      setupCanvasAPI(engine, () => mockController)
+
+      const result = await engine.doString(`
+        local canvas = require('canvas')
+        return type(canvas.assets.image)
+      `)
+      expect(result).toBe('function')
+    })
+
+    it('should call registerAsset when canvas.assets.image() is called', async () => {
+      const mockController = createMockController()
+      setupCanvasAPI(engine, () => mockController)
+
+      await engine.doString(`
+        local canvas = require('canvas')
+        canvas.assets.image('player', 'sprites/player.png')
+      `)
+
+      expect(mockController.registerAsset).toHaveBeenCalledWith('player', 'sprites/player.png')
+    })
+
+    it('should expose canvas.draw_image function', async () => {
+      const mockController = createMockController()
+      setupCanvasAPI(engine, () => mockController)
+
+      const result = await engine.doString(`
+        local canvas = require('canvas')
+        return type(canvas.draw_image)
+      `)
+      expect(result).toBe('function')
+    })
+
+    it('should call drawImage when canvas.draw_image() is called', async () => {
+      const mockController = createMockController()
+      setupCanvasAPI(engine, () => mockController)
+
+      await engine.doString(`
+        local canvas = require('canvas')
+        canvas.draw_image('player', 100, 200)
+      `)
+
+      expect(mockController.drawImage).toHaveBeenCalledWith('player', 100, 200, undefined, undefined)
+    })
+
+    it('should call drawImage with scaling when width and height provided', async () => {
+      const mockController = createMockController()
+      setupCanvasAPI(engine, () => mockController)
+
+      await engine.doString(`
+        local canvas = require('canvas')
+        canvas.draw_image('player', 100, 200, 64, 64)
+      `)
+
+      expect(mockController.drawImage).toHaveBeenCalledWith('player', 100, 200, 64, 64)
+    })
+
+    it('should expose canvas.assets.get_width function', async () => {
+      const mockController = createMockController()
+      setupCanvasAPI(engine, () => mockController)
+
+      const result = await engine.doString(`
+        local canvas = require('canvas')
+        return type(canvas.assets.get_width)
+      `)
+      expect(result).toBe('function')
+    })
+
+    it('should call getAssetWidth when canvas.assets.get_width() is called', async () => {
+      const mockController = createMockController()
+      ;(mockController.getAssetWidth as ReturnType<typeof vi.fn>).mockReturnValue(128)
+      setupCanvasAPI(engine, () => mockController)
+
+      const result = await engine.doString(`
+        local canvas = require('canvas')
+        return canvas.assets.get_width('player')
+      `)
+
+      expect(mockController.getAssetWidth).toHaveBeenCalledWith('player')
+      expect(result).toBe(128)
+    })
+
+    it('should expose canvas.assets.get_height function', async () => {
+      const mockController = createMockController()
+      setupCanvasAPI(engine, () => mockController)
+
+      const result = await engine.doString(`
+        local canvas = require('canvas')
+        return type(canvas.assets.get_height)
+      `)
+      expect(result).toBe('function')
+    })
+
+    it('should call getAssetHeight when canvas.assets.get_height() is called', async () => {
+      const mockController = createMockController()
+      ;(mockController.getAssetHeight as ReturnType<typeof vi.fn>).mockReturnValue(96)
+      setupCanvasAPI(engine, () => mockController)
+
+      const result = await engine.doString(`
+        local canvas = require('canvas')
+        return canvas.assets.get_height('player')
+      `)
+
+      expect(mockController.getAssetHeight).toHaveBeenCalledWith('player')
+      expect(result).toBe(96)
     })
   })
 })


### PR DESCRIPTION
## Summary
- Implement image asset support for the shell-based canvas in `lua-runtime` package
- Add `CanvasController` methods: `registerAsset`, `loadAssets`, `drawImage`, `getAssetWidth`, `getAssetHeight`
- Add Lua bindings: `canvas.assets.image()`, `canvas.draw_image()`, `canvas.assets.get_width()`, `canvas.assets.get_height()`
- Export `ImageCache`, `AssetLoader`, and related types from `canvas-runtime`

## Test plan
- [x] 47 unit tests for CanvasController asset methods
- [x] 28 unit tests for setupCanvasAPI Lua bindings
- [x] All 1909 project tests passing
- [x] Build succeeds
- [x] Lint passes

## Part of Epic
Closes #309

Part of #305 - Canvas Image Support Epic

🤖 Generated with [Claude Code](https://claude.com/claude-code)