### PR TITLE
feat(#304): Add audio file playback support to BinaryFileViewer

### DIFF
--- a/lua-learning-website/src/components/BinaryFileViewer/BinaryFileViewer.module.css
+++ b/lua-learning-website/src/components/BinaryFileViewer/BinaryFileViewer.module.css
@@ -39,6 +39,23 @@
   border-radius: 4px;
 }
 
+/* Audio display */
+.audioContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  max-width: 400px;
+  padding: 1rem;
+  background-color: var(--theme-bg-secondary);
+  border-radius: 8px;
+  border: 1px solid var(--theme-border-secondary);
+}
+
+.audioPlayer {
+  width: 100%;
+}
+
 /* Non-image binary file display */
 .binaryInfo {
   display: flex;


### PR DESCRIPTION
## Summary
Add audio file playback support to BinaryFileViewer component

- Add detection for audio file extensions (.mp3, .wav, .ogg, .m4a, .flac, .aac)
- Extend MIME type mapping for audio formats
- Render HTML5 audio player with native controls for audio files
- Display file info (name, size) alongside audio player
- Add CSS styles for audio container
- Clean up blob URLs on unmount (reuses existing pattern from images)

## Test plan
- Verify audio player renders for each supported extension (.mp3, .wav, .ogg, .m4a, .flac, .aac)
- Verify audio element has controls attribute
- Verify blob URL is created with correct MIME type for each audio format
- Verify file info (name and size) displays correctly
- Verify uppercase extensions are handled (case-insensitive detection)
- Verify audio files don't render as images
- Verify existing image and binary file rendering is unchanged

## Manual Testing
**UI Changes:**
  - [ ] Verify `BinaryFileViewer` renders correctly

**Visual Changes:**
  - [ ] Check styling changes visually across affected components

Fixes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)