### PR TITLE
feat(#362): When a canvas tab opens, the keyboard input should focus to the canvas

### DIFF
--- a/lua-learning-website/e2e/canvas-keyboard-focus.spec.ts
+++ b/lua-learning-website/e2e/canvas-keyboard-focus.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect } from '@playwright/test'
+import { TIMEOUTS } from './constants'
+import { createTerminalHelper } from './helpers/terminal'
+
+/**
+ * E2E tests for canvas keyboard focus behavior.
+ *
+ * Tests that canvas tabs automatically receive keyboard focus when:
+ * - A new canvas tab opens (via canvas.start())
+ *
+ * This ensures keyboard-controlled games work immediately without
+ * requiring the user to click on the canvas first.
+ */
+test.describe('Canvas Keyboard Focus', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/editor')
+    await expect(page.locator('[data-testid="ide-layout"]')).toBeVisible()
+    // Wait for the shell terminal to initialize
+    await expect(page.locator('[data-testid="shell-terminal-container"]')).toBeVisible({
+      timeout: TIMEOUTS.ELEMENT_VISIBLE,
+    })
+  })
+
+  test.describe('Auto-focus on Canvas Tab Open', () => {
+    test('canvas element is focusable with tabIndex', async ({ page }) => {
+      const terminal = createTerminalHelper(page)
+      await terminal.focus()
+
+      // Start Lua REPL
+      await terminal.execute('lua')
+      await page.waitForTimeout(TIMEOUTS.ANIMATION)
+
+      // Wait for REPL to be ready
+      const stopButton = page.getByRole('button', { name: /stop process/i })
+      await expect(stopButton).toBeVisible({ timeout: TIMEOUTS.ELEMENT_VISIBLE })
+
+      // Require canvas module
+      await terminal.type('canvas = require("canvas")')
+      await terminal.press('Enter')
+      await page.waitForTimeout(TIMEOUTS.TRANSITION)
+
+      // Set up canvas with timer-based stop
+      await terminal.type('canvas.tick(function() if canvas.get_time() > 0.5 then canvas.stop() end end)')
+      await terminal.press('Enter')
+      await page.waitForTimeout(TIMEOUTS.TRANSITION)
+
+      // Start canvas
+      await terminal.type('canvas.start()')
+      await terminal.press('Enter')
+
+      // Canvas tab should appear
+      const canvasTab = page.locator('[class*="canvasTab"]').first()
+      await expect(canvasTab).toBeVisible({ timeout: TIMEOUTS.ELEMENT_VISIBLE })
+
+      // Verify canvas element exists and has tabIndex for focusability
+      const canvasElement = page.locator('canvas[tabindex="0"]')
+      await expect(canvasElement).toBeVisible({ timeout: TIMEOUTS.ELEMENT_VISIBLE })
+
+      // Wait for canvas to stop
+      await expect(canvasTab).not.toBeVisible({ timeout: TIMEOUTS.ASYNC_OPERATION })
+    })
+
+    test('canvas receives keyboard events when tab opens', async ({ page }) => {
+      const terminal = createTerminalHelper(page)
+      await terminal.focus()
+
+      // Start Lua REPL
+      await terminal.execute('lua')
+      await page.waitForTimeout(TIMEOUTS.ANIMATION)
+
+      // Wait for REPL to be ready
+      const stopButton = page.getByRole('button', { name: /stop process/i })
+      await expect(stopButton).toBeVisible({ timeout: TIMEOUTS.ELEMENT_VISIBLE })
+
+      // Require canvas module
+      await terminal.type('canvas = require("canvas")')
+      await terminal.press('Enter')
+      await page.waitForTimeout(TIMEOUTS.TRANSITION)
+
+      // Set up key tracking variable
+      await terminal.type('key_a_pressed = false')
+      await terminal.press('Enter')
+      await page.waitForTimeout(TIMEOUTS.TRANSITION)
+
+      // Set up canvas that checks for 'a' key press and stops
+      await terminal.type('canvas.tick(function() if canvas.is_key_pressed("a") then key_a_pressed = true canvas.stop() end if canvas.get_time() > 3 then canvas.stop() end end)')
+      await terminal.press('Enter')
+      await page.waitForTimeout(TIMEOUTS.TRANSITION)
+
+      // Start canvas
+      await terminal.type('canvas.start()')
+      await terminal.press('Enter')
+
+      // Canvas tab should appear
+      const canvasTab = page.locator('[class*="canvasTab"]').first()
+      await expect(canvasTab).toBeVisible({ timeout: TIMEOUTS.ELEMENT_VISIBLE })
+
+      // Wait for canvas to render and receive focus
+      await page.waitForTimeout(TIMEOUTS.ANIMATION)
+
+      // Press 'a' key - canvas should receive it if focused
+      await page.keyboard.press('a')
+
+      // Wait for canvas to process the key and stop
+      await expect(canvasTab).not.toBeVisible({ timeout: TIMEOUTS.ASYNC_OPERATION })
+
+      // Verify the key was detected by checking the variable
+      await terminal.type('print(key_a_pressed)')
+      await terminal.press('Enter')
+      await page.waitForTimeout(TIMEOUTS.TRANSITION)
+
+      // If canvas received keyboard focus, key_a_pressed should be true
+      await terminal.expectToContain('true', { timeout: TIMEOUTS.ASYNC_OPERATION })
+    })
+  })
+})

