### PR TITLE
feat(canvas): Implement conic gradients (#425)

### DIFF
--- a/lua-learning-website/public/docs/canvas.md
+++ b/lua-learning-website/public/docs/canvas.md
@@ -372,6 +372,45 @@ sphere:add_color_stop(0.3, "#4dabf7") -- Light blue
 sphere:add_color_stop(1, "#1864ab")   -- Dark blue
 ```
 
+### canvas.create_conic_gradient(startAngle, x, y)
+
+Create a conic (angular) gradient that sweeps colors around a center point. Perfect for color wheels, pie charts, and circular progress indicators.
+
+**Parameters:**
+- `startAngle` (number): Starting angle in radians (0 = right, PI/2 = down, PI = left)
+- `x` (number): Center X coordinate
+- `y` (number): Center Y coordinate
+
+**Returns:**
+- (Gradient): A gradient object
+
+```lua
+-- Color wheel (full spectrum)
+local wheel = canvas.create_conic_gradient(0, 200, 200)
+wheel:add_color_stop(0, "#FF0000")     -- Red
+wheel:add_color_stop(0.17, "#FFFF00")  -- Yellow
+wheel:add_color_stop(0.33, "#00FF00")  -- Green
+wheel:add_color_stop(0.5, "#00FFFF")   -- Cyan
+wheel:add_color_stop(0.67, "#0000FF")  -- Blue
+wheel:add_color_stop(0.83, "#FF00FF")  -- Magenta
+wheel:add_color_stop(1, "#FF0000")     -- Back to red
+canvas.set_fill_style(wheel)
+canvas.begin_path()
+canvas.arc(200, 200, 100, 0, math.pi * 2)
+canvas.fill()
+
+-- Pie chart (start from top with -PI/2)
+local pie = canvas.create_conic_gradient(-math.pi/2, 200, 200)
+pie:add_color_stop(0, "#4dabf7")    -- Blue (30%)
+pie:add_color_stop(0.3, "#4dabf7")
+pie:add_color_stop(0.3, "#ff6b6b")  -- Red (50%)
+pie:add_color_stop(0.8, "#ff6b6b")
+pie:add_color_stop(0.8, "#51cf66")  -- Green (20%)
+pie:add_color_stop(1, "#51cf66")
+canvas.set_fill_style(pie)
+canvas.fill_circle(200, 200, 80)
+```
+
 ### Gradient:add_color_stop(offset, color)
 
 Add a color stop to a gradient. Color stops define where colors appear along the gradient. Returns the gradient for method chaining.

--- a/lua-learning-website/public/examples/canvas/conic-gradient.lua
+++ b/lua-learning-website/public/examples/canvas/conic-gradient.lua
@@ -1,0 +1,48 @@
+-- Conic Gradient Demo
+-- Demonstrates conic gradients for color wheels and pie charts
+
+local canvas = require("canvas")
+
+canvas.set_size(400, 400)
+
+canvas.tick(function()
+  canvas.clear()
+
+  -- Dark background
+  canvas.set_fill_style("#1a1a2e")
+  canvas.fill_rect(0, 0, 400, 400)
+
+  -- Color wheel (full spectrum)
+  local wheel = canvas.create_conic_gradient(0, 200, 150)
+  wheel:add_color_stop(0, "#FF0000")
+  wheel:add_color_stop(0.17, "#FFFF00")
+  wheel:add_color_stop(0.33, "#00FF00")
+  wheel:add_color_stop(0.5, "#00FFFF")
+  wheel:add_color_stop(0.67, "#0000FF")
+  wheel:add_color_stop(0.83, "#FF00FF")
+  wheel:add_color_stop(1, "#FF0000")
+  canvas.set_fill_style(wheel)
+  canvas.begin_path()
+  canvas.arc(200, 150, 100, 0, math.pi * 2)
+  canvas.fill()
+
+  -- Pie chart style (offset start angle to start from top)
+  local pie = canvas.create_conic_gradient(-math.pi/2, 200, 320)
+  pie:add_color_stop(0, "#4dabf7")
+  pie:add_color_stop(0.3, "#4dabf7")
+  pie:add_color_stop(0.3, "#ff6b6b")
+  pie:add_color_stop(0.6, "#ff6b6b")
+  pie:add_color_stop(0.6, "#51cf66")
+  pie:add_color_stop(1, "#51cf66")
+  canvas.set_fill_style(pie)
+  canvas.begin_path()
+  canvas.arc(200, 320, 60, 0, math.pi * 2)
+  canvas.fill()
+
+  -- Title
+  canvas.set_fill_style("#ffffff")
+  canvas.set_font_size(20)
+  canvas.draw_text(120, 20, "Conic Gradients")
+end)
+
+canvas.start()

--- a/lua-learning-website/public/examples/manifest.json
+++ b/lua-learning-website/public/examples/manifest.json
@@ -38,6 +38,7 @@
     "canvas/dashed-lines.lua",
     "canvas/linear-gradient.lua",
     "canvas/radial-gradient.lua",
+    "canvas/conic-gradient.lua",
     "canvas/fonts/10px-Bitfantasy.ttf",
     "canvas/fonts/10px-CelticTime.ttf",
     "canvas/fonts/10px-HelvetiPixel.ttf",

--- a/packages/canvas-runtime/src/renderer/CanvasRenderer.ts
+++ b/packages/canvas-runtime/src/renderer/CanvasRenderer.ts
@@ -316,8 +316,11 @@ export class CanvasRenderer {
     let gradient: CanvasGradient;
     if (def.type === 'linear') {
       gradient = this.ctx.createLinearGradient(def.x0, def.y0, def.x1, def.y1);
-    } else {
+    } else if (def.type === 'radial') {
       gradient = this.ctx.createRadialGradient(def.x0, def.y0, def.r0, def.x1, def.y1, def.r1);
+    } else {
+      // conic gradient
+      gradient = this.ctx.createConicGradient(def.startAngle, def.x, def.y);
     }
     for (const stop of def.stops) {
       gradient.addColorStop(stop.offset, stop.color);

--- a/packages/canvas-runtime/src/shared/index.ts
+++ b/packages/canvas-runtime/src/shared/index.ts
@@ -21,6 +21,7 @@ export type {
   GradientColorStop,
   LinearGradientDef,
   RadialGradientDef,
+  ConicGradientDef,
   GradientDef,
   FillStyle,
 } from './types.js';

--- a/packages/canvas-runtime/src/shared/types.ts
+++ b/packages/canvas-runtime/src/shared/types.ts
@@ -550,9 +550,24 @@ export interface RadialGradientDef {
 }
 
 /**
+ * Definition for a conic (angular) gradient.
+ */
+export interface ConicGradientDef {
+  type: 'conic';
+  /** Starting angle in radians (0 = right, PI/2 = down) */
+  startAngle: number;
+  /** Center X coordinate */
+  x: number;
+  /** Center Y coordinate */
+  y: number;
+  /** Color stops */
+  stops: GradientColorStop[];
+}
+
+/**
  * Union type for gradient definitions.
  */
-export type GradientDef = LinearGradientDef | RadialGradientDef;
+export type GradientDef = LinearGradientDef | RadialGradientDef | ConicGradientDef;
 
 /**
  * Fill or stroke style - can be a CSS color string or gradient definition.

--- a/packages/canvas-runtime/tests/renderer/CanvasRenderer.test.ts
+++ b/packages/canvas-runtime/tests/renderer/CanvasRenderer.test.ts
@@ -56,6 +56,7 @@ function createMockContext(): CanvasRenderingContext2D {
     // Gradient methods
     createLinearGradient: vi.fn(() => createMockGradient()),
     createRadialGradient: vi.fn(() => createMockGradient()),
+    createConicGradient: vi.fn(() => createMockGradient()),
   } as unknown as CanvasRenderingContext2D;
 }
 
@@ -1375,6 +1376,35 @@ describe('CanvasRenderer', () => {
       expect(mockCtx.fillStyle).toBe(mockGradient);
     });
 
+    it('should create and set conic gradient as fillStyle', () => {
+      const mockGradient = createMockGradient();
+      (mockCtx.createConicGradient as ReturnType<typeof vi.fn>).mockReturnValue(mockGradient);
+
+      const commands: DrawCommand[] = [
+        {
+          type: 'setFillStyle',
+          style: {
+            type: 'conic',
+            startAngle: 0,
+            x: 200, y: 200,
+            stops: [
+              { offset: 0, color: '#ff0000' },
+              { offset: 0.5, color: '#00ff00' },
+              { offset: 1, color: '#0000ff' },
+            ],
+          },
+        },
+      ];
+
+      renderer.render(commands);
+
+      expect(mockCtx.createConicGradient).toHaveBeenCalledWith(0, 200, 200);
+      expect(mockGradient.addColorStop).toHaveBeenCalledWith(0, '#ff0000');
+      expect(mockGradient.addColorStop).toHaveBeenCalledWith(0.5, '#00ff00');
+      expect(mockGradient.addColorStop).toHaveBeenCalledWith(1, '#0000ff');
+      expect(mockCtx.fillStyle).toBe(mockGradient);
+    });
+
     it('should handle gradient with empty stops array', () => {
       const mockGradient = createMockGradient();
       (mockCtx.createLinearGradient as ReturnType<typeof vi.fn>).mockReturnValue(mockGradient);
@@ -1473,6 +1503,33 @@ describe('CanvasRenderer', () => {
       expect(mockCtx.createRadialGradient).toHaveBeenCalledWith(50, 50, 10, 50, 50, 100);
       expect(mockGradient.addColorStop).toHaveBeenCalledWith(0, '#ffffff');
       expect(mockGradient.addColorStop).toHaveBeenCalledWith(1, '#000000');
+      expect(mockCtx.strokeStyle).toBe(mockGradient);
+    });
+
+    it('should create and set conic gradient as strokeStyle', () => {
+      const mockGradient = createMockGradient();
+      (mockCtx.createConicGradient as ReturnType<typeof vi.fn>).mockReturnValue(mockGradient);
+
+      const commands: DrawCommand[] = [
+        {
+          type: 'setStrokeStyle',
+          style: {
+            type: 'conic',
+            startAngle: Math.PI / 2,
+            x: 100, y: 100,
+            stops: [
+              { offset: 0, color: 'blue' },
+              { offset: 1, color: 'red' },
+            ],
+          },
+        },
+      ];
+
+      renderer.render(commands);
+
+      expect(mockCtx.createConicGradient).toHaveBeenCalledWith(Math.PI / 2, 100, 100);
+      expect(mockGradient.addColorStop).toHaveBeenCalledWith(0, 'blue');
+      expect(mockGradient.addColorStop).toHaveBeenCalledWith(1, 'red');
       expect(mockCtx.strokeStyle).toBe(mockGradient);
     });
   });

--- a/packages/lua-runtime/src/canvasLuaWrapper.ts
+++ b/packages/lua-runtime/src/canvasLuaWrapper.ts
@@ -351,6 +351,15 @@ export const canvasLuaCode = `
       }, GradientMT)
     end
 
+    function _canvas.create_conic_gradient(startAngle, x, y)
+      return setmetatable({
+        type = "conic",
+        startAngle = startAngle,
+        x = x, y = y,
+        stops = {}
+      }, GradientMT)
+    end
+
     function _canvas.set_fill_style(style)
       __canvas_setFillStyle(style)
     end

--- a/packages/lua-runtime/src/lua/canvas.lua
+++ b/packages/lua-runtime/src/lua/canvas.lua
@@ -166,10 +166,10 @@ function canvas.set_line_dash_offset(offset) end
 -- =============================================================================
 
 --- Gradient object for creating smooth color transitions.
---- Create with create_linear_gradient() or create_radial_gradient(),
+--- Create with create_linear_gradient(), create_radial_gradient(), or create_conic_gradient(),
 --- then add color stops and apply with set_fill_style() or set_stroke_style().
 ---@class Gradient
----@field type string Gradient type: "linear" or "radial"
+---@field type string Gradient type: "linear", "radial", or "conic"
 ---@field stops table[] Array of color stops
 
 --- Add a color stop to the gradient.
@@ -234,10 +234,44 @@ function canvas.create_linear_gradient(x0, y0, x1, y1) end
 ---@usage canvas.fill_circle(200, 200, 80)
 function canvas.create_radial_gradient(x0, y0, r0, x1, y1, r1) end
 
+--- Create a conic (angular) gradient.
+--- Conic gradients transition colors around a center point, sweeping like a radar.
+--- Perfect for color wheels, pie charts, and circular progress indicators.
+--- The gradient starts at startAngle and rotates clockwise.
+---@param startAngle number Starting angle in radians (0 = right, PI/2 = down, PI = left)
+---@param x number Center X coordinate
+---@param y number Center Y coordinate
+---@return Gradient gradient The gradient object
+---@usage -- Color wheel (full spectrum)
+---@usage local wheel = canvas.create_conic_gradient(0, 200, 200)
+---@usage wheel:add_color_stop(0, "#FF0000")     -- Red
+---@usage wheel:add_color_stop(0.17, "#FFFF00")  -- Yellow
+---@usage wheel:add_color_stop(0.33, "#00FF00")  -- Green
+---@usage wheel:add_color_stop(0.5, "#00FFFF")   -- Cyan
+---@usage wheel:add_color_stop(0.67, "#0000FF")  -- Blue
+---@usage wheel:add_color_stop(0.83, "#FF00FF")  -- Magenta
+---@usage wheel:add_color_stop(1, "#FF0000")     -- Back to red
+---@usage canvas.set_fill_style(wheel)
+---@usage canvas.begin_path()
+---@usage canvas.arc(200, 200, 100, 0, math.pi * 2)
+---@usage canvas.fill()
+---@usage
+---@usage -- Pie chart (start from top with -PI/2)
+---@usage local pie = canvas.create_conic_gradient(-math.pi/2, 200, 200)
+---@usage pie:add_color_stop(0, "#4dabf7")    -- Blue (30%)
+---@usage pie:add_color_stop(0.3, "#4dabf7")
+---@usage pie:add_color_stop(0.3, "#ff6b6b")  -- Red (50%)
+---@usage pie:add_color_stop(0.8, "#ff6b6b")
+---@usage pie:add_color_stop(0.8, "#51cf66")  -- Green (20%)
+---@usage pie:add_color_stop(1, "#51cf66")
+---@usage canvas.set_fill_style(pie)
+---@usage canvas.fill_circle(200, 200, 80)
+function canvas.create_conic_gradient(startAngle, x, y) end
+
 --- Set the fill style (color or gradient).
 --- Affects all subsequent fill operations (fill_rect, fill_circle, fill).
---- Can be a CSS color string or a gradient created with create_linear_gradient
---- or create_radial_gradient.
+--- Can be a CSS color string or a gradient created with create_linear_gradient,
+--- create_radial_gradient, or create_conic_gradient.
 ---@param style string|Gradient CSS color string or gradient object
 ---@return nil
 ---@usage -- Simple color
@@ -255,8 +289,8 @@ function canvas.set_fill_style(style) end
 
 --- Set the stroke style (color or gradient).
 --- Affects all subsequent stroke operations (stroke, draw_rect, draw_circle, draw_line).
---- Can be a CSS color string or a gradient created with create_linear_gradient
---- or create_radial_gradient.
+--- Can be a CSS color string or a gradient created with create_linear_gradient,
+--- create_radial_gradient, or create_conic_gradient.
 ---@param style string|Gradient CSS color string or gradient object
 ---@return nil
 ---@usage -- Simple color

--- a/packages/lua-runtime/src/setupCanvasAPI.ts
+++ b/packages/lua-runtime/src/setupCanvasAPI.ts
@@ -311,7 +311,7 @@ export function setupCanvasAPI(
   // --- Fill/Stroke Style API functions ---
   /**
    * Convert a Lua style value (string or gradient table) to a JavaScript FillStyle.
-   * Gradient tables have: type, x0, y0, x1, y1, r0?, r1?, stops[]
+   * Gradient tables have: type, x0, y0, x1, y1, r0?, r1?, startAngle?, x?, y?, stops[]
    */
   const convertLuaStyleToJS = (style: unknown): import('@lua-learning/canvas-runtime').FillStyle => {
     // String colors pass through directly
@@ -322,7 +322,7 @@ export function setupCanvasAPI(
     // Gradient table: convert from Lua proxy to JS object
     if (style && typeof style === 'object') {
       const luaTable = style as Record<string, unknown>
-      const type = luaTable.type as 'linear' | 'radial'
+      const type = luaTable.type as 'linear' | 'radial' | 'conic'
 
       // Convert stops array from Lua table proxy
       const luaStops = luaTable.stops as Record<number, { offset: number; color: string }> | undefined
@@ -356,6 +356,14 @@ export function setupCanvasAPI(
           x1: luaTable.x1 as number,
           y1: luaTable.y1 as number,
           r1: luaTable.r1 as number,
+          stops,
+        }
+      } else if (type === 'conic') {
+        return {
+          type: 'conic',
+          startAngle: luaTable.startAngle as number,
+          x: luaTable.x as number,
+          y: luaTable.y as number,
           stops,
         }
       }


### PR DESCRIPTION
## Summary

- Add `canvas.create_conic_gradient(startAngle, x, y)` for angular gradients
- Works with existing `add_color_stop()` method and style setters
- Extends gradient infrastructure from #424 with minimal changes
- Includes documentation and example (color wheel + pie chart)

## Changes

- **types.ts**: Add `ConicGradientDef` type, extend `GradientDef` union
- **CanvasRenderer.ts**: Handle conic type in `createGradient()`
- **canvasLuaWrapper.ts**: Add `create_conic_gradient()` Lua function
- **setupCanvasAPI.ts**: Handle conic in `convertLuaStyleToJS()`
- **canvas.lua**: Add LuaDoc annotations
- **canvas.md**: Add Conic Gradients documentation section
- **conic-gradient.lua**: New example with color wheel and pie chart
- **manifest.json**: Add example to manifest

## Test plan

- [x] Unit tests pass (2138 tests)
- [x] CanvasRenderer mutation score: 84.93% (>80% threshold)
- [x] Lint clean
- [x] Build successful

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)