### PR TITLE
feat(canvas): Implement compositing (globalAlpha, globalCompositeOperation) (#428)

### DIFF
--- a/EPIC-415.md
+++ b/EPIC-415.md
@@ -1,6 +1,6 @@
 # Epic #415: Epic: Complete Canvas 2D API Implementation
 
-**Status:** In Progress (12/17 complete)
+**Status:** In Progress (13/17 complete)
 **Branch:** epic-415
 **Created:** 2025-12-22
 **Last Updated:** 2025-12-24
@@ -47,7 +47,7 @@ Key considerations:
 | #425 | Implement conic gradients | ✅ Complete | 425-conic-gradients | Merged PR #444 |
 | #426 | Implement patterns (createPattern) | ✅ Complete | epic-415 | Direct commit to epic branch |
 | #427 | Implement shadows (shadowColor, shadowBlur, shadowOffsetX/Y) | ✅ Complete | epic-415 | Direct commit to epic branch |
-| #428 | Implement compositing (globalAlpha, globalCompositeOperation) | ⏳ Pending | - | - |
+| #428 | Implement compositing (globalAlpha, globalCompositeOperation) | ✅ Complete | 428-compositing | - |
 | #429 | Implement text alignment (textAlign, textBaseline) | ⏳ Pending | - | - |
 | #430 | Implement hit testing (isPointInPath, isPointInStroke) | ⏳ Pending | - | - |
 | #431 | Implement pixel manipulation (getImageData, putImageData, createImageData) | ⏳ Pending | - | - |
@@ -142,6 +142,14 @@ Key considerations:
   - Updated docs/canvas.md with Shadows section
   - Updated both canvas.lua files with LuaDoc
   - Committed directly to epic-415 branch
+- #428 Compositing implementation complete
+  - Added 2 compositing commands: setGlobalAlpha, setCompositeOperation
+  - Added GlobalCompositeOperation type with 26 blend modes
+  - Mutation score: CanvasRenderer 84.51%
+  - Created 1 example: compositing-demo.lua
+  - Updated docs/canvas.md with Compositing section
+  - Updated both canvas.lua files with LuaDoc
+  - Created on feature branch 428-compositing
 
 ## Key Files
 

--- a/lua-learning-website/public/docs/canvas.md
+++ b/lua-learning-website/public/docs/canvas.md
@@ -647,6 +647,74 @@ canvas.clear_shadow()
 canvas.fill_rect(200, 50, 100, 100) -- No shadow
 ```
 
+## Compositing
+
+Control transparency and blend modes for layered graphics and visual effects.
+
+### canvas.set_global_alpha(alpha)
+
+Set the global alpha (transparency) for all subsequent drawing. Affects all drawing operations including shapes, text, and images.
+
+**Parameters:**
+- `alpha` (number): Value from 0.0 (fully transparent) to 1.0 (fully opaque)
+
+**Example:**
+```lua
+canvas.set_global_alpha(0.5)  -- 50% transparent
+canvas.set_fill_style("#FF0000")
+canvas.fill_rect(50, 50, 100, 100)  -- Semi-transparent red
+
+canvas.set_global_alpha(1.0)  -- Reset to fully opaque
+```
+
+### canvas.set_composite_operation(operation)
+
+Set the composite operation (blend mode) for all subsequent drawing. Controls how new pixels are combined with existing pixels on the canvas.
+
+**Parameters:**
+- `operation` (string): One of the blend mode names listed below
+
+**Common Blend Modes:**
+
+| Mode | Description |
+|------|-------------|
+| `"source-over"` | Default. Draw new content on top of existing |
+| `"multiply"` | Multiply colors (darkening effect) |
+| `"screen"` | Screen blend (lightening effect) |
+| `"lighter"` | Additive blending (great for glow effects) |
+| `"overlay"` | Overlay blend |
+| `"darken"` | Keep the darker color |
+| `"lighten"` | Keep the lighter color |
+
+**Additional Blend Modes:**
+- `"source-in"`, `"source-out"`, `"source-atop"`
+- `"destination-over"`, `"destination-in"`, `"destination-out"`, `"destination-atop"`
+- `"copy"`, `"xor"`
+- `"color-dodge"`, `"color-burn"`, `"hard-light"`, `"soft-light"`
+- `"difference"`, `"exclusion"`, `"hue"`, `"saturation"`, `"color"`, `"luminosity"`
+
+**Example:**
+```lua
+-- Draw base shapes
+canvas.set_fill_style("#00FF00")
+canvas.fill_circle(100, 100, 50)
+
+-- Multiply blend (darkening)
+canvas.set_composite_operation("multiply")
+canvas.set_fill_style("#FF0000")
+canvas.fill_circle(130, 100, 50)
+
+-- Additive glow effect
+canvas.set_composite_operation("lighter")
+canvas.set_fill_style("#0000FF40")
+for i = 1, 5 do
+    canvas.fill_circle(250, 100, 20 + i * 10)
+end
+
+-- Reset to default
+canvas.set_composite_operation("source-over")
+```
+
 ## Drawing Functions
 
 ### canvas.draw_rect(x, y, width, height)

--- a/lua-learning-website/public/examples/canvas/compositing-demo.lua
+++ b/lua-learning-website/public/examples/canvas/compositing-demo.lua
@@ -1,0 +1,104 @@
+-- Compositing Demo
+-- Demonstrates alpha transparency and blend modes
+
+local canvas = require("canvas")
+
+canvas.set_size(450, 350)
+
+canvas.tick(function()
+  canvas.clear()
+
+  -- Dark background
+  canvas.set_fill_style("#1a1a2e")
+  canvas.fill_rect(0, 0, 450, 350)
+
+  -- Title
+  canvas.set_fill_style("#FFFFFF")
+  canvas.set_font_size(18)
+  canvas.draw_text(20, 30, "Compositing Demo")
+  canvas.set_font_size(12)
+
+  -- Alpha Transparency Section
+  canvas.set_fill_style("#888888")
+  canvas.draw_text(20, 60, "Alpha Transparency:")
+
+  -- Draw overlapping circles with transparency
+  canvas.set_global_alpha(0.6)
+
+  canvas.set_fill_style("#FF6B6B")
+  canvas.fill_circle(60, 110, 40)
+
+  canvas.set_fill_style("#4ECDC4")
+  canvas.fill_circle(100, 110, 40)
+
+  canvas.set_fill_style("#FFE66D")
+  canvas.fill_circle(80, 145, 40)
+
+  canvas.set_global_alpha(1.0) -- Reset
+
+  -- Blend Modes Section
+  canvas.set_fill_style("#888888")
+  canvas.draw_text(180, 60, "Blend Modes:")
+
+  -- Base shape for blend demos
+  local function draw_blend_demo(x, y, mode, label)
+    -- Draw a green base circle
+    canvas.set_composite_operation("source-over")
+    canvas.set_fill_style("#00CC66")
+    canvas.fill_circle(x, y, 25)
+
+    -- Apply blend mode and draw red circle
+    canvas.set_composite_operation(mode)
+    canvas.set_fill_style("#FF4444")
+    canvas.fill_circle(x + 20, y, 25)
+
+    -- Reset and draw label
+    canvas.set_composite_operation("source-over")
+    canvas.set_fill_style("#AAAAAA")
+    canvas.set_font_size(10)
+    canvas.draw_text(x - 20, y + 40, label)
+  end
+
+  draw_blend_demo(220, 110, "multiply", "multiply")
+  draw_blend_demo(320, 110, "screen", "screen")
+  draw_blend_demo(220, 190, "lighter", "lighter")
+  draw_blend_demo(320, 190, "overlay", "overlay")
+
+  -- Glow Effect Demo
+  canvas.set_composite_operation("source-over")
+  canvas.set_fill_style("#888888")
+  canvas.set_font_size(12)
+  canvas.draw_text(20, 210, "Glow Effect (lighter):")
+
+  -- Create glow with lighter blend mode
+  canvas.set_composite_operation("lighter")
+  canvas.set_fill_style("#4400FF20")
+  for i = 1, 6 do
+    canvas.fill_circle(80, 270, 15 + i * 8)
+  end
+
+  -- Bright core
+  canvas.set_fill_style("#8855FF")
+  canvas.fill_circle(80, 270, 15)
+
+  canvas.set_composite_operation("source-over")
+
+  -- Fade Demo
+  canvas.set_fill_style("#888888")
+  canvas.draw_text(180, 250, "Alpha Fade:")
+
+  for i = 0, 4 do
+    canvas.set_global_alpha((i + 1) / 5)
+    canvas.set_fill_style("#FF6B6B")
+    canvas.fill_rect(220 + i * 40, 270, 30, 30)
+  end
+
+  canvas.set_global_alpha(1.0) -- Reset
+
+  -- Instructions
+  canvas.set_fill_style("#666666")
+  canvas.set_font_size(10)
+  canvas.draw_text(20, 340, "Compositing controls how colors blend together")
+end)
+
+canvas.start()

--- a/lua-learning-website/public/examples/manifest.json
+++ b/lua-learning-website/public/examples/manifest.json
@@ -41,6 +41,7 @@
     "canvas/conic-gradient.lua",
     "canvas/pattern-demo.lua",
     "canvas/shadow-demo.lua",
+    "canvas/compositing-demo.lua",
     "canvas/fonts/10px-Bitfantasy.ttf",
     "canvas/fonts/10px-CelticTime.ttf",
     "canvas/fonts/10px-HelvetiPixel.ttf",

--- a/packages/canvas-runtime/src/index.ts
+++ b/packages/canvas-runtime/src/index.ts
@@ -30,6 +30,8 @@ export type {
   PatternDef,
   // Style type
   FillStyle,
+  // Compositing types
+  GlobalCompositeOperation,
 } from './shared/index.js';
 
 export {

--- a/packages/canvas-runtime/src/renderer/CanvasRenderer.ts
+++ b/packages/canvas-runtime/src/renderer/CanvasRenderer.ts
@@ -258,6 +258,14 @@ export class CanvasRenderer {
         this.ctx.shadowOffsetY = 0;
         break;
 
+      case 'setGlobalAlpha':
+        this.ctx.globalAlpha = command.alpha;
+        break;
+
+      case 'setCompositeOperation':
+        this.ctx.globalCompositeOperation = command.operation;
+        break;
+
       default:
         // Ignore unknown commands for forward compatibility
         break;

--- a/packages/canvas-runtime/src/shared/index.ts
+++ b/packages/canvas-runtime/src/shared/index.ts
@@ -28,6 +28,8 @@ export type {
   PatternDef,
   // Style type
   FillStyle,
+  // Compositing types
+  GlobalCompositeOperation,
 } from './types.js';
 
 export {

--- a/packages/canvas-runtime/src/shared/types.ts
+++ b/packages/canvas-runtime/src/shared/types.ts
@@ -48,7 +48,9 @@ export type DrawCommandType =
   | 'setShadowOffsetX'
   | 'setShadowOffsetY'
   | 'setShadow'
-  | 'clearShadow';
+  | 'clearShadow'
+  | 'setGlobalAlpha'
+  | 'setCompositeOperation';
 
 /**
  * Base interface for all draw commands.
@@ -672,6 +674,59 @@ export interface ClearShadowCommand extends DrawCommandBase {
   type: 'clearShadow';
 }
 
+// ============================================================================
+// Compositing Commands
+// ============================================================================
+
+/**
+ * Standard Canvas 2D composite operations.
+ */
+export type GlobalCompositeOperation =
+  | 'source-over'
+  | 'source-in'
+  | 'source-out'
+  | 'source-atop'
+  | 'destination-over'
+  | 'destination-in'
+  | 'destination-out'
+  | 'destination-atop'
+  | 'lighter'
+  | 'copy'
+  | 'xor'
+  | 'multiply'
+  | 'screen'
+  | 'overlay'
+  | 'darken'
+  | 'lighten'
+  | 'color-dodge'
+  | 'color-burn'
+  | 'hard-light'
+  | 'soft-light'
+  | 'difference'
+  | 'exclusion'
+  | 'hue'
+  | 'saturation'
+  | 'color'
+  | 'luminosity';
+
+/**
+ * Set the global alpha (transparency) for all subsequent drawing.
+ */
+export interface SetGlobalAlphaCommand extends DrawCommandBase {
+  type: 'setGlobalAlpha';
+  /** Alpha value from 0.0 (fully transparent) to 1.0 (fully opaque) */
+  alpha: number;
+}
+
+/**
+ * Set the composite operation (blend mode) for all subsequent drawing.
+ */
+export interface SetCompositeOperationCommand extends DrawCommandBase {
+  type: 'setCompositeOperation';
+  /** Blend mode to use */
+  operation: GlobalCompositeOperation;
+}
+
 /**
  * Union type of all draw commands.
  */
@@ -722,7 +777,9 @@ export type DrawCommand =
   | SetShadowOffsetXCommand
   | SetShadowOffsetYCommand
   | SetShadowCommand
-  | ClearShadowCommand;
+  | ClearShadowCommand
+  | SetGlobalAlphaCommand
+  | SetCompositeOperationCommand;
 
 /**
  * Mouse button identifiers.

--- a/packages/canvas-runtime/tests/renderer/CanvasRenderer.test.ts
+++ b/packages/canvas-runtime/tests/renderer/CanvasRenderer.test.ts
@@ -69,6 +69,9 @@ function createMockContext(): CanvasRenderingContext2D {
     shadowBlur: 0,
     shadowOffsetX: 0,
     shadowOffsetY: 0,
+    // Compositing properties
+    globalAlpha: 1,
+    globalCompositeOperation: 'source-over' as GlobalCompositeOperation,
   } as unknown as CanvasRenderingContext2D;
 }
 
@@ -1869,6 +1872,82 @@ describe('CanvasRenderer', () => {
       expect(mockCtx.shadowBlur).toBe(0);
       expect(mockCtx.shadowOffsetX).toBe(0);
       expect(mockCtx.shadowOffsetY).toBe(0);
+    });
+  });
+
+  describe('setGlobalAlpha command', () => {
+    it('should set globalAlpha to the specified value', () => {
+      const commands: DrawCommand[] = [
+        { type: 'setGlobalAlpha', alpha: 0.5 },
+      ];
+
+      renderer.render(commands);
+
+      expect(mockCtx.globalAlpha).toBe(0.5);
+    });
+
+    it('should set globalAlpha to 0 for fully transparent', () => {
+      const commands: DrawCommand[] = [
+        { type: 'setGlobalAlpha', alpha: 0 },
+      ];
+
+      renderer.render(commands);
+
+      expect(mockCtx.globalAlpha).toBe(0);
+    });
+
+    it('should set globalAlpha to 1 for fully opaque', () => {
+      mockCtx.globalAlpha = 0.5; // Start with different value
+      const commands: DrawCommand[] = [
+        { type: 'setGlobalAlpha', alpha: 1 },
+      ];
+
+      renderer.render(commands);
+
+      expect(mockCtx.globalAlpha).toBe(1);
+    });
+  });
+
+  describe('setCompositeOperation command', () => {
+    it('should set globalCompositeOperation to the specified mode', () => {
+      const commands: DrawCommand[] = [
+        { type: 'setCompositeOperation', operation: 'multiply' },
+      ];
+
+      renderer.render(commands);
+
+      expect(mockCtx.globalCompositeOperation).toBe('multiply');
+    });
+
+    it('should support source-over (default) mode', () => {
+      mockCtx.globalCompositeOperation = 'multiply';
+      const commands: DrawCommand[] = [
+        { type: 'setCompositeOperation', operation: 'source-over' },
+      ];
+
+      renderer.render(commands);
+
+      expect(mockCtx.globalCompositeOperation).toBe('source-over');
+    });
+
+    it('should support lighter mode for additive blending', () => {
+      const commands: DrawCommand[] = [
+        { type: 'setCompositeOperation', operation: 'lighter' },
+      ];
+
+      renderer.render(commands);
+
+      expect(mockCtx.globalCompositeOperation).toBe('lighter');
+    });
+
+    it('should support screen mode', () => {
+      const commands: DrawCommand[] = [
+        { type: 'setCompositeOperation', operation: 'screen' },
+      ];
+
+      renderer.render(commands);
+
+      expect(mockCtx.globalCompositeOperation).toBe('screen');
     });
   });
 });

--- a/packages/lua-runtime/src/CanvasController.ts
+++ b/packages/lua-runtime/src/CanvasController.ts
@@ -27,6 +27,7 @@ import type {
   TimingInfo,
   AssetManifest,
   FillStyle,
+  GlobalCompositeOperation,
 } from '@lua-learning/canvas-runtime'
 import type { IFileSystem } from '@lua-learning/shell-core'
 import { formatOnDrawError, createImageFromData, createFontFromData } from './canvasErrorFormatter'
@@ -717,6 +718,24 @@ export class CanvasController {
    */
   clearShadow(): void {
     this.addDrawCommand({ type: 'clearShadow' })
+  }
+
+  // --- Compositing API ---
+
+  /**
+   * Set the global alpha (transparency) for all subsequent drawing.
+   * @param alpha - Value from 0.0 (fully transparent) to 1.0 (fully opaque)
+   */
+  setGlobalAlpha(alpha: number): void {
+    this.addDrawCommand({ type: 'setGlobalAlpha', alpha })
+  }
+
+  /**
+   * Set the composite operation (blend mode) for all subsequent drawing.
+   * @param operation - The blend mode to use
+   */
+  setCompositeOperation(operation: GlobalCompositeOperation): void {
+    this.addDrawCommand({ type: 'setCompositeOperation', operation })
   }
 
   // --- Timing API ---

--- a/packages/lua-runtime/src/canvasLuaWrapper.ts
+++ b/packages/lua-runtime/src/canvasLuaWrapper.ts
@@ -402,6 +402,15 @@ export const canvasLuaCode = `
       __canvas_clearShadow()
     end
 
+    -- Compositing
+    function _canvas.set_global_alpha(alpha)
+      __canvas_setGlobalAlpha(alpha)
+    end
+
+    function _canvas.set_composite_operation(operation)
+      __canvas_setCompositeOperation(operation)
+    end
+
     -- Timing
     function _canvas.get_delta()
       return __canvas_getDelta()

--- a/packages/lua-runtime/src/lua/canvas.lua
+++ b/packages/lua-runtime/src/lua/canvas.lua
@@ -409,6 +409,49 @@ function canvas.set_shadow(color, blur, offsetX, offsetY) end
 function canvas.clear_shadow() end
 
 -- =============================================================================
+-- Compositing
+-- =============================================================================
+
+--- Set the global alpha (transparency) for all subsequent drawing.
+--- Affects all drawing operations including shapes, text, and images.
+---@param alpha number Alpha value from 0.0 (fully transparent) to 1.0 (fully opaque)
+---@return nil
+---@usage canvas.set_global_alpha(0.5)  -- 50% transparent
+---@usage canvas.fill_rect(50, 50, 100, 100)  -- Semi-transparent rectangle
+---@usage canvas.set_global_alpha(1.0)  -- Reset to fully opaque
+function canvas.set_global_alpha(alpha) end
+
+--- Set the composite operation (blend mode) for all subsequent drawing.
+--- Controls how new pixels are combined with existing pixels on the canvas.
+---@param operation string Blend mode name
+---@return nil
+---@usage canvas.set_composite_operation("multiply")  -- Darkening blend
+---@usage canvas.set_composite_operation("screen")    -- Lightening blend
+---@usage canvas.set_composite_operation("lighter")   -- Additive blend
+---@usage canvas.set_composite_operation("source-over") -- Default (draw on top)
+---
+--- Blend modes:
+--- - "source-over" (default): Draw new content on top
+--- - "source-in": Draw only where new overlaps existing
+--- - "source-out": Draw only where new doesn't overlap existing
+--- - "source-atop": Draw on top, only on existing content
+--- - "destination-over": Draw behind existing content
+--- - "destination-in": Keep existing only where new overlaps
+--- - "destination-out": Keep existing only where new doesn't overlap
+--- - "destination-atop": Keep existing on top of new
+--- - "lighter": Additive blending (good for glow effects)
+--- - "copy": Replace existing with new
+--- - "xor": XOR blend
+--- - "multiply": Multiply colors (darkening)
+--- - "screen": Screen blend (lightening)
+--- - "overlay": Overlay blend
+--- - "darken": Keep darker color
+--- - "lighten": Keep lighter color
+--- - "color-dodge", "color-burn", "hard-light", "soft-light"
+--- - "difference", "exclusion", "hue", "saturation", "color", "luminosity"
+function canvas.set_composite_operation(operation) end
+
+-- =============================================================================
 -- Font Styling
 -- =============================================================================
 

--- a/packages/lua-runtime/src/setupCanvasAPI.ts
+++ b/packages/lua-runtime/src/setupCanvasAPI.ts
@@ -4,6 +4,7 @@
  */
 
 import type { LuaEngine } from 'wasmoon'
+import type { GlobalCompositeOperation } from '@lua-learning/canvas-runtime'
 import type { CanvasController } from './CanvasController'
 import { canvasLuaCode } from './canvasLuaWrapper'
 
@@ -418,6 +419,15 @@ export function setupCanvasAPI(
 
   engine.global.set('__canvas_clearShadow', () => {
     getController()?.clearShadow()
+  })
+
+  // Compositing
+  engine.global.set('__canvas_setGlobalAlpha', (alpha: number) => {
+    getController()?.setGlobalAlpha(alpha)
+  })
+
+  engine.global.set('__canvas_setCompositeOperation', (operation: string) => {
+    getController()?.setCompositeOperation(operation as GlobalCompositeOperation)
   })
 
   // --- Set up Lua-side canvas table ---


### PR DESCRIPTION
## Summary

Adds alpha transparency control and blend modes for layered graphics and visual effects as part of Epic #415.

**Features:**
- `set_global_alpha(alpha)` - Set transparency (0.0 fully transparent to 1.0 fully opaque)
- `set_composite_operation(mode)` - Set blend mode for subsequent drawing

**Supported blend modes:**
- Basic: `source-over` (default), `source-in`, `source-out`, `source-atop`
- Destination: `destination-over`, `destination-in`, `destination-out`, `destination-atop`
- Blending: `lighter`, `copy`, `xor`
- Color: `multiply`, `screen`, `overlay`, `darken`, `lighten`
- Advanced: `color-dodge`, `color-burn`, `hard-light`, `soft-light`, `difference`, `exclusion`, `hue`, `saturation`, `color`, `luminosity`

## Test plan

- [x] Unit tests passing (424 tests)
- [x] Mutation score: CanvasRenderer 84.51%
- [x] Full build successful
- [x] Example demo created: `compositing-demo.lua`
- [x] Documentation added to canvas.md
- [x] LuaDoc annotations added

## Related

Closes #428
Part of Epic #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)