### PR TITLE
feat(canvas): Implement ellipse() and roundRect() (#419)

### DIFF
--- a/EPIC-415.md
+++ b/EPIC-415.md
@@ -1,9 +1,9 @@
 # Epic #415: Epic: Complete Canvas 2D API Implementation
 
-**Status:** In Progress (4/17 complete)
+**Status:** In Progress (5/17 complete)
 **Branch:** epic-415
 **Created:** 2025-12-22
-**Last Updated:** 2025-12-22
+**Last Updated:** 2025-12-23
 
 ## Overview
 
@@ -39,7 +39,7 @@ Key considerations:
 | #416 | Implement Path API basics (beginPath, closePath, moveTo, lineTo, fill, stroke) | ✅ Complete | 416-path-api-basics | Merged PR #437 |
 | #417 | Implement arc and arcTo for path API | ✅ Complete | 417-implement-arc-and-arcto-for-path-api | Merged PR #438 |
 | #418 | Implement Bezier curves (bezierCurveTo, quadraticCurveTo) | ✅ Complete | epic-415 | Direct commit to epic branch |
-| #419 | Implement ellipse() and roundRect() | ⏳ Pending | - | - |
+| #419 | Implement ellipse() and roundRect() | ✅ Complete | 419-ellipse-roundrect | - |
 | #420 | Implement clipping (clip) | ⏳ Pending | - | - |
 | #421 | Implement line styles (lineCap, lineJoin, miterLimit) | ⏳ Pending | - | - |
 | #422 | Implement dashed lines (setLineDash, getLineDash, lineDashOffset) | ⏳ Pending | - | - |
@@ -84,6 +84,15 @@ Key considerations:
   - Updated docs/canvas.md with Bezier curves section
   - Added LuaDoc annotations in canvas.lua
   - Committed directly to epic-415 branch
+
+### 2025-12-23
+- #419 Ellipse and RoundRect complete
+  - Added 2 path commands: ellipse, round_rect
+  - Mutation score: CanvasRenderer 80.7%
+  - Created 2 examples: ellipse-shapes.lua, rounded-buttons.lua
+  - Updated docs/canvas.md and canvas.lua LuaDoc
+  - Updated manifest.json with new examples
+  - Branch: 419-ellipse-roundrect
 
 ## Key Files
 

--- a/lua-learning-website/public/docs/canvas.md
+++ b/lua-learning-website/public/docs/canvas.md
@@ -275,6 +275,64 @@ canvas.set_line_width(3)
 canvas.stroke()
 ```
 
+### canvas.ellipse(x, y, radiusX, radiusY, rotation?, startAngle?, endAngle?, counterclockwise?)
+
+Draw an ellipse (oval) on the current path. An ellipse has separate horizontal and vertical radii.
+
+**Parameters:**
+- `x` (number): X coordinate of the ellipse's center
+- `y` (number): Y coordinate of the ellipse's center
+- `radiusX` (number): Horizontal radius (half-width)
+- `radiusY` (number): Vertical radius (half-height)
+- `rotation` (number, optional): Rotation in radians (default: 0)
+- `startAngle` (number, optional): Start angle in radians (default: 0)
+- `endAngle` (number, optional): End angle in radians (default: 2π for full ellipse)
+- `counterclockwise` (boolean, optional): Draw counterclockwise (default: false)
+
+```lua
+-- Draw a full oval
+canvas.begin_path()
+canvas.ellipse(200, 150, 100, 50)  -- Wide oval
+canvas.set_color("#4ECDC4")
+canvas.fill()
+
+-- Draw a rotated ellipse
+canvas.begin_path()
+canvas.ellipse(200, 200, 80, 40, math.pi / 4)  -- 45-degree rotation
+canvas.stroke()
+```
+
+### canvas.round_rect(x, y, width, height, radii)
+
+Draw a rounded rectangle on the current path. Great for buttons and UI elements.
+
+**Parameters:**
+- `x` (number): X coordinate of top-left corner
+- `y` (number): Y coordinate of top-left corner
+- `width` (number): Rectangle width
+- `height` (number): Rectangle height
+- `radii` (number or table): Corner radius/radii
+
+**Radii formats:**
+- Single number: Same radius for all corners
+- `{r}`: Same radius for all corners
+- `{r1, r2}`: r1 for top-left/bottom-right, r2 for top-right/bottom-left
+- `{r1, r2, r3}`: r1=top-left, r2=top-right/bottom-left, r3=bottom-right
+- `{r1, r2, r3, r4}`: top-left, top-right, bottom-right, bottom-left
+
+```lua
+-- Draw a button with uniform rounded corners
+canvas.begin_path()
+canvas.round_rect(50, 50, 200, 60, 15)
+canvas.set_color("#667EEA")
+canvas.fill()
+
+-- Draw with different corner radii
+canvas.begin_path()
+canvas.round_rect(50, 150, 200, 60, {20, 0, 20, 0})  -- Alternating corners
+canvas.fill()
+```
+
 ### canvas.fill()
 
 Fill the current path with the current color.

--- a/lua-learning-website/public/examples/canvas/ellipse-shapes.lua
+++ b/lua-learning-website/public/examples/canvas/ellipse-shapes.lua
@@ -1,0 +1,111 @@
+-- Ellipse Shapes Demo
+-- Demonstrates the canvas.ellipse() function for drawing ovals and partial arcs
+
+local canvas = require('canvas')
+
+canvas.set_size(600, 500)
+
+canvas.tick(function()
+  canvas.clear()
+
+  -- Title
+  canvas.set_color("#FFFFFF")
+  canvas.set_font_size(24)
+  canvas.draw_text(20, 20, "Ellipse Shapes Demo")
+  canvas.set_font_size(14)
+  canvas.draw_text(20, 50, "canvas.ellipse(x, y, radiusX, radiusY, rotation, startAngle, endAngle)")
+
+  -- 1. Basic horizontal ellipse (oval)
+  canvas.begin_path()
+  canvas.ellipse(100, 150, 70, 40)  -- Wide oval
+  canvas.set_color("#FF6B6B")
+  canvas.fill()
+  canvas.set_color("#FFFFFF")
+  canvas.set_font_size(12)
+  canvas.draw_text(40, 200, "Wide oval (70x40)")
+
+  -- 2. Vertical ellipse
+  canvas.begin_path()
+  canvas.ellipse(250, 150, 35, 60)  -- Tall oval
+  canvas.set_color("#4ECDC4")
+  canvas.fill()
+  canvas.draw_text(210, 220, "Tall oval (35x60)")
+
+  -- 3. Rotated ellipse (45 degrees)
+  canvas.begin_path()
+  canvas.ellipse(400, 150, 60, 30, math.pi / 4)  -- Rotated 45 degrees
+  canvas.set_color("#A8E6CF")
+  canvas.fill()
+  canvas.draw_text(350, 200, "Rotated 45 deg")
+
+  -- 4. Perfect circle (radiusX == radiusY)
+  canvas.begin_path()
+  canvas.ellipse(530, 150, 40, 40)  -- Equal radii = circle
+  canvas.set_color("#FFD93D")
+  canvas.fill()
+  canvas.draw_text(490, 200, "Circle (40x40)")
+
+  -- 5. Partial ellipse arc
+  canvas.begin_path()
+  canvas.ellipse(100, 320, 50, 30, 0, 0, math.pi)  -- Half ellipse (0 to PI)
+  canvas.set_color("#C9B1FF")
+  canvas.fill()
+  canvas.draw_text(50, 370, "Half ellipse (0 to PI)")
+
+  -- 6. Quarter ellipse
+  canvas.begin_path()
+  canvas.ellipse(250, 320, 50, 30, 0, 0, math.pi / 2)  -- Quarter ellipse
+  canvas.close_path()
+  canvas.set_color("#FF9F43")
+  canvas.fill()
+  canvas.draw_text(200, 370, "Quarter (0 to PI/2)")
+
+  -- 7. Stroked ellipse with thick line
+  canvas.begin_path()
+  canvas.ellipse(400, 320, 55, 35)
+  canvas.set_line_width(4)
+  canvas.set_color("#00CEC9")
+  canvas.stroke()
+  canvas.draw_text(350, 370, "Stroked ellipse")
+
+  -- 8. Face using ellipses (fun example)
+  -- Head
+  canvas.begin_path()
+  canvas.ellipse(300, 450, 60, 50)
+  canvas.set_color("#FFE4B5")
+  canvas.fill()
+  canvas.set_color("#000000")
+  canvas.stroke()
+
+  -- Eyes (small ellipses)
+  canvas.begin_path()
+  canvas.ellipse(275, 440, 10, 15)
+  canvas.set_color("#FFFFFF")
+  canvas.fill()
+  canvas.set_color("#000000")
+  canvas.stroke()
+  canvas.begin_path()
+  canvas.ellipse(275, 440, 4, 6)
+  canvas.fill()
+
+  canvas.begin_path()
+  canvas.ellipse(325, 440, 10, 15)
+  canvas.set_color("#FFFFFF")
+  canvas.fill()
+  canvas.set_color("#000000")
+  canvas.stroke()
+  canvas.begin_path()
+  canvas.ellipse(325, 440, 4, 6)
+  canvas.fill()
+
+  -- Smile (half ellipse arc)
+  canvas.begin_path()
+  canvas.ellipse(300, 460, 25, 15, 0, 0, math.pi)
+  canvas.set_line_width(2)
+  canvas.stroke()
+
+  canvas.set_color("#FFFFFF")
+  canvas.draw_text(250, 500, "Face using ellipses")
+end)
+
+canvas.start()

--- a/lua-learning-website/public/examples/canvas/rounded-buttons.lua
+++ b/lua-learning-website/public/examples/canvas/rounded-buttons.lua
@@ -1,0 +1,154 @@
+-- Rounded Buttons Demo
+-- Demonstrates the canvas.round_rect() function for UI elements
+
+local canvas = require('canvas')
+
+canvas.set_size(600, 550)
+
+-- Button hover state (for interactive demo)
+local hover_button = 0
+
+canvas.tick(function()
+  canvas.clear()
+
+  -- Title
+  canvas.set_color("#FFFFFF")
+  canvas.set_font_size(24)
+  canvas.draw_text(20, 20, "Rounded Rectangle Demo")
+  canvas.set_font_size(14)
+  canvas.draw_text(20, 50, "canvas.round_rect(x, y, width, height, radii)")
+
+  -- Check mouse position for hover effects
+  local mx = canvas.get_mouse_x()
+  local my = canvas.get_mouse_y()
+
+  -- 1. Uniform rounded corners (single number)
+  local btn1_x, btn1_y = 50, 100
+  local btn1_hover = mx >= btn1_x and mx <= btn1_x + 180 and my >= btn1_y and my <= btn1_y + 50
+
+  canvas.begin_path()
+  canvas.round_rect(btn1_x, btn1_y, 180, 50, 10)  -- 10px radius on all corners
+  canvas.set_color(btn1_hover and "#7B8FEE" or "#667EEA")
+  canvas.fill()
+  canvas.set_color("#FFFFFF")
+  canvas.set_font_size(16)
+  canvas.draw_text(btn1_x + 35, btn1_y + 17, "Uniform (10px)")
+
+  canvas.set_color("#AAAAAA")
+  canvas.set_font_size(12)
+  canvas.draw_text(btn1_x, btn1_y + 60, "round_rect(x, y, w, h, 10)")
+
+  -- 2. Pill button (large radius)
+  local btn2_x, btn2_y = 50, 200
+  local btn2_hover = mx >= btn2_x and mx <= btn2_x + 180 and my >= btn2_y and my <= btn2_y + 50
+
+  canvas.begin_path()
+  canvas.round_rect(btn2_x, btn2_y, 180, 50, 25)  -- Large radius = pill shape
+  canvas.set_color(btn2_hover and "#FF7F7F" or "#FF6B6B")
+  canvas.fill()
+  canvas.set_color("#FFFFFF")
+  canvas.set_font_size(16)
+  canvas.draw_text(btn2_x + 45, btn2_y + 17, "Pill Shape")
+
+  canvas.set_color("#AAAAAA")
+  canvas.set_font_size(12)
+  canvas.draw_text(btn2_x, btn2_y + 60, "round_rect(x, y, w, h, 25)")
+
+  -- 3. Two different radii (diagonal corners)
+  local btn3_x, btn3_y = 50, 300
+  local btn3_hover = mx >= btn3_x and mx <= btn3_x + 180 and my >= btn3_y and my <= btn3_y + 50
+
+  canvas.begin_path()
+  canvas.round_rect(btn3_x, btn3_y, 180, 50, {20, 5})  -- TL/BR=20, TR/BL=5
+  canvas.set_color(btn3_hover and "#5DE0D9" or "#4ECDC4")
+  canvas.fill()
+  canvas.set_color("#FFFFFF")
+  canvas.set_font_size(16)
+  canvas.draw_text(btn3_x + 30, btn3_y + 17, "Diagonal {20, 5}")
+
+  canvas.set_color("#AAAAAA")
+  canvas.set_font_size(12)
+  canvas.draw_text(btn3_x, btn3_y + 60, "radii = {20, 5}")
+
+  -- 4. Four different radii (each corner different)
+  local btn4_x, btn4_y = 50, 400
+  local btn4_hover = mx >= btn4_x and mx <= btn4_x + 180 and my >= btn4_y and my <= btn4_y + 50
+
+  canvas.begin_path()
+  canvas.round_rect(btn4_x, btn4_y, 180, 50, {25, 10, 25, 10})  -- All corners different
+  canvas.set_color(btn4_hover and "#FFE066" or "#FFD93D")
+  canvas.fill()
+  canvas.set_color("#333333")
+  canvas.set_font_size(16)
+  canvas.draw_text(btn4_x + 5, btn4_y + 17, "Custom {25,10,25,10}")
+
+  canvas.set_color("#AAAAAA")
+  canvas.set_font_size(12)
+  canvas.draw_text(btn4_x, btn4_y + 60, "radii = {25, 10, 25, 10}")
+
+  -- Right column - more examples
+
+  -- 5. Sharp top corners, rounded bottom
+  local btn5_x, btn5_y = 320, 100
+  canvas.begin_path()
+  canvas.round_rect(btn5_x, btn5_y, 180, 50, {0, 0, 15, 15})
+  canvas.set_color("#A8E6CF")
+  canvas.fill()
+  canvas.set_color("#333333")
+  canvas.set_font_size(16)
+  canvas.draw_text(btn5_x + 15, btn5_y + 17, "Bottom rounded")
+
+  canvas.set_color("#AAAAAA")
+  canvas.set_font_size(12)
+  canvas.draw_text(btn5_x, btn5_y + 60, "radii = {0, 0, 15, 15}")
+
+  -- 6. Rounded top only (tab style)
+  local btn6_x, btn6_y = 320, 200
+  canvas.begin_path()
+  canvas.round_rect(btn6_x, btn6_y, 180, 50, {15, 15, 0, 0})
+  canvas.set_color("#C9B1FF")
+  canvas.fill()
+  canvas.set_color("#333333")
+  canvas.set_font_size(16)
+  canvas.draw_text(btn6_x + 35, btn6_y + 17, "Tab Style")
+
+  canvas.set_color("#AAAAAA")
+  canvas.set_font_size(12)
+  canvas.draw_text(btn6_x, btn6_y + 60, "radii = {15, 15, 0, 0}")
+
+  -- 7. One corner rounded (dialog bubble style)
+  local btn7_x, btn7_y = 320, 300
+  canvas.begin_path()
+  canvas.round_rect(btn7_x, btn7_y, 180, 50, {15, 15, 15, 0})
+  canvas.set_color("#FF9F43")
+  canvas.fill()
+  canvas.set_color("#FFFFFF")
+  canvas.set_font_size(16)
+  canvas.draw_text(btn7_x + 25, btn7_y + 17, "Speech Bubble")
+
+  canvas.set_color("#AAAAAA")
+  canvas.set_font_size(12)
+  canvas.draw_text(btn7_x, btn7_y + 60, "radii = {15, 15, 15, 0}")
+
+  -- 8. Zero radius (sharp corners - same as fill_rect)
+  local btn8_x, btn8_y = 320, 400
+  canvas.begin_path()
+  canvas.round_rect(btn8_x, btn8_y, 180, 50, 0)
+  canvas.set_color("#00CEC9")
+  canvas.fill()
+  canvas.set_color("#FFFFFF")
+  canvas.set_font_size(16)
+  canvas.draw_text(btn8_x + 30, btn8_y + 17, "Sharp (radii=0)")
+
+  canvas.set_color("#AAAAAA")
+  canvas.set_font_size(12)
+  canvas.draw_text(btn8_x, btn8_y + 60, "round_rect(x, y, w, h, 0)")
+
+  -- Card with rounded corners at bottom
+  canvas.set_color("#FFFFFF")
+  canvas.set_font_size(14)
+  canvas.draw_text(20, 490, "Tip: Hover over buttons on the left to see color change!")
+  canvas.draw_text(20, 510, "Radii format: {top-left, top-right, bottom-right, bottom-left}")
+end)
+
+canvas.start()

--- a/lua-learning-website/public/examples/manifest.json
+++ b/lua-learning-website/public/examples/manifest.json
@@ -31,6 +31,8 @@
     "canvas/arc-smiley.lua",
     "canvas/bezier-curves.lua",
     "canvas/quadratic-curves.lua",
+    "canvas/ellipse-shapes.lua",
+    "canvas/rounded-buttons.lua",
     "canvas/fonts/10px-Bitfantasy.ttf",
     "canvas/fonts/10px-CelticTime.ttf",
     "canvas/fonts/10px-HelvetiPixel.ttf",

--- a/packages/canvas-runtime/src/renderer/CanvasRenderer.ts
+++ b/packages/canvas-runtime/src/renderer/CanvasRenderer.ts
@@ -179,6 +179,19 @@ export class CanvasRenderer {
         this.ctx.bezierCurveTo(command.cp1x, command.cp1y, command.cp2x, command.cp2y, command.x, command.y);
         break;
 
+      case 'ellipse':
+        this.ctx.ellipse(
+          command.x, command.y,
+          command.radiusX, command.radiusY,
+          command.rotation, command.startAngle, command.endAngle,
+          command.counterclockwise
+        );
+        break;
+
+      case 'roundRect':
+        this.ctx.roundRect(command.x, command.y, command.width, command.height, command.radii);
+        break;
+
       default:
         // Ignore unknown commands for forward compatibility
         break;

--- a/packages/canvas-runtime/src/shared/types.ts
+++ b/packages/canvas-runtime/src/shared/types.ts
@@ -32,7 +32,9 @@ export type DrawCommandType =
   | 'arc'
   | 'arcTo'
   | 'quadraticCurveTo'
-  | 'bezierCurveTo';
+  | 'bezierCurveTo'
+  | 'ellipse'
+  | 'roundRect';
 
 /**
  * Base interface for all draw commands.
@@ -387,6 +389,46 @@ export interface BezierCurveToCommand extends DrawCommandBase {
 }
 
 /**
+ * Draw an ellipse on the current path.
+ */
+export interface EllipseCommand extends DrawCommandBase {
+  type: 'ellipse';
+  /** X coordinate of the ellipse's center */
+  x: number;
+  /** Y coordinate of the ellipse's center */
+  y: number;
+  /** Horizontal radius of the ellipse */
+  radiusX: number;
+  /** Vertical radius of the ellipse */
+  radiusY: number;
+  /** Rotation of the ellipse in radians */
+  rotation: number;
+  /** Start angle in radians */
+  startAngle: number;
+  /** End angle in radians */
+  endAngle: number;
+  /** Draw counterclockwise (default: false) */
+  counterclockwise?: boolean;
+}
+
+/**
+ * Draw a rounded rectangle on the current path.
+ */
+export interface RoundRectCommand extends DrawCommandBase {
+  type: 'roundRect';
+  /** X coordinate of the rectangle's starting point */
+  x: number;
+  /** Y coordinate of the rectangle's starting point */
+  y: number;
+  /** Width of the rectangle */
+  width: number;
+  /** Height of the rectangle */
+  height: number;
+  /** Corner radii - single value or array of 1-4 values */
+  radii: number | number[];
+}
+
+/**
  * Union type of all draw commands.
  */
 export type DrawCommand =
@@ -420,7 +462,9 @@ export type DrawCommand =
   | ArcCommand
   | ArcToCommand
   | QuadraticCurveToCommand
-  | BezierCurveToCommand;
+  | BezierCurveToCommand
+  | EllipseCommand
+  | RoundRectCommand;
 
 /**
  * Mouse button identifiers.

--- a/packages/canvas-runtime/tests/renderer/CanvasRenderer.test.ts
+++ b/packages/canvas-runtime/tests/renderer/CanvasRenderer.test.ts
@@ -18,6 +18,8 @@ function createMockContext(): CanvasRenderingContext2D {
     arcTo: vi.fn(),
     quadraticCurveTo: vi.fn(),
     bezierCurveTo: vi.fn(),
+    ellipse: vi.fn(),
+    roundRect: vi.fn(),
     fill: vi.fn(),
     stroke: vi.fn(),
     moveTo: vi.fn(),
@@ -947,6 +949,120 @@ describe('CanvasRenderer', () => {
 
       expect(mockCtx.fill).toHaveBeenCalled();
       expect(mockCtx.stroke).toHaveBeenCalled();
+    });
+  });
+
+  describe('ellipse command', () => {
+    it('should call ctx.ellipse() with correct parameters', () => {
+      const commands: DrawCommand[] = [
+        { type: 'ellipse', x: 200, y: 150, radiusX: 100, radiusY: 50, rotation: 0, startAngle: 0, endAngle: Math.PI * 2 },
+      ];
+
+      renderer.render(commands);
+
+      expect(mockCtx.ellipse).toHaveBeenCalledWith(200, 150, 100, 50, 0, 0, Math.PI * 2, undefined);
+    });
+
+    it('should pass counterclockwise parameter when true', () => {
+      const commands: DrawCommand[] = [
+        { type: 'ellipse', x: 100, y: 100, radiusX: 80, radiusY: 40, rotation: Math.PI / 4, startAngle: 0, endAngle: Math.PI, counterclockwise: true },
+      ];
+
+      renderer.render(commands);
+
+      expect(mockCtx.ellipse).toHaveBeenCalledWith(100, 100, 80, 40, Math.PI / 4, 0, Math.PI, true);
+    });
+
+    it('should pass counterclockwise parameter when false', () => {
+      const commands: DrawCommand[] = [
+        { type: 'ellipse', x: 150, y: 150, radiusX: 60, radiusY: 30, rotation: 0, startAngle: 0, endAngle: Math.PI / 2, counterclockwise: false },
+      ];
+
+      renderer.render(commands);
+
+      expect(mockCtx.ellipse).toHaveBeenCalledWith(150, 150, 60, 30, 0, 0, Math.PI / 2, false);
+    });
+
+    it('should handle rotation angle', () => {
+      const commands: DrawCommand[] = [
+        { type: 'ellipse', x: 200, y: 200, radiusX: 100, radiusY: 50, rotation: Math.PI / 6, startAngle: 0, endAngle: Math.PI * 2 },
+      ];
+
+      renderer.render(commands);
+
+      expect(mockCtx.ellipse).toHaveBeenCalledWith(200, 200, 100, 50, Math.PI / 6, 0, Math.PI * 2, undefined);
+    });
+
+    it('should handle partial ellipse arc', () => {
+      const commands: DrawCommand[] = [
+        { type: 'ellipse', x: 100, y: 100, radiusX: 50, radiusY: 25, rotation: 0, startAngle: Math.PI / 4, endAngle: Math.PI * 3 / 4 },
+      ];
+
+      renderer.render(commands);
+
+      expect(mockCtx.ellipse).toHaveBeenCalledWith(100, 100, 50, 25, 0, Math.PI / 4, Math.PI * 3 / 4, undefined);
+    });
+  });
+
+  describe('roundRect command', () => {
+    it('should call ctx.roundRect() with single radius value', () => {
+      const commands: DrawCommand[] = [
+        { type: 'roundRect', x: 50, y: 50, width: 200, height: 100, radii: 15 },
+      ];
+
+      renderer.render(commands);
+
+      expect(mockCtx.roundRect).toHaveBeenCalledWith(50, 50, 200, 100, 15);
+    });
+
+    it('should call ctx.roundRect() with array of radii', () => {
+      const commands: DrawCommand[] = [
+        { type: 'roundRect', x: 100, y: 100, width: 150, height: 80, radii: [10, 20, 30, 40] },
+      ];
+
+      renderer.render(commands);
+
+      expect(mockCtx.roundRect).toHaveBeenCalledWith(100, 100, 150, 80, [10, 20, 30, 40]);
+    });
+
+    it('should handle single-element radii array', () => {
+      const commands: DrawCommand[] = [
+        { type: 'roundRect', x: 0, y: 0, width: 100, height: 50, radii: [25] },
+      ];
+
+      renderer.render(commands);
+
+      expect(mockCtx.roundRect).toHaveBeenCalledWith(0, 0, 100, 50, [25]);
+    });
+
+    it('should handle two-element radii array', () => {
+      const commands: DrawCommand[] = [
+        { type: 'roundRect', x: 10, y: 20, width: 200, height: 100, radii: [10, 20] },
+      ];
+
+      renderer.render(commands);
+
+      expect(mockCtx.roundRect).toHaveBeenCalledWith(10, 20, 200, 100, [10, 20]);
+    });
+
+    it('should handle three-element radii array', () => {
+      const commands: DrawCommand[] = [
+        { type: 'roundRect', x: 30, y: 40, width: 180, height: 90, radii: [5, 10, 15] },
+      ];
+
+      renderer.render(commands);
+
+      expect(mockCtx.roundRect).toHaveBeenCalledWith(30, 40, 180, 90, [5, 10, 15]);
+    });
+
+    it('should handle zero radius', () => {
+      const commands: DrawCommand[] = [
+        { type: 'roundRect', x: 0, y: 0, width: 100, height: 100, radii: 0 },
+      ];
+
+      renderer.render(commands);
+
+      expect(mockCtx.roundRect).toHaveBeenCalledWith(0, 0, 100, 100, 0);
     });
   });
 });

--- a/packages/lua-runtime/src/CanvasController.ts
+++ b/packages/lua-runtime/src/CanvasController.ts
@@ -537,6 +537,52 @@ export class CanvasController {
     this.addDrawCommand({ type: 'bezierCurveTo', cp1x, cp1y, cp2x, cp2y, x, y })
   }
 
+  /**
+   * Draw an ellipse on the current path.
+   * @param x - X coordinate of the ellipse's center
+   * @param y - Y coordinate of the ellipse's center
+   * @param radiusX - Horizontal radius of the ellipse
+   * @param radiusY - Vertical radius of the ellipse
+   * @param rotation - Rotation of the ellipse in radians
+   * @param startAngle - Start angle in radians
+   * @param endAngle - End angle in radians
+   * @param counterclockwise - Draw counterclockwise (default: false)
+   */
+  ellipse(
+    x: number,
+    y: number,
+    radiusX: number,
+    radiusY: number,
+    rotation: number,
+    startAngle: number,
+    endAngle: number,
+    counterclockwise?: boolean
+  ): void {
+    this.addDrawCommand({
+      type: 'ellipse',
+      x,
+      y,
+      radiusX,
+      radiusY,
+      rotation,
+      startAngle,
+      endAngle,
+      counterclockwise,
+    })
+  }
+
+  /**
+   * Draw a rounded rectangle on the current path.
+   * @param x - X coordinate of the rectangle's starting point
+   * @param y - Y coordinate of the rectangle's starting point
+   * @param width - Width of the rectangle
+   * @param height - Height of the rectangle
+   * @param radii - Corner radii (single value or array of 1-4 values)
+   */
+  roundRect(x: number, y: number, width: number, height: number, radii: number | number[]): void {
+    this.addDrawCommand({ type: 'roundRect', x, y, width, height, radii })
+  }
+
   // --- Timing API ---
 
   /**

--- a/packages/lua-runtime/src/canvasLuaWrapper.ts
+++ b/packages/lua-runtime/src/canvasLuaWrapper.ts
@@ -276,6 +276,14 @@ export const canvasLuaCode = `
       __canvas_bezierCurveTo(cp1x, cp1y, cp2x, cp2y, x, y)
     end
 
+    function _canvas.ellipse(x, y, radiusX, radiusY, rotation, startAngle, endAngle, counterclockwise)
+      __canvas_ellipse(x, y, radiusX, radiusY, rotation or 0, startAngle or 0, endAngle or (math.pi * 2), counterclockwise or false)
+    end
+
+    function _canvas.round_rect(x, y, width, height, radii)
+      __canvas_roundRect(x, y, width, height, radii)
+    end
+
     -- Timing
     function _canvas.get_delta()
       return __canvas_getDelta()

--- a/packages/lua-runtime/src/lua/canvas.lua
+++ b/packages/lua-runtime/src/lua/canvas.lua
@@ -671,4 +671,56 @@ function canvas.quadratic_curve_to(cpx, cpy, x, y) end
 ---@usage canvas.stroke()
 function canvas.bezier_curve_to(cp1x, cp1y, cp2x, cp2y, x, y) end
 
+--- Draw an ellipse (oval) on the current path.
+--- An ellipse is like a stretched circle with separate horizontal and vertical radii.
+--- Can also draw partial ellipse arcs by specifying start and end angles.
+---@param x number X coordinate of the ellipse's center
+---@param y number Y coordinate of the ellipse's center
+---@param radiusX number Horizontal radius (half-width) of the ellipse
+---@param radiusY number Vertical radius (half-height) of the ellipse
+---@param rotation? number Rotation of the ellipse in radians (default: 0)
+---@param startAngle? number Start angle in radians (default: 0)
+---@param endAngle? number End angle in radians (default: 2*PI for full ellipse)
+---@param counterclockwise? boolean Draw counterclockwise (default: false)
+---@return nil
+---@usage -- Draw a full oval
+---@usage canvas.begin_path()
+---@usage canvas.ellipse(200, 150, 100, 50)  -- Wide oval
+---@usage canvas.set_color("#4ECDC4")
+---@usage canvas.fill()
+---@usage
+---@usage -- Draw a rotated ellipse
+---@usage canvas.begin_path()
+---@usage canvas.ellipse(200, 200, 80, 40, math.pi / 4)  -- 45-degree rotation
+---@usage canvas.stroke()
+function canvas.ellipse(x, y, radiusX, radiusY, rotation, startAngle, endAngle, counterclockwise) end
+
+--- Draw a rounded rectangle on the current path.
+--- Creates a rectangle with rounded corners, useful for buttons and UI elements.
+--- The radii parameter can be a single number for uniform corners, or a table
+--- of 1-4 values for different corner radii.
+---@param x number X coordinate of the rectangle's top-left corner
+---@param y number Y coordinate of the rectangle's top-left corner
+---@param width number Width of the rectangle
+---@param height number Height of the rectangle
+---@param radii number|table Corner radii - single value or table of 1-4 values
+---@return nil
+---@usage -- Draw a button with uniform rounded corners
+---@usage canvas.begin_path()
+---@usage canvas.round_rect(50, 50, 200, 60, 15)  -- 15px radius on all corners
+---@usage canvas.set_color("#667EEA")
+---@usage canvas.fill()
+---@usage
+---@usage -- Draw with different corner radii
+---@usage canvas.begin_path()
+---@usage canvas.round_rect(50, 150, 200, 60, {20, 0, 20, 0})  -- Alternating corners
+---@usage canvas.fill()
+---@usage
+---@usage -- Radii table formats:
+---@usage -- {r}       - Same radius for all corners
+---@usage -- {r1, r2}  - r1=top-left/bottom-right, r2=top-right/bottom-left
+---@usage -- {r1, r2, r3} - r1=top-left, r2=top-right/bottom-left, r3=bottom-right
+---@usage -- {r1, r2, r3, r4} - top-left, top-right, bottom-right, bottom-left
+function canvas.round_rect(x, y, width, height, radii) end
+
 return canvas

--- a/packages/lua-runtime/src/setupCanvasAPI.ts
+++ b/packages/lua-runtime/src/setupCanvasAPI.ts
@@ -260,6 +260,14 @@ export function setupCanvasAPI(
     getController()?.bezierCurveTo(cp1x, cp1y, cp2x, cp2y, x, y)
   })
 
+  engine.global.set('__canvas_ellipse', (x: number, y: number, radiusX: number, radiusY: number, rotation: number, startAngle: number, endAngle: number, counterclockwise?: boolean) => {
+    getController()?.ellipse(x, y, radiusX, radiusY, rotation, startAngle, endAngle, counterclockwise)
+  })
+
+  engine.global.set('__canvas_roundRect', (x: number, y: number, width: number, height: number, radii: number | number[]) => {
+    getController()?.roundRect(x, y, width, height, radii)
+  })
+
   // --- Set up Lua-side canvas table ---
   // Canvas is NOT a global - it must be accessed via require('canvas')
   engine.doStringSync(canvasLuaCode)

--- a/packages/lua-runtime/tests/CanvasController.path.test.ts
+++ b/packages/lua-runtime/tests/CanvasController.path.test.ts
@@ -465,4 +465,188 @@ describe('CanvasController Path API', () => {
       expect(commands[3]).toEqual({ type: 'stroke' })
     })
   })
+
+  describe('ellipse', () => {
+    it('should add ellipse command with all parameters', () => {
+      controller.ellipse(200, 150, 100, 50, 0, 0, Math.PI * 2, false)
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({
+        type: 'ellipse',
+        x: 200,
+        y: 150,
+        radiusX: 100,
+        radiusY: 50,
+        rotation: 0,
+        startAngle: 0,
+        endAngle: Math.PI * 2,
+        counterclockwise: false,
+      })
+    })
+
+    it('should add ellipse command without counterclockwise parameter', () => {
+      controller.ellipse(100, 100, 80, 40, Math.PI / 4, 0, Math.PI)
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({
+        type: 'ellipse',
+        x: 100,
+        y: 100,
+        radiusX: 80,
+        radiusY: 40,
+        rotation: Math.PI / 4,
+        startAngle: 0,
+        endAngle: Math.PI,
+        counterclockwise: undefined,
+      })
+    })
+
+    it('should add ellipse command with counterclockwise true', () => {
+      controller.ellipse(150, 150, 60, 30, 0, 0, Math.PI / 2, true)
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({
+        type: 'ellipse',
+        x: 150,
+        y: 150,
+        radiusX: 60,
+        radiusY: 30,
+        rotation: 0,
+        startAngle: 0,
+        endAngle: Math.PI / 2,
+        counterclockwise: true,
+      })
+    })
+
+    it('should add ellipse command with rotation', () => {
+      controller.ellipse(200, 200, 100, 50, Math.PI / 6, 0, Math.PI * 2)
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({
+        type: 'ellipse',
+        x: 200,
+        y: 200,
+        radiusX: 100,
+        radiusY: 50,
+        rotation: Math.PI / 6,
+        startAngle: 0,
+        endAngle: Math.PI * 2,
+        counterclockwise: undefined,
+      })
+    })
+
+    it('should add ellipse command with partial arc', () => {
+      controller.ellipse(100, 100, 50, 25, 0, Math.PI / 4, Math.PI * 3 / 4)
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({
+        type: 'ellipse',
+        x: 100,
+        y: 100,
+        radiusX: 50,
+        radiusY: 25,
+        rotation: 0,
+        startAngle: Math.PI / 4,
+        endAngle: Math.PI * 3 / 4,
+        counterclockwise: undefined,
+      })
+    })
+  })
+
+  describe('roundRect', () => {
+    it('should add roundRect command with single radius value', () => {
+      controller.roundRect(50, 50, 200, 100, 15)
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({
+        type: 'roundRect',
+        x: 50,
+        y: 50,
+        width: 200,
+        height: 100,
+        radii: 15,
+      })
+    })
+
+    it('should add roundRect command with array of radii', () => {
+      controller.roundRect(100, 100, 150, 80, [10, 20, 30, 40])
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({
+        type: 'roundRect',
+        x: 100,
+        y: 100,
+        width: 150,
+        height: 80,
+        radii: [10, 20, 30, 40],
+      })
+    })
+
+    it('should add roundRect command with single-element radii array', () => {
+      controller.roundRect(0, 0, 100, 50, [25])
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({
+        type: 'roundRect',
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 50,
+        radii: [25],
+      })
+    })
+
+    it('should add roundRect command with two-element radii array', () => {
+      controller.roundRect(10, 20, 200, 100, [10, 20])
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({
+        type: 'roundRect',
+        x: 10,
+        y: 20,
+        width: 200,
+        height: 100,
+        radii: [10, 20],
+      })
+    })
+
+    it('should add roundRect command with three-element radii array', () => {
+      controller.roundRect(30, 40, 180, 90, [5, 10, 15])
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({
+        type: 'roundRect',
+        x: 30,
+        y: 40,
+        width: 180,
+        height: 90,
+        radii: [5, 10, 15],
+      })
+    })
+
+    it('should add roundRect command with zero radius', () => {
+      controller.roundRect(0, 0, 100, 100, 0)
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({
+        type: 'roundRect',
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100,
+        radii: 0,
+      })
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Implements issue #419 - adds `ellipse()` and `round_rect()` path commands to the canvas API.

**New Functions:**
- `canvas.ellipse(x, y, radiusX, radiusY, rotation?, startAngle?, endAngle?, counterclockwise?)` - Draw ellipses and partial ellipse arcs with optional rotation
- `canvas.round_rect(x, y, width, height, radii)` - Draw rounded rectangles with flexible corner radii (single value or table of 1-4 values)

**Files Changed:**
- Types: Added `EllipseCommand`, `RoundRectCommand` in `types.ts`
- Renderer: Added cases in `CanvasRenderer.ts`
- Controller: Added methods in `CanvasController.ts`
- Bindings: Added JS bridge in `setupCanvasAPI.ts`
- Lua wrapper: Added functions in `canvasLuaWrapper.ts`
- Documentation: Updated `canvas.lua` LuaDoc and `docs/canvas.md`
- Examples: Created `ellipse-shapes.lua` and `rounded-buttons.lua`
- Manifest: Added new example entries

## Test plan

- [x] All 88 CanvasRenderer tests passing (11 new)
- [x] All 39 CanvasController path tests passing (11 new)
- [x] Mutation test coverage: 80.7% for CanvasRenderer.ts
- [x] Examples work correctly in canvas mode

**Part of Epic #415 - Complete Canvas 2D API Implementation (5/17 complete)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)