### PR TITLE
feat(split-editor): Core Split Infrastructure - useSplitLayout hook and types

### DIFF
--- a/EPIC-386.md
+++ b/EPIC-386.md
@@ -1,0 +1,101 @@
+# Epic #386: Add tab / window splitting allowing multiple tabs to be shown and open at a time
+
+**Status:** In Progress (1/6 in progress)
+**Branch:** epic-386
+**Created:** 2025-12-20
+**Last Updated:** 2025-12-20
+
+## Overview
+
+Currently, users can only view one tab at a time. When working on projects that reference multiple files or comparing code, users must switch back and forth between tabs, losing context.
+
+Add the ability to split the editor area horizontally or vertically, allowing multiple tabs to be displayed simultaneously (similar to VS Code or JetBrains IDEs).
+
+### Acceptance Criteria
+
+- [ ] Users can split the current view horizontally (side-by-side)
+- [ ] Users can split the current view vertically (top-bottom)
+- [ ] Each split pane can have its own independent tab
+- [ ] Split panes can be resized by dragging the divider
+- [ ] Users can close a split pane (returning to single view)
+- [ ] Focus state is clearly indicated for the active pane
+- [ ] Layout state persists across page refreshes
+
+## Architecture Decisions
+
+<!-- Document key decisions as work progresses -->
+
+1. **Split Layout State Management**: Using a custom `useSplitLayout` hook with React's `useState` for state management. The hook provides operations for splitting, closing, and moving tabs between groups.
+
+2. **Group ID Generation**: Using timestamp + random string (`group-{timestamp}-{random}`) for unique group IDs rather than UUID to avoid additional dependencies.
+
+3. **Tab Migration on Close**: When a group is closed, tabs are migrated to the previous group (or next if closing the first group). This ensures no tabs are lost.
+
+## Sub-Issues
+
+| # | Title | Status | Branch | Notes |
+|---|-------|--------|--------|-------|
+| #396 | Core Split Infrastructure - useSplitLayout hook and types | :arrows_counterclockwise: In Progress | 396-core-split-infrastructure | Started 2025-12-20 |
+| #397 | EditorGroup Component - Standalone editor group with TabBar | :hourglass_flowing_sand: Pending | - | Depends on #396 |
+| #398 | SplitEditorLayout Integration - Integrate with IDELayout | :hourglass_flowing_sand: Pending | - | Depends on #396, #397 |
+| #399 | Split Actions & UI - Context menu, close split, focus states | :hourglass_flowing_sand: Pending | - | Depends on #396, #397, #398 |
+| #400 | Keyboard Shortcuts & Persistence - Split navigation and localStorage | :hourglass_flowing_sand: Pending | - | Depends on #396, #398, #399 |
+| #401 | Testing Suite - Unit tests and E2E tests for split functionality | :hourglass_flowing_sand: Pending | - | Depends on all above |
+
+**Status Legend:**
+- :hourglass_flowing_sand: Pending - Not yet started
+- :arrows_counterclockwise: In Progress - Currently being worked on
+- :white_check_mark: Complete - Merged to epic branch
+- :x: Blocked - Has unresolved blockers
+
+## Dependency Graph
+
+```
+#396 Core Split Infrastructure (no dependencies)
+  |
+  v
+#397 EditorGroup Component
+  |
+  v
+#398 SplitEditorLayout Integration
+  |
+  v
+#399 Split Actions & UI
+  |
+  v
+#400 Keyboard Shortcuts & Persistence
+  |
+  v
+#401 Testing Suite
+```
+
+## Progress Log
+
+<!-- Updated after each sub-issue completion -->
+
+### 2025-12-20
+- Epic started
+- Created epic branch and worktree
+- Generated EPIC-386.md tracking file
+- Started work on #396: Core Split Infrastructure
+- Created `useSplitLayout` hook with types and 27 unit tests (97%+ coverage)
+
+## Key Files
+
+<!-- Populated as files are created/modified -->
+
+- `src/components/SplitEditorLayout/types.ts` - Core type definitions (SplitLayout, EditorGroupInfo, SplitDirection)
+- `src/components/SplitEditorLayout/useSplitLayout.ts` - Split layout state management hook
+- `src/components/SplitEditorLayout/__tests__/useSplitLayout.test.ts` - Hook unit tests (27 tests)
+
+## Open Questions
+
+<!-- Questions that arise during implementation -->
+
+- How should users initiate a split? (menu option, keyboard shortcut, drag tab?)
+- Should there be a limit to the number of splits?
+- How should splits be closed? (button, keyboard shortcut, context menu?)
+
+## Blockers
+
+(none)