--- a/lua-learning-website/src/components/CanvasGamePanel/CanvasGamePanel.test.tsx
+++ b/lua-learning-website/src/components/CanvasGamePanel/CanvasGamePanel.test.tsx
@@ -319,6 +319,49 @@ describe('CanvasGamePanel', () => {
     })
   })
 
+  describe('auto-focus behavior', () => {
+    it('focuses canvas when isActive is true on mount', () => {
+      render(<CanvasGamePanel code="print('hello')" isActive />)
+      const canvas = document.querySelector('canvas')
+      expect(canvas).toHaveFocus()
+    })
+
+    it('does not focus canvas when isActive is false on mount', () => {
+      render(<CanvasGamePanel code="print('hello')" isActive={false} />)
+      const canvas = document.querySelector('canvas')
+      expect(canvas).not.toHaveFocus()
+    })
+
+    it('focuses canvas when isActive changes from false to true', () => {
+      const { rerender } = render(<CanvasGamePanel code="print('hello')" isActive={false} />)
+      const canvas = document.querySelector('canvas')
+      expect(canvas).not.toHaveFocus()
+
+      rerender(<CanvasGamePanel code="print('hello')" isActive />)
+      expect(canvas).toHaveFocus()
+    })
+
+    it('does not focus canvas when isActive changes from true to false', () => {
+      const { rerender } = render(<CanvasGamePanel code="print('hello')" isActive />)
+      const canvas = document.querySelector('canvas') as HTMLCanvasElement
+      expect(canvas).toHaveFocus()
+
+      // Blur the canvas first
+      canvas.blur()
+      expect(canvas).not.toHaveFocus()
+
+      rerender(<CanvasGamePanel code="print('hello')" isActive={false} />)
+      expect(canvas).not.toHaveFocus()
+    })
+
+    it('defaults isActive to undefined (no auto-focus) for backward compatibility', () => {
+      render(<CanvasGamePanel code="print('hello')" />)
+      const canvas = document.querySelector('canvas')
+      // Without isActive prop, canvas should not auto-focus
+      expect(canvas).not.toHaveFocus()
+    })
+  })
+
   describe('scaling mode', () => {
     it('defaults to fit scaling mode', () => {
       const { container } = render(<CanvasGamePanel code="print('hello')" />)

--- a/lua-learning-website/src/components/CanvasGamePanel/CanvasGamePanel.tsx
+++ b/lua-learning-website/src/components/CanvasGamePanel/CanvasGamePanel.tsx
@@ -26,6 +26,8 @@ export interface CanvasGamePanelProps {
   scalingMode?: CanvasScalingMode
   /** Callback when scaling mode is changed (enables the scaling selector UI) */
   onScalingModeChange?: (mode: CanvasScalingMode) => void
+  /** Whether the canvas tab is active and should receive focus */
+  isActive?: boolean
 }
 
 export function CanvasGamePanel({
@@ -38,6 +40,7 @@ export function CanvasGamePanel({
   onCanvasReady,
   scalingMode = 'fit',
   onScalingModeChange,
+  isActive,
 }: CanvasGamePanelProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
 
@@ -69,6 +72,13 @@ export function CanvasGamePanel({
       onCanvasReady(canvasRef.current)
     }
   }, [onCanvasReady])
+
+  // Auto-focus canvas when isActive becomes true
+  useEffect(() => {
+    if (isActive && canvasRef.current) {
+      canvasRef.current.focus()
+    }
+  }, [isActive])
 
   const handlePauseResume = useCallback(() => {
     if (isPaused) {

--- a/lua-learning-website/src/components/IDELayout/CanvasTabContent.test.tsx
+++ b/lua-learning-website/src/components/IDELayout/CanvasTabContent.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * Tests for CanvasTabContent component.
+ * Renders the canvas game panel with a simple tab bar for switching between tabs.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { CanvasTabContent } from './CanvasTabContent'
+import type { TabInfo } from '../TabBar'
+
+// Mock the CanvasGamePanel component
+vi.mock('../CanvasGamePanel', () => ({
+  CanvasGamePanel: vi.fn(({ isActive }: { isActive?: boolean }) => (
+    <div data-testid="canvas-game-panel" data-is-active={isActive}>
+      Mock Canvas
+    </div>
+  )),
+}))
+
+// Mock the useCanvasScaling hook
+vi.mock('../../hooks/useCanvasScaling', () => ({
+  useCanvasScaling: vi.fn(() => ({
+    scalingMode: 'fit',
+    setScalingMode: vi.fn(),
+  })),
+}))
+
+const createMockTabs = (): TabInfo[] => [
+  { path: 'canvas://canvas-1', name: 'Canvas 1', isDirty: false, type: 'canvas', isPreview: false, isPinned: false },
+  { path: 'canvas://canvas-2', name: 'Canvas 2', isDirty: false, type: 'canvas', isPreview: false, isPinned: false },
+]
+
+describe('CanvasTabContent', () => {
+  describe('rendering', () => {
+    it('renders canvas tabs', () => {
+      const tabs = createMockTabs()
+      render(
+        <CanvasTabContent
+          tabs={tabs}
+          activeTab="canvas://canvas-1"
+          canvasCode="print('hello')"
+          onSelectTab={vi.fn()}
+          onCloseTab={vi.fn()}
+          onExit={vi.fn()}
+        />
+      )
+
+      expect(screen.getByText('Canvas 1')).toBeInTheDocument()
+      expect(screen.getByText('Canvas 2')).toBeInTheDocument()
+    })
+
+    it('renders CanvasGamePanel', () => {
+      const tabs = createMockTabs()
+      render(
+        <CanvasTabContent
+          tabs={tabs}
+          activeTab="canvas://canvas-1"
+          canvasCode="print('hello')"
+          onSelectTab={vi.fn()}
+          onCloseTab={vi.fn()}
+          onExit={vi.fn()}
+        />
+      )
+
+      expect(screen.getByTestId('canvas-game-panel')).toBeInTheDocument()
+    })
+  })
+
+  describe('tab interactions', () => {
+    it('calls onSelectTab when a tab is clicked', () => {
+      const tabs = createMockTabs()
+      const onSelectTab = vi.fn()
+      render(
+        <CanvasTabContent
+          tabs={tabs}
+          activeTab="canvas://canvas-1"
+          canvasCode="print('hello')"
+          onSelectTab={onSelectTab}
+          onCloseTab={vi.fn()}
+          onExit={vi.fn()}
+        />
+      )
+
+      fireEvent.click(screen.getByText('Canvas 2'))
+      expect(onSelectTab).toHaveBeenCalledWith('canvas://canvas-2')
+    })
+
+    it('calls onCloseTab when close button is clicked', () => {
+      const tabs = createMockTabs()
+      const onCloseTab = vi.fn()
+      render(
+        <CanvasTabContent
+          tabs={tabs}
+          activeTab="canvas://canvas-1"
+          canvasCode="print('hello')"
+          onSelectTab={vi.fn()}
+          onCloseTab={onCloseTab}
+          onExit={vi.fn()}
+        />
+      )
+
+      // Find the close button for Canvas 1
+      const closeButtons = screen.getAllByText('×')
+      fireEvent.click(closeButtons[0])
+      expect(onCloseTab).toHaveBeenCalledWith('canvas://canvas-1')
+    })
+  })
+
+  describe('isActive prop passthrough', () => {
+    it('passes isActive=true to CanvasGamePanel when activeTab is a canvas tab', () => {
+      const tabs = createMockTabs()
+      render(
+        <CanvasTabContent
+          tabs={tabs}
+          activeTab="canvas://canvas-1"
+          canvasCode="print('hello')"
+          onSelectTab={vi.fn()}
+          onCloseTab={vi.fn()}
+          onExit={vi.fn()}
+          isActive
+        />
+      )
+
+      const panel = screen.getByTestId('canvas-game-panel')
+      expect(panel).toHaveAttribute('data-is-active', 'true')
+    })
+
+    it('passes isActive=false to CanvasGamePanel when isActive prop is false', () => {
+      const tabs = createMockTabs()
+      render(
+        <CanvasTabContent
+          tabs={tabs}
+          activeTab="canvas://canvas-1"
+          canvasCode="print('hello')"
+          onSelectTab={vi.fn()}
+          onCloseTab={vi.fn()}
+          onExit={vi.fn()}
+          isActive={false}
+        />
+      )
+
+      const panel = screen.getByTestId('canvas-game-panel')
+      expect(panel).toHaveAttribute('data-is-active', 'false')
+    })
+
+    it('defaults isActive to undefined when not provided', () => {
+      const tabs = createMockTabs()
+      render(
+        <CanvasTabContent
+          tabs={tabs}
+          activeTab="canvas://canvas-1"
+          canvasCode="print('hello')"
+          onSelectTab={vi.fn()}
+          onCloseTab={vi.fn()}
+          onExit={vi.fn()}
+        />
+      )
+
+      const panel = screen.getByTestId('canvas-game-panel')
+      // When isActive is undefined, data-is-active should not have a value set
+      expect(panel.getAttribute('data-is-active')).toBe(null)
+    })
+  })
+})

--- a/lua-learning-website/src/components/IDELayout/CanvasTabContent.tsx
+++ b/lua-learning-website/src/components/IDELayout/CanvasTabContent.tsx
@@ -22,6 +22,8 @@ export interface CanvasTabContentProps {
   onExit: (exitCode: number) => void
   /** Callback when canvas element is ready (for shell integration) */
   onCanvasReady?: (canvasId: string, canvas: HTMLCanvasElement) => void
+  /** Whether the canvas tab is active and should receive focus */
+  isActive?: boolean
 }
 
 export function CanvasTabContent({
@@ -32,6 +34,7 @@ export function CanvasTabContent({
   onCloseTab,
   onExit,
   onCanvasReady,
+  isActive,
 }: CanvasTabContentProps) {
   const { scalingMode, setScalingMode } = useCanvasScaling()
 
@@ -66,6 +69,7 @@ export function CanvasTabContent({
         onCanvasReady={activeTab && onCanvasReady ? (canvas) => onCanvasReady(activeTab, canvas) : undefined}
         scalingMode={scalingMode}
         onScalingModeChange={setScalingMode}
+        isActive={isActive}
       />
     </div>
   )

--- a/lua-learning-website/src/components/IDELayout/IDELayout.tsx
+++ b/lua-learning-website/src/components/IDELayout/IDELayout.tsx
@@ -393,6 +393,7 @@ function IDELayoutInner({
                             onCloseTab={handleCloseTab}
                             onExit={handleCanvasExit}
                             onCanvasReady={handleCanvasReady}
+                            isActive={activeTabType === 'canvas'}
                           />
                         </div>
                       )}


### PR DESCRIPTION
## Summary
Auto-focus canvas element when canvas tab opens or becomes active.

- Added `isActive` prop to `CanvasGamePanel` that triggers canvas focus when true
- Added `isActive` prop to `CanvasTabContent` to pass through to `CanvasGamePanel`
- Updated `IDELayout` to pass `isActive={activeTabType === 'canvas'}` to `CanvasTabContent`
- This ensures keyboard-controlled games work immediately without requiring the user to click on the canvas first

## Test plan
- [ ] Open the editor at /editor
- [ ] Open a Lua REPL with `lua` command
- [ ] Run canvas with keyboard controls: `canvas = require("canvas"); canvas.tick(function() if canvas.is_key_pressed("space") then print("Space pressed!") canvas.stop() end if canvas.get_time() > 5 then canvas.stop() end end); canvas.start()`
- [ ] Verify canvas tab opens and keyboard input works immediately (press space without clicking)
- [ ] The canvas should detect the key press and stop, printing "Space pressed!"

## Manual Testing
**UI Changes:**
  - [ ] Verify `CanvasGamePanel` renders correctly
  - [ ] Verify `CanvasTabContent` renders correctly
  - [ ] Verify `IDELayout` renders correctly

Fixes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)