### PR TITLE
feat(#357): All tabs disappear when canvas closes

### DIFF
--- a/lua-learning-website/src/components/IDELayout/IDELayout.tsx
+++ b/lua-learning-website/src/components/IDELayout/IDELayout.tsx
@@ -401,7 +401,7 @@ function IDELayoutInner({
                       )}
                       {/* Editor panel - hidden when canvas, markdown, or binary tab is active */}
                       {/* Note: also show if hasCanvasTabs is false to handle race condition during canvas tab close */}
-                      {activeTabType !== 'canvas' && activeTabType !== 'markdown' && activeTabType !== 'binary' && (
+                      {(activeTabType !== 'canvas' || !hasCanvasTabs) && activeTabType !== 'markdown' && activeTabType !== 'binary' && (
                         <EditorPanel
                           code={code}
                           onChange={setCode}


### PR DESCRIPTION
## Summary
Fix race condition where all tabs disappear when canvas closes.

Root cause: During canvas tab close, `tabs` state updates before `activeTab`, creating a window where `hasCanvasTabs` is false but `activeTabType` is still 'canvas' (inferred from path). This caused neither CanvasTabContent nor EditorPanel to render.

Fix: Updated the EditorPanel rendering condition in IDELayout.tsx to also show when `activeTabType === 'canvas'` but `hasCanvasTabs === false` (the race condition state). This matches the existing comment at line 403.

## Test plan
- Open multiple file tabs in the IDE
- Run code that opens a canvas tab
- Close the canvas tab (via exit or close button)
- Verify file tabs remain visible
- Verify one of the file tabs becomes active

## Manual Testing
**UI Changes:**
  - [ ] Verify `IDELayout` renders correctly

Fixes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)