--- a/lua-learning-website/src/components/SplitEditorLayout/__tests__/useSplitLayout.test.ts
+++ b/lua-learning-website/src/components/SplitEditorLayout/__tests__/useSplitLayout.test.ts
@@ -1,0 +1,484 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useSplitLayout } from '../useSplitLayout'
+import type { SplitLayout, EditorGroupInfo } from '../types'
+import type { TabInfo } from '../../TabBar/types'
+
+// Helper to create a mock tab
+function createMockTab(path: string): TabInfo {
+  return {
+    path,
+    name: path.split('/').pop() ?? path,
+    isDirty: false,
+    type: 'file',
+    isPreview: false,
+    isPinned: false,
+  }
+}
+
+describe('useSplitLayout', () => {
+  describe('initial state', () => {
+    it('should initialize with a single group', () => {
+      const { result } = renderHook(() => useSplitLayout())
+
+      expect(result.current.layout.groups).toHaveLength(1)
+    })
+
+    it('should initialize with horizontal direction by default', () => {
+      const { result } = renderHook(() => useSplitLayout())
+
+      expect(result.current.layout.direction).toBe('horizontal')
+    })
+
+    it('should have the first group as active by default', () => {
+      const { result } = renderHook(() => useSplitLayout())
+
+      const firstGroup = result.current.layout.groups[0]
+      expect(result.current.layout.activeGroupId).toBe(firstGroup.id)
+    })
+
+    it('should initialize groups with empty tabs', () => {
+      const { result } = renderHook(() => useSplitLayout())
+
+      const firstGroup = result.current.layout.groups[0]
+      expect(firstGroup.tabs).toEqual([])
+      expect(firstGroup.activeTab).toBeNull()
+    })
+
+    it('should accept initial layout via options', () => {
+      const initialGroup: EditorGroupInfo = {
+        id: 'custom-group',
+        tabs: [],
+        activeTab: null,
+      }
+      const initialLayout: SplitLayout = {
+        groups: [initialGroup],
+        activeGroupId: 'custom-group',
+        direction: 'vertical',
+      }
+
+      const { result } = renderHook(() =>
+        useSplitLayout({ initialLayout })
+      )
+
+      expect(result.current.layout).toEqual(initialLayout)
+    })
+  })
+
+  describe('getActiveGroup', () => {
+    it('should return the active group', () => {
+      const { result } = renderHook(() => useSplitLayout())
+
+      const activeGroup = result.current.getActiveGroup()
+      expect(activeGroup).toBeDefined()
+      expect(activeGroup?.id).toBe(result.current.layout.activeGroupId)
+    })
+
+    it('should return undefined if activeGroupId does not match any group', () => {
+      const initialLayout: SplitLayout = {
+        groups: [{ id: 'group-1', tabs: [], activeTab: null }],
+        activeGroupId: 'non-existent',
+        direction: 'horizontal',
+      }
+
+      const { result } = renderHook(() =>
+        useSplitLayout({ initialLayout })
+      )
+
+      expect(result.current.getActiveGroup()).toBeUndefined()
+    })
+  })
+
+  describe('setActiveGroup', () => {
+    it('should change the active group', () => {
+      const initialLayout: SplitLayout = {
+        groups: [
+          { id: 'group-1', tabs: [], activeTab: null },
+          { id: 'group-2', tabs: [], activeTab: null },
+        ],
+        activeGroupId: 'group-1',
+        direction: 'horizontal',
+      }
+
+      const { result } = renderHook(() =>
+        useSplitLayout({ initialLayout })
+      )
+
+      act(() => {
+        result.current.setActiveGroup('group-2')
+      })
+
+      expect(result.current.layout.activeGroupId).toBe('group-2')
+    })
+
+    it('should not change state if group does not exist', () => {
+      const { result } = renderHook(() => useSplitLayout())
+
+      const originalActiveGroupId = result.current.layout.activeGroupId
+
+      act(() => {
+        result.current.setActiveGroup('non-existent')
+      })
+
+      expect(result.current.layout.activeGroupId).toBe(originalActiveGroupId)
+    })
+  })
+
+  describe('splitGroup', () => {
+    it('should create a new group when splitting', () => {
+      const { result } = renderHook(() => useSplitLayout())
+
+      const originalGroupId = result.current.layout.groups[0].id
+
+      act(() => {
+        result.current.splitGroup(originalGroupId, 'horizontal')
+      })
+
+      expect(result.current.layout.groups).toHaveLength(2)
+    })
+
+    it('should set the layout direction when splitting', () => {
+      const { result } = renderHook(() => useSplitLayout())
+
+      const groupId = result.current.layout.groups[0].id
+
+      act(() => {
+        result.current.splitGroup(groupId, 'vertical')
+      })
+
+      expect(result.current.layout.direction).toBe('vertical')
+    })
+
+    it('should set the new group as active after splitting', () => {
+      const { result } = renderHook(() => useSplitLayout())
+
+      const originalGroupId = result.current.layout.groups[0].id
+
+      act(() => {
+        result.current.splitGroup(originalGroupId, 'horizontal')
+      })
+
+      const newGroup = result.current.layout.groups.find(
+        (g) => g.id !== originalGroupId
+      )
+      expect(result.current.layout.activeGroupId).toBe(newGroup?.id)
+    })
+
+    it('should insert new group after the split group', () => {
+      const initialLayout: SplitLayout = {
+        groups: [
+          { id: 'group-1', tabs: [], activeTab: null },
+          { id: 'group-2', tabs: [], activeTab: null },
+        ],
+        activeGroupId: 'group-1',
+        direction: 'horizontal',
+      }
+
+      const { result } = renderHook(() =>
+        useSplitLayout({ initialLayout })
+      )
+
+      act(() => {
+        result.current.splitGroup('group-1', 'horizontal')
+      })
+
+      // New group should be at index 1, group-2 should be at index 2
+      expect(result.current.layout.groups).toHaveLength(3)
+      expect(result.current.layout.groups[0].id).toBe('group-1')
+      expect(result.current.layout.groups[2].id).toBe('group-2')
+    })
+
+    it('should not split if group does not exist', () => {
+      const { result } = renderHook(() => useSplitLayout())
+
+      act(() => {
+        result.current.splitGroup('non-existent', 'horizontal')
+      })
+
+      expect(result.current.layout.groups).toHaveLength(1)
+    })
+
+    it('should create new group with empty tabs', () => {
+      const { result } = renderHook(() => useSplitLayout())
+
+      const groupId = result.current.layout.groups[0].id
+
+      act(() => {
+        result.current.splitGroup(groupId, 'horizontal')
+      })
+
+      const newGroup = result.current.layout.groups.find(
+        (g) => g.id !== groupId
+      )
+      expect(newGroup?.tabs).toEqual([])
+      expect(newGroup?.activeTab).toBeNull()
+    })
+  })
+
+  describe('closeGroup', () => {
+    it('should remove the group from the layout', () => {
+      const initialLayout: SplitLayout = {
+        groups: [
+          { id: 'group-1', tabs: [], activeTab: null },
+          { id: 'group-2', tabs: [], activeTab: null },
+        ],
+        activeGroupId: 'group-1',
+        direction: 'horizontal',
+      }
+
+      const { result } = renderHook(() =>
+        useSplitLayout({ initialLayout })
+      )
+
+      act(() => {
+        result.current.closeGroup('group-2')
+      })
+
+      expect(result.current.layout.groups).toHaveLength(1)
+      expect(result.current.layout.groups[0].id).toBe('group-1')
+    })
+
+    it('should not close the last remaining group', () => {
+      const { result } = renderHook(() => useSplitLayout())
+
+      const groupId = result.current.layout.groups[0].id
+
+      act(() => {
+        result.current.closeGroup(groupId)
+      })
+
+      expect(result.current.layout.groups).toHaveLength(1)
+    })
+
+    it('should migrate tabs to the previous group when closing', () => {
+      const tab1 = createMockTab('/file1.lua')
+      const tab2 = createMockTab('/file2.lua')
+      const initialLayout: SplitLayout = {
+        groups: [
+          { id: 'group-1', tabs: [tab1], activeTab: '/file1.lua' },
+          { id: 'group-2', tabs: [tab2], activeTab: '/file2.lua' },
+        ],
+        activeGroupId: 'group-2',
+        direction: 'horizontal',
+      }
+
+      const { result } = renderHook(() =>
+        useSplitLayout({ initialLayout })
+      )
+
+      act(() => {
+        result.current.closeGroup('group-2')
+      })
+
+      expect(result.current.layout.groups).toHaveLength(1)
+      expect(result.current.layout.groups[0].tabs).toHaveLength(2)
+      expect(result.current.layout.groups[0].tabs).toContainEqual(tab1)
+      expect(result.current.layout.groups[0].tabs).toContainEqual(tab2)
+    })
+
+    it('should set active group to the previous group when closing active group', () => {
+      const initialLayout: SplitLayout = {
+        groups: [
+          { id: 'group-1', tabs: [], activeTab: null },
+          { id: 'group-2', tabs: [], activeTab: null },
+        ],
+        activeGroupId: 'group-2',
+        direction: 'horizontal',
+      }
+
+      const { result } = renderHook(() =>
+        useSplitLayout({ initialLayout })
+      )
+
+      act(() => {
+        result.current.closeGroup('group-2')
+      })
+
+      expect(result.current.layout.activeGroupId).toBe('group-1')
+    })
+
+    it('should set active group to the next group when closing first group', () => {
+      const initialLayout: SplitLayout = {
+        groups: [
+          { id: 'group-1', tabs: [], activeTab: null },
+          { id: 'group-2', tabs: [], activeTab: null },
+        ],
+        activeGroupId: 'group-1',
+        direction: 'horizontal',
+      }
+
+      const { result } = renderHook(() =>
+        useSplitLayout({ initialLayout })
+      )
+
+      act(() => {
+        result.current.closeGroup('group-1')
+      })
+
+      expect(result.current.layout.activeGroupId).toBe('group-2')
+    })
+
+    it('should not change state if group does not exist', () => {
+      const initialLayout: SplitLayout = {
+        groups: [
+          { id: 'group-1', tabs: [], activeTab: null },
+          { id: 'group-2', tabs: [], activeTab: null },
+        ],
+        activeGroupId: 'group-1',
+        direction: 'horizontal',
+      }
+
+      const { result } = renderHook(() =>
+        useSplitLayout({ initialLayout })
+      )
+
+      act(() => {
+        result.current.closeGroup('non-existent')
+      })
+
+      expect(result.current.layout.groups).toHaveLength(2)
+    })
+  })
+
+  describe('moveTabToGroup', () => {
+    it('should move a tab from one group to another', () => {
+      const tab1 = createMockTab('/file1.lua')
+      const tab2 = createMockTab('/file2.lua')
+      const initialLayout: SplitLayout = {
+        groups: [
+          { id: 'group-1', tabs: [tab1, tab2], activeTab: '/file1.lua' },
+          { id: 'group-2', tabs: [], activeTab: null },
+        ],
+        activeGroupId: 'group-1',
+        direction: 'horizontal',
+      }
+
+      const { result } = renderHook(() =>
+        useSplitLayout({ initialLayout })
+      )
+
+      act(() => {
+        result.current.moveTabToGroup('/file1.lua', 'group-1', 'group-2')
+      })
+
+      expect(result.current.layout.groups[0].tabs).toHaveLength(1)
+      expect(result.current.layout.groups[0].tabs[0].path).toBe('/file2.lua')
+      expect(result.current.layout.groups[1].tabs).toHaveLength(1)
+      expect(result.current.layout.groups[1].tabs[0].path).toBe('/file1.lua')
+    })
+
+    it('should update activeTab in source group when moving active tab', () => {
+      const tab1 = createMockTab('/file1.lua')
+      const tab2 = createMockTab('/file2.lua')
+      const initialLayout: SplitLayout = {
+        groups: [
+          { id: 'group-1', tabs: [tab1, tab2], activeTab: '/file1.lua' },
+          { id: 'group-2', tabs: [], activeTab: null },
+        ],
+        activeGroupId: 'group-1',
+        direction: 'horizontal',
+      }
+
+      const { result } = renderHook(() =>
+        useSplitLayout({ initialLayout })
+      )
+
+      act(() => {
+        result.current.moveTabToGroup('/file1.lua', 'group-1', 'group-2')
+      })
+
+      // Active tab should now be the remaining tab in group-1
+      expect(result.current.layout.groups[0].activeTab).toBe('/file2.lua')
+    })
+
+    it('should set activeTab in target group to the moved tab', () => {
+      const tab1 = createMockTab('/file1.lua')
+      const initialLayout: SplitLayout = {
+        groups: [
+          { id: 'group-1', tabs: [tab1], activeTab: '/file1.lua' },
+          { id: 'group-2', tabs: [], activeTab: null },
+        ],
+        activeGroupId: 'group-1',
+        direction: 'horizontal',
+      }
+
+      const { result } = renderHook(() =>
+        useSplitLayout({ initialLayout })
+      )
+
+      act(() => {
+        result.current.moveTabToGroup('/file1.lua', 'group-1', 'group-2')
+      })
+
+      expect(result.current.layout.groups[1].activeTab).toBe('/file1.lua')
+    })
+
+    it('should not move tab if source group does not exist', () => {
+      const tab1 = createMockTab('/file1.lua')
+      const initialLayout: SplitLayout = {
+        groups: [
+          { id: 'group-1', tabs: [tab1], activeTab: '/file1.lua' },
+          { id: 'group-2', tabs: [], activeTab: null },
+        ],
+        activeGroupId: 'group-1',
+        direction: 'horizontal',
+      }
+
+      const { result } = renderHook(() =>
+        useSplitLayout({ initialLayout })
+      )
+
+      act(() => {
+        result.current.moveTabToGroup('/file1.lua', 'non-existent', 'group-2')
+      })
+
+      expect(result.current.layout.groups[0].tabs).toHaveLength(1)
+      expect(result.current.layout.groups[1].tabs).toHaveLength(0)
+    })
+
+    it('should not move tab if target group does not exist', () => {
+      const tab1 = createMockTab('/file1.lua')
+      const initialLayout: SplitLayout = {
+        groups: [
+          { id: 'group-1', tabs: [tab1], activeTab: '/file1.lua' },
+          { id: 'group-2', tabs: [], activeTab: null },
+        ],
+        activeGroupId: 'group-1',
+        direction: 'horizontal',
+      }
+
+      const { result } = renderHook(() =>
+        useSplitLayout({ initialLayout })
+      )
+
+      act(() => {
+        result.current.moveTabToGroup('/file1.lua', 'group-1', 'non-existent')
+      })
+
+      expect(result.current.layout.groups[0].tabs).toHaveLength(1)
+    })
+
+    it('should not move tab if tab does not exist in source group', () => {
+      const tab1 = createMockTab('/file1.lua')
+      const initialLayout: SplitLayout = {
+        groups: [
+          { id: 'group-1', tabs: [tab1], activeTab: '/file1.lua' },
+          { id: 'group-2', tabs: [], activeTab: null },
+        ],
+        activeGroupId: 'group-1',
+        direction: 'horizontal',
+      }
+
+      const { result } = renderHook(() =>
+        useSplitLayout({ initialLayout })
+      )
+
+      act(() => {
+        result.current.moveTabToGroup('/non-existent.lua', 'group-1', 'group-2')
+      })
+
+      expect(result.current.layout.groups[0].tabs).toHaveLength(1)
+      expect(result.current.layout.groups[1].tabs).toHaveLength(0)
+    })
+  })
+})

--- a/lua-learning-website/src/components/SplitEditorLayout/types.ts
+++ b/lua-learning-website/src/components/SplitEditorLayout/types.ts
@@ -1,0 +1,57 @@
+import type { TabInfo } from '../TabBar/types'
+
+/**
+ * Direction of a split - horizontal creates side-by-side panes,
+ * vertical creates top-bottom panes
+ */
+export type SplitDirection = 'horizontal' | 'vertical'
+
+/**
+ * Information about an editor group (a pane that can contain tabs)
+ */
+export interface EditorGroupInfo {
+  /** Unique identifier for this group */
+  id: string
+  /** Tabs open in this group */
+  tabs: TabInfo[]
+  /** Path of the currently active tab, or null if no tab is active */
+  activeTab: string | null
+}
+
+/**
+ * The complete split layout state
+ */
+export interface SplitLayout {
+  /** All editor groups in the layout */
+  groups: EditorGroupInfo[]
+  /** ID of the currently focused group */
+  activeGroupId: string
+  /** Direction of the split (only applies when there are 2+ groups) */
+  direction: SplitDirection
+}
+
+/**
+ * Options for the useSplitLayout hook
+ */
+export interface UseSplitLayoutOptions {
+  /** Initial layout state (optional) */
+  initialLayout?: SplitLayout
+}
+
+/**
+ * Return type for the useSplitLayout hook
+ */
+export interface UseSplitLayoutReturn {
+  /** Current layout state */
+  layout: SplitLayout
+  /** Split a group into two groups */
+  splitGroup: (groupId: string, direction: SplitDirection) => void
+  /** Close a group and migrate its tabs to the previous group */
+  closeGroup: (groupId: string) => void
+  /** Set the active (focused) group */
+  setActiveGroup: (groupId: string) => void
+  /** Move a tab from one group to another */
+  moveTabToGroup: (tabPath: string, fromGroupId: string, toGroupId: string) => void
+  /** Get the currently active group */
+  getActiveGroup: () => EditorGroupInfo | undefined
+}

--- a/lua-learning-website/src/components/SplitEditorLayout/useSplitLayout.ts
+++ b/lua-learning-website/src/components/SplitEditorLayout/useSplitLayout.ts
@@ -1,0 +1,197 @@
+import { useState, useCallback } from 'react'
+import type {
+  SplitLayout,
+  SplitDirection,
+  EditorGroupInfo,
+  UseSplitLayoutOptions,
+  UseSplitLayoutReturn,
+} from './types'
+
+/**
+ * Generate a unique ID for editor groups
+ */
+function generateGroupId(): string {
+  return `group-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
+}
+
+/**
+ * Create a default single-group layout
+ */
+function createDefaultLayout(): SplitLayout {
+  const groupId = generateGroupId()
+  return {
+    groups: [
+      {
+        id: groupId,
+        tabs: [],
+        activeTab: null,
+      },
+    ],
+    activeGroupId: groupId,
+    direction: 'horizontal',
+  }
+}
+
+/**
+ * Hook for managing split editor layout state
+ */
+export function useSplitLayout(
+  options: UseSplitLayoutOptions = {}
+): UseSplitLayoutReturn {
+  const { initialLayout } = options
+
+  const [layout, setLayout] = useState<SplitLayout>(
+    () => initialLayout ?? createDefaultLayout()
+  )
+
+  const getActiveGroup = useCallback((): EditorGroupInfo | undefined => {
+    return layout.groups.find((group) => group.id === layout.activeGroupId)
+  }, [layout.groups, layout.activeGroupId])
+
+  const setActiveGroup = useCallback((groupId: string): void => {
+    setLayout((prev) => {
+      const groupExists = prev.groups.some((g) => g.id === groupId)
+      if (!groupExists) {
+        return prev
+      }
+      return {
+        ...prev,
+        activeGroupId: groupId,
+      }
+    })
+  }, [])
+
+  const splitGroup = useCallback(
+    (groupId: string, direction: SplitDirection): void => {
+      setLayout((prev) => {
+        const groupIndex = prev.groups.findIndex((g) => g.id === groupId)
+        if (groupIndex === -1) {
+          return prev
+        }
+
+        const newGroup: EditorGroupInfo = {
+          id: generateGroupId(),
+          tabs: [],
+          activeTab: null,
+        }
+
+        // Insert new group after the split group
+        const newGroups = [...prev.groups]
+        newGroups.splice(groupIndex + 1, 0, newGroup)
+
+        return {
+          groups: newGroups,
+          activeGroupId: newGroup.id,
+          direction,
+        }
+      })
+    },
+    []
+  )
+
+  const closeGroup = useCallback((groupId: string): void => {
+    setLayout((prev) => {
+      // Don't close the last group
+      if (prev.groups.length <= 1) {
+        return prev
+      }
+
+      const groupIndex = prev.groups.findIndex((g) => g.id === groupId)
+      if (groupIndex === -1) {
+        return prev
+      }
+
+      const closingGroup = prev.groups[groupIndex]
+      const newGroups = prev.groups.filter((g) => g.id !== groupId)
+
+      // Determine which group receives the tabs (prefer previous, fallback to next)
+      const targetIndex = groupIndex > 0 ? groupIndex - 1 : 0
+      const targetGroup = newGroups[targetIndex]
+
+      // Migrate tabs from closing group to target group
+      const updatedGroups = newGroups.map((g) => {
+        if (g.id === targetGroup.id) {
+          return {
+            ...g,
+            tabs: [...g.tabs, ...closingGroup.tabs],
+          }
+        }
+        return g
+      })
+
+      // Determine new active group
+      let newActiveGroupId = prev.activeGroupId
+      if (prev.activeGroupId === groupId) {
+        // If closing the active group, set active to target group
+        newActiveGroupId = targetGroup.id
+      }
+
+      return {
+        ...prev,
+        groups: updatedGroups,
+        activeGroupId: newActiveGroupId,
+      }
+    })
+  }, [])
+
+  const moveTabToGroup = useCallback(
+    (tabPath: string, fromGroupId: string, toGroupId: string): void => {
+      setLayout((prev) => {
+        const fromGroup = prev.groups.find((g) => g.id === fromGroupId)
+        const toGroup = prev.groups.find((g) => g.id === toGroupId)
+
+        if (!fromGroup || !toGroup) {
+          return prev
+        }
+
+        const tabIndex = fromGroup.tabs.findIndex((t) => t.path === tabPath)
+        if (tabIndex === -1) {
+          return prev
+        }
+
+        const tab = fromGroup.tabs[tabIndex]
+        const newFromTabs = fromGroup.tabs.filter((t) => t.path !== tabPath)
+
+        // Update activeTab in source group if we moved the active tab
+        let newFromActiveTab = fromGroup.activeTab
+        if (fromGroup.activeTab === tabPath) {
+          // Set to next tab, or previous, or null
+          newFromActiveTab = newFromTabs.length > 0 ? newFromTabs[0].path : null
+        }
+
+        const updatedGroups = prev.groups.map((g) => {
+          if (g.id === fromGroupId) {
+            return {
+              ...g,
+              tabs: newFromTabs,
+              activeTab: newFromActiveTab,
+            }
+          }
+          if (g.id === toGroupId) {
+            return {
+              ...g,
+              tabs: [...g.tabs, tab],
+              activeTab: tabPath, // Set moved tab as active in target
+            }
+          }
+          return g
+        })
+
+        return {
+          ...prev,
+          groups: updatedGroups,
+        }
+      })
+    },
+    []
+  )
+
+  return {
+    layout,
+    splitGroup,
+    closeGroup,
+    setActiveGroup,
+    moveTabToGroup,
+    getActiveGroup,
+  }
+}


### PR DESCRIPTION
## Summary

- Create foundational types for split editor layout (`SplitLayout`, `EditorGroupInfo`, `SplitDirection`)
- Implement `useSplitLayout` hook with split/close/move operations
- Add comprehensive unit tests with 97%+ code coverage (27 tests)

## Implementation Details

### Types Created
- `SplitDirection`: `'horizontal' | 'vertical'`
- `EditorGroupInfo`: Group state with tabs and active tab
- `SplitLayout`: Complete layout state with groups and direction

### Hook API
- `splitGroup(groupId, direction)` - Split a group into two
- `closeGroup(groupId)` - Close a group, migrate tabs to adjacent group
- `setActiveGroup(groupId)` - Set the focused group
- `moveTabToGroup(tabPath, fromGroupId, toGroupId)` - Move tabs between groups
- `getActiveGroup()` - Get the currently active group

## Test Plan

- [x] Unit tests for initial state (single group, horizontal direction)
- [x] Unit tests for getActiveGroup and setActiveGroup
- [x] Unit tests for splitGroup (6 test cases)
- [x] Unit tests for closeGroup (6 test cases including tab migration)
- [x] Unit tests for moveTabToGroup (6 test cases)
- [x] Code coverage: 97.26% statements, 90.32% branches

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)