### PR TITLE
fix: Remove scrollbars in Fit/Full canvas scaling modes

### DIFF
--- a/lua-learning-website/src/components/CanvasGamePanel/CanvasGamePanel.module.css
+++ b/lua-learning-website/src/components/CanvasGamePanel/CanvasGamePanel.module.css
@@ -2,7 +2,8 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 100%;
+  flex: 1;
+  min-height: 0;
   background: var(--theme-editor-bg);
   color: var(--theme-editor-fg);
 }
@@ -101,11 +102,13 @@
 /* Auto-fit mode: canvas scales down to fit container, no scrollbars */
 .canvasContainerFit {
   overflow: hidden;
+  padding: 0;
 }
 
 /* Full mode: canvas scales to fill container (up or down), no scrollbars */
 .canvasContainerFull {
   overflow: hidden;
+  padding: 0;
 }
 
 /* Native mode: canvas at native size, scrollbars if needed */


### PR DESCRIPTION
## Summary
- Fixed scrollbars appearing in Fit and Full canvas scaling modes
- Changed `.panel` from `height: 100%` to `flex: 1` with `min-height: 0` to properly account for tab bar height
- Removed padding from Fit/Full container modes so canvas fills edge-to-edge

## Test plan
- [x] E2E tests added to verify no scrollbars in Fit/Full modes
- [x] All 11 canvas-scaling E2E tests pass
- [x] All 30 CanvasGamePanel unit tests pass
- [x] Manual verification in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)