### PR TITLE
feat(canvas): Implement clipping (clip) (#420)

### DIFF
--- a/EPIC-415.md
+++ b/EPIC-415.md
@@ -40,7 +40,7 @@ Key considerations:
 | #417 | Implement arc and arcTo for path API | ✅ Complete | 417-implement-arc-and-arcto-for-path-api | Merged PR #438 |
 | #418 | Implement Bezier curves (bezierCurveTo, quadraticCurveTo) | ✅ Complete | epic-415 | Direct commit to epic branch |
 | #419 | Implement ellipse() and roundRect() | ✅ Complete | 419-ellipse-roundrect | - |
-| #420 | Implement clipping (clip) | ⏳ Pending | - | - |
+| #420 | Implement clipping (clip) | 🔄 In Progress | 420-clipping | - |
 | #421 | Implement line styles (lineCap, lineJoin, miterLimit) | ⏳ Pending | - | - |
 | #422 | Implement dashed lines (setLineDash, getLineDash, lineDashOffset) | ⏳ Pending | - | - |
 | #424 | Implement linear and radial gradients | ⏳ Pending | - | - |
@@ -93,6 +93,11 @@ Key considerations:
   - Updated docs/canvas.md and canvas.lua LuaDoc
   - Updated manifest.json with new examples
   - Branch: 419-ellipse-roundrect
+- #420 Clipping in progress
+  - Added clip() path command with optional fillRule parameter
+  - Mutation score: CanvasRenderer 80.7%
+  - Created 1 example: clipping-demo.lua
+  - Branch: 420-clipping
 
 ## Key Files
 

--- a/lua-learning-website/public/docs/canvas.md
+++ b/lua-learning-website/public/docs/canvas.md
@@ -354,6 +354,31 @@ canvas.set_color("#000000")
 canvas.stroke()
 ```
 
+### canvas.clip(fillRule?)
+
+Clip all future drawing to the current path. Creates a clipping region from the current path - all subsequent drawing is constrained to this region.
+
+**Parameters:**
+- `fillRule` (string, optional): "nonzero" (default) or "evenodd"
+
+**Important:** Clipping can only shrink the region, not expand it. Use `save()` before clipping and `restore()` to remove the clipping region.
+
+```lua
+-- Create a circular viewport
+canvas.save()
+canvas.begin_path()
+canvas.arc(200, 200, 80, 0, math.pi * 2)
+canvas.clip()
+
+-- Draw a pattern (clipped to circle)
+canvas.set_color(255, 100, 100)
+for i = 0, 400, 20 do
+  canvas.fill_rect(0, i, 400, 10)
+end
+
+canvas.restore()  -- Remove clipping
+```
+
 ## Transformation Functions
 
 Transformations allow you to translate, rotate, and scale the canvas coordinate system.

--- a/lua-learning-website/public/examples/canvas/clipping-demo.lua
+++ b/lua-learning-website/public/examples/canvas/clipping-demo.lua
@@ -1,0 +1,169 @@
+-- Clipping Demo
+-- Demonstrates canvas.clip() for constraining drawing regions
+
+local canvas = require("canvas")
+
+local time = 0
+
+canvas.tick(function()
+  canvas.clear()
+  time = time + canvas.get_delta()
+
+  -- Title
+  canvas.set_color(50, 50, 50)
+  canvas.set_font_size(20)
+  canvas.draw_text(10, 10, "Clipping Demo")
+
+  -- ===========================================
+  -- Example 1: Circular Viewport
+  -- ===========================================
+  canvas.set_font_size(14)
+  canvas.set_color(100, 100, 100)
+  canvas.draw_text(50, 50, "Circular Viewport")
+
+  canvas.save()
+
+  -- Create circular clipping region
+  canvas.begin_path()
+  canvas.arc(120, 130, 50, 0, math.pi * 2)
+  canvas.clip()
+
+  -- Draw horizontal stripes (clipped to circle)
+  for i = 0, 200, 10 do
+    local hue = (i + time * 50) % 200
+    canvas.set_color(200 - hue, 100, hue + 55)
+    canvas.fill_rect(50, 60 + i, 140, 5)
+  end
+
+  canvas.restore()  -- Remove clipping
+
+  -- Draw circle outline (not clipped)
+  canvas.set_color(0, 0, 0)
+  canvas.set_line_width(2)
+  canvas.begin_path()
+  canvas.arc(120, 130, 50, 0, math.pi * 2)
+  canvas.stroke()
+
+  -- ===========================================
+  -- Example 2: Star Mask
+  -- ===========================================
+  canvas.set_color(100, 100, 100)
+  canvas.draw_text(220, 50, "Star Clipping")
+
+  canvas.save()
+
+  -- Create star-shaped clipping region
+  canvas.begin_path()
+  local cx, cy = 290, 130
+  local outerR, innerR = 50, 20
+  local points = 5
+
+  for i = 0, points * 2 - 1 do
+    local angle = (i * math.pi / points) - math.pi / 2
+    local r = (i % 2 == 0) and outerR or innerR
+    local px = cx + r * math.cos(angle)
+    local py = cy + r * math.sin(angle)
+    if i == 0 then
+      canvas.move_to(px, py)
+    else
+      canvas.line_to(px, py)
+    end
+  end
+  canvas.close_path()
+  canvas.clip()
+
+  -- Draw gradient background (clipped to star)
+  for y = 60, 200, 2 do
+    local t = (y - 60) / 140
+    canvas.set_color(255 * (1 - t), 100, 255 * t)
+    canvas.fill_rect(220, y, 140, 2)
+  end
+
+  canvas.restore()
+
+  -- Draw star outline
+  canvas.set_color(0, 0, 0)
+  canvas.set_line_width(2)
+  canvas.begin_path()
+  for i = 0, points * 2 - 1 do
+    local angle = (i * math.pi / points) - math.pi / 2
+    local r = (i % 2 == 0) and outerR or innerR
+    local px = cx + r * math.cos(angle)
+    local py = cy + r * math.sin(angle)
+    if i == 0 then
+      canvas.move_to(px, py)
+    else
+      canvas.line_to(px, py)
+    end
+  end
+  canvas.close_path()
+  canvas.stroke()
+
+  -- ===========================================
+  -- Example 3: Animated Reveal
+  -- ===========================================
+  canvas.set_color(100, 100, 100)
+  canvas.draw_text(50, 210, "Animated Reveal")
+
+  canvas.save()
+
+  -- Animated circular clip that grows and shrinks
+  local radius = 30 + 20 * math.sin(time * 2)
+  canvas.begin_path()
+  canvas.arc(120, 280, radius, 0, math.pi * 2)
+  canvas.clip()
+
+  -- Draw checkerboard (clipped)
+  for row = 0, 8 do
+    for col = 0, 8 do
+      if (row + col) % 2 == 0 then
+        canvas.set_color(70, 130, 180)
+      else
+        canvas.set_color(255, 215, 0)
+      end
+      canvas.fill_rect(60 + col * 15, 220 + row * 15, 15, 15)
+    end
+  end
+
+  canvas.restore()
+
+  -- ===========================================
+  -- Example 4: Nested Clipping
+  -- ===========================================
+  canvas.set_color(100, 100, 100)
+  canvas.draw_text(220, 210, "Nested Clips")
+
+  canvas.save()
+
+  -- Outer rectangle clip
+  canvas.begin_path()
+  canvas.round_rect(230, 230, 120, 100, 10)
+  canvas.clip()
+
+  -- Draw base color
+  canvas.set_color(200, 200, 220)
+  canvas.fill_rect(230, 230, 120, 100)
+
+  canvas.save()
+
+  -- Inner circle clip (intersects with rectangle)
+  canvas.begin_path()
+  canvas.arc(290, 280, 40, 0, math.pi * 2)
+  canvas.clip()
+
+  -- Draw spinning lines (double-clipped)
+  for i = 0, 11 do
+    local angle = time + (i * math.pi / 6)
+    canvas.set_color(255 * (i / 12), 100, 255 * (1 - i / 12))
+    canvas.set_line_width(3)
+    canvas.begin_path()
+    canvas.move_to(290, 280)
+    canvas.line_to(290 + 60 * math.cos(angle), 280 + 60 * math.sin(angle))
+    canvas.stroke()
+  end
+
+  canvas.restore()  -- Remove inner clip
+  canvas.restore()  -- Remove outer clip
+end)
+
+canvas.start()

--- a/lua-learning-website/public/examples/manifest.json
+++ b/lua-learning-website/public/examples/manifest.json
@@ -33,6 +33,7 @@
     "canvas/quadratic-curves.lua",
     "canvas/ellipse-shapes.lua",
     "canvas/rounded-buttons.lua",
+    "canvas/clipping-demo.lua",
     "canvas/fonts/10px-Bitfantasy.ttf",
     "canvas/fonts/10px-CelticTime.ttf",
     "canvas/fonts/10px-HelvetiPixel.ttf",

--- a/packages/canvas-runtime/src/renderer/CanvasRenderer.ts
+++ b/packages/canvas-runtime/src/renderer/CanvasRenderer.ts
@@ -192,6 +192,14 @@ export class CanvasRenderer {
         this.ctx.roundRect(command.x, command.y, command.width, command.height, command.radii);
         break;
 
+      case 'clip':
+        if (command.fillRule) {
+          this.ctx.clip(command.fillRule);
+        } else {
+          this.ctx.clip();
+        }
+        break;
+
       default:
         // Ignore unknown commands for forward compatibility
         break;

--- a/packages/canvas-runtime/src/shared/types.ts
+++ b/packages/canvas-runtime/src/shared/types.ts
@@ -34,7 +34,8 @@ export type DrawCommandType =
   | 'quadraticCurveTo'
   | 'bezierCurveTo'
   | 'ellipse'
-  | 'roundRect';
+  | 'roundRect'
+  | 'clip';
 
 /**
  * Base interface for all draw commands.
@@ -429,6 +430,16 @@ export interface RoundRectCommand extends DrawCommandBase {
 }
 
 /**
+ * Clip all future drawing to the current path.
+ * Use with save()/restore() to manage clipping regions.
+ */
+export interface ClipCommand extends DrawCommandBase {
+  type: 'clip';
+  /** Fill rule: "nonzero" (default) or "evenodd" */
+  fillRule?: 'nonzero' | 'evenodd';
+}
+
+/**
  * Union type of all draw commands.
  */
 export type DrawCommand =
@@ -464,7 +475,8 @@ export type DrawCommand =
   | QuadraticCurveToCommand
   | BezierCurveToCommand
   | EllipseCommand
-  | RoundRectCommand;
+  | RoundRectCommand
+  | ClipCommand;
 
 /**
  * Mouse button identifiers.

--- a/packages/canvas-runtime/tests/renderer/CanvasRenderer.test.ts
+++ b/packages/canvas-runtime/tests/renderer/CanvasRenderer.test.ts
@@ -20,6 +20,7 @@ function createMockContext(): CanvasRenderingContext2D {
     bezierCurveTo: vi.fn(),
     ellipse: vi.fn(),
     roundRect: vi.fn(),
+    clip: vi.fn(),
     fill: vi.fn(),
     stroke: vi.fn(),
     moveTo: vi.fn(),
@@ -1063,6 +1064,38 @@ describe('CanvasRenderer', () => {
       renderer.render(commands);
 
       expect(mockCtx.roundRect).toHaveBeenCalledWith(0, 0, 100, 100, 0);
+    });
+  });
+
+  describe('clip command', () => {
+    it('should call ctx.clip() with no fill rule', () => {
+      const commands: DrawCommand[] = [
+        { type: 'clip' },
+      ];
+
+      renderer.render(commands);
+
+      expect(mockCtx.clip).toHaveBeenCalledWith();
+    });
+
+    it('should call ctx.clip() with nonzero fill rule', () => {
+      const commands: DrawCommand[] = [
+        { type: 'clip', fillRule: 'nonzero' },
+      ];
+
+      renderer.render(commands);
+
+      expect(mockCtx.clip).toHaveBeenCalledWith('nonzero');
+    });
+
+    it('should call ctx.clip() with evenodd fill rule', () => {
+      const commands: DrawCommand[] = [
+        { type: 'clip', fillRule: 'evenodd' },
+      ];
+
+      renderer.render(commands);
+
+      expect(mockCtx.clip).toHaveBeenCalledWith('evenodd');
     });
   });
 });

--- a/packages/lua-runtime/src/CanvasController.ts
+++ b/packages/lua-runtime/src/CanvasController.ts
@@ -583,6 +583,15 @@ export class CanvasController {
     this.addDrawCommand({ type: 'roundRect', x, y, width, height, radii })
   }
 
+  /**
+   * Clip all future drawing to the current path.
+   * Use with save()/restore() to manage clipping regions.
+   * @param fillRule - Fill rule: "nonzero" (default) or "evenodd"
+   */
+  clip(fillRule?: 'nonzero' | 'evenodd'): void {
+    this.addDrawCommand({ type: 'clip', fillRule })
+  }
+
   // --- Timing API ---
 
   /**

--- a/packages/lua-runtime/src/canvasLuaWrapper.ts
+++ b/packages/lua-runtime/src/canvasLuaWrapper.ts
@@ -284,6 +284,10 @@ export const canvasLuaCode = `
       __canvas_roundRect(x, y, width, height, radii)
     end
 
+    function _canvas.clip(fillRule)
+      __canvas_clip(fillRule)
+    end
+
     -- Timing
     function _canvas.get_delta()
       return __canvas_getDelta()

--- a/packages/lua-runtime/src/lua/canvas.lua
+++ b/packages/lua-runtime/src/lua/canvas.lua
@@ -723,4 +723,20 @@ function canvas.ellipse(x, y, radiusX, radiusY, rotation, startAngle, endAngle, 
 ---@usage -- {r1, r2, r3, r4} - top-left, top-right, bottom-right, bottom-left
 function canvas.round_rect(x, y, width, height, radii) end
 
+--- Clip all future drawing to the current path.
+--- Creates a clipping region from the current path. All subsequent drawing
+--- operations will be constrained to this region. Use save()/restore()
+--- to manage clipping regions - clipping can only shrink, not expand.
+---@param fillRule? string Fill rule: "nonzero" (default) or "evenodd"
+---@return nil
+---@usage -- Create a circular viewport
+---@usage canvas.save()
+---@usage canvas.begin_path()
+---@usage canvas.arc(200, 200, 100, 0, math.pi * 2)
+---@usage canvas.clip()
+---@usage -- All drawing now clipped to the circle
+---@usage canvas.fill_rect(0, 0, 400, 400)  -- Only circle area is filled
+---@usage canvas.restore()  -- Remove clipping
+function canvas.clip(fillRule) end
+
 return canvas

--- a/packages/lua-runtime/src/setupCanvasAPI.ts
+++ b/packages/lua-runtime/src/setupCanvasAPI.ts
@@ -268,6 +268,10 @@ export function setupCanvasAPI(
     getController()?.roundRect(x, y, width, height, radii)
   })
 
+  engine.global.set('__canvas_clip', (fillRule?: string) => {
+    getController()?.clip(fillRule as 'nonzero' | 'evenodd' | undefined)
+  })
+
   // --- Set up Lua-side canvas table ---
   // Canvas is NOT a global - it must be accessed via require('canvas')
   engine.doStringSync(canvasLuaCode)

--- a/packages/lua-runtime/tests/CanvasController.path.test.ts
+++ b/packages/lua-runtime/tests/CanvasController.path.test.ts
@@ -649,4 +649,39 @@ describe('CanvasController Path API', () => {
       })
     })
   })
+
+  describe('clip', () => {
+    it('should add clip command with no fill rule', () => {
+      controller.clip()
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({
+        type: 'clip',
+        fillRule: undefined,
+      })
+    })
+
+    it('should add clip command with nonzero fill rule', () => {
+      controller.clip('nonzero')
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({
+        type: 'clip',
+        fillRule: 'nonzero',
+      })
+    })
+
+    it('should add clip command with evenodd fill rule', () => {
+      controller.clip('evenodd')
+
+      const commands = controller.getFrameCommands()
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toEqual({
+        type: 'clip',
+        fillRule: 'evenodd',
+      })
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- Add `clip()` path command to constrain all future drawing to the current path
- Completes Phase 2: Path Extensions for Epic #415
- Optional `fillRule` parameter: "nonzero" (default) or "evenodd"

## Changes

- **ClipCommand** type added to types.ts
- **CanvasRenderer** case for clip command
- **CanvasController** `clip()` method
- **Lua API** `canvas.clip(fillRule?)` function
- **LuaDoc** annotations in canvas.lua
- **Documentation** updated in canvas.md
- **Example** clipping-demo.lua (circular viewport, star mask, animated reveal, nested clips)

## Test plan

- [x] CanvasRenderer tests (91 passing, 3 new)
- [x] CanvasController tests (42 passing, 3 new)
- [x] Mutation test coverage: 80.7%
- [x] Build succeeds

## Closes

Closes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)