### PR TITLE
feat: Add HiDPI canvas scaling for shell integration

### DIFF
--- a/lua-learning-website/src/components/CanvasGamePanel/CanvasGamePanel.test.tsx
+++ b/lua-learning-website/src/components/CanvasGamePanel/CanvasGamePanel.test.tsx
@@ -6,12 +6,28 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { CanvasGamePanel } from './CanvasGamePanel'
 
+// Mock window.matchMedia for DPR tracking
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+})
+
 // Mock the useCanvasGame hook
 const mockStartGame = vi.fn()
 const mockStopGame = vi.fn()
 const mockPauseGame = vi.fn()
 const mockResumeGame = vi.fn()
 const mockClearError = vi.fn()
+const mockSetDevicePixelRatio = vi.fn()
 
 vi.mock('../../hooks/useCanvasGame', () => ({
   useCanvasGame: vi.fn(() => ({
@@ -28,6 +44,7 @@ vi.mock('../../hooks/useCanvasGame', () => ({
     resumeGame: mockResumeGame,
     clearOutput: vi.fn(),
     clearError: mockClearError,
+    setDevicePixelRatio: mockSetDevicePixelRatio,
   })),
 }))
 
@@ -59,6 +76,7 @@ describe('CanvasGamePanel', () => {
         resumeGame: mockResumeGame,
         clearOutput: vi.fn(),
         clearError: mockClearError,
+        setDevicePixelRatio: mockSetDevicePixelRatio,
       })
 
       render(<CanvasGamePanel code="print('hello')" />)
@@ -81,6 +99,7 @@ describe('CanvasGamePanel', () => {
         resumeGame: mockResumeGame,
         clearOutput: vi.fn(),
         clearError: mockClearError,
+        setDevicePixelRatio: mockSetDevicePixelRatio,
       })
 
       render(<CanvasGamePanel code="print('hello')" />)
@@ -103,6 +122,7 @@ describe('CanvasGamePanel', () => {
         resumeGame: mockResumeGame,
         clearOutput: vi.fn(),
         clearError: mockClearError,
+        setDevicePixelRatio: mockSetDevicePixelRatio,
       })
 
       render(<CanvasGamePanel code="print('hello')" />)
@@ -125,6 +145,7 @@ describe('CanvasGamePanel', () => {
         resumeGame: mockResumeGame,
         clearOutput: vi.fn(),
         clearError: mockClearError,
+        setDevicePixelRatio: mockSetDevicePixelRatio,
       })
 
       render(<CanvasGamePanel code="print('hello')" />)
@@ -172,6 +193,7 @@ describe('CanvasGamePanel', () => {
         resumeGame: mockResumeGame,
         clearOutput: vi.fn(),
         clearError: mockClearError,
+        setDevicePixelRatio: mockSetDevicePixelRatio,
       })
 
       render(<CanvasGamePanel code="print('hello')" />)
@@ -195,6 +217,7 @@ describe('CanvasGamePanel', () => {
         resumeGame: mockResumeGame,
         clearOutput: vi.fn(),
         clearError: mockClearError,
+        setDevicePixelRatio: mockSetDevicePixelRatio,
       })
 
       render(<CanvasGamePanel code="print('hello')" />)
@@ -218,6 +241,7 @@ describe('CanvasGamePanel', () => {
         resumeGame: mockResumeGame,
         clearOutput: vi.fn(),
         clearError: mockClearError,
+        setDevicePixelRatio: mockSetDevicePixelRatio,
       })
 
       render(<CanvasGamePanel code="print('hello')" />)
@@ -244,6 +268,7 @@ describe('CanvasGamePanel', () => {
         resumeGame: mockResumeGame,
         clearOutput: vi.fn(),
         clearError: mockClearError,
+        setDevicePixelRatio: mockSetDevicePixelRatio,
       })
 
       render(<CanvasGamePanel code="print('hello')" autoStart />)
@@ -266,6 +291,7 @@ describe('CanvasGamePanel', () => {
         resumeGame: mockResumeGame,
         clearOutput: vi.fn(),
         clearError: mockClearError,
+        setDevicePixelRatio: mockSetDevicePixelRatio,
       })
 
       render(<CanvasGamePanel code="print('hello')" autoStart={false} />)
@@ -294,6 +320,7 @@ describe('CanvasGamePanel', () => {
           resumeGame: mockResumeGame,
           clearOutput: vi.fn(),
           clearError: mockClearError,
+          setDevicePixelRatio: mockSetDevicePixelRatio,
         }
       })
 

--- a/lua-learning-website/src/components/IDELayout/CanvasTabContent.tsx
+++ b/lua-learning-website/src/components/IDELayout/CanvasTabContent.tsx
@@ -21,7 +21,7 @@ export interface CanvasTabContentProps {
   /** Callback when the canvas game exits */
   onExit: (exitCode: number) => void
   /** Callback when canvas element is ready (for shell integration) */
-  onCanvasReady?: (canvasId: string, canvas: HTMLCanvasElement) => void
+  onCanvasReady?: (canvasId: string, canvas: HTMLCanvasElement, devicePixelRatio: number) => void
   /** Whether the canvas tab is active and should receive focus */
   isActive?: boolean
 }
@@ -66,7 +66,7 @@ export function CanvasTabContent({
       <CanvasGamePanel
         code={canvasCode}
         onExit={onExit}
-        onCanvasReady={activeTab && onCanvasReady ? (canvas) => onCanvasReady(activeTab, canvas) : undefined}
+        onCanvasReady={activeTab && onCanvasReady ? (canvas, dpr) => onCanvasReady(activeTab, canvas, dpr) : undefined}
         scalingMode={scalingMode}
         onScalingModeChange={setScalingMode}
         isActive={isActive}

--- a/lua-learning-website/src/hooks/useShell.ts
+++ b/lua-learning-website/src/hooks/useShell.ts
@@ -65,8 +65,8 @@ export type UseShellFileSystem = IFileSystem | UseFileSystemReturn
  * Canvas callbacks for shell-to-UI communication
  */
 export interface ShellCanvasCallbacks {
-  /** Request a canvas tab to be opened, returns the canvas element when ready */
-  onRequestCanvasTab: (canvasId: string) => Promise<HTMLCanvasElement>
+  /** Request a canvas tab to be opened, returns the canvas element and DPR when ready */
+  onRequestCanvasTab: (canvasId: string) => Promise<{ canvas: HTMLCanvasElement; devicePixelRatio: number }>
   /** Request a canvas tab to be closed */
   onCloseCanvasTab: (canvasId: string) => void
   /**

--- a/packages/canvas-runtime/src/renderer/InputCapture.ts
+++ b/packages/canvas-runtime/src/renderer/InputCapture.ts
@@ -18,6 +18,12 @@ export class InputCapture {
   private mouseY = 0;
   private disposed = false;
 
+  // DPR scaling support (Issue #515): track logical size separately from canvas.width/height
+  // When DPR scaling is active, canvas.width/height are physical pixels (logical × DPR),
+  // but we need logical dimensions for coordinate mapping.
+  private logicalWidth: number | null = null;
+  private logicalHeight: number | null = null;
+
   // Bound event handlers for removal
   private readonly handleKeyDown: (e: KeyboardEvent) => void;
   private readonly handleKeyUp: (e: KeyboardEvent) => void;
@@ -118,6 +124,19 @@ export class InputCapture {
   }
 
   /**
+   * Set the logical canvas size for DPR-aware coordinate mapping.
+   * When DPR scaling is active, canvas.width/height are physical pixels,
+   * but input coordinates should use logical dimensions.
+   *
+   * @param width - Logical width in CSS pixels
+   * @param height - Logical height in CSS pixels
+   */
+  setLogicalSize(width: number, height: number): void {
+    this.logicalWidth = width;
+    this.logicalHeight = height;
+  }
+
+  /**
    * Reset all input state.
    */
   reset(): void {
@@ -164,8 +183,9 @@ export class InputCapture {
 
     // If target is a canvas, handle object-fit: contain letterboxing and scaling
     if (this.target instanceof HTMLCanvasElement) {
-      const canvasWidth = this.target.width;
-      const canvasHeight = this.target.height;
+      // Use logical dimensions if set (for DPR scaling), otherwise use canvas dimensions
+      const canvasWidth = this.logicalWidth ?? this.target.width;
+      const canvasHeight = this.logicalHeight ?? this.target.height;
       const rectWidth = rect.width;
       const rectHeight = rect.height;
 

--- a/packages/lua-runtime/tests/CanvasController.assets.test.ts
+++ b/packages/lua-runtime/tests/CanvasController.assets.test.ts
@@ -38,6 +38,7 @@ vi.mock('@lua-learning/canvas-runtime', () => {
   return {
     CanvasRenderer: class MockCanvasRenderer {
       render = vi.fn()
+      configureScaling = vi.fn()
     },
     InputCapture: class MockInputCapture {
       isKeyDown = vi.fn().mockReturnValue(false)
@@ -56,6 +57,7 @@ vi.mock('@lua-learning/canvas-runtime', () => {
       isMouseButtonPressed = vi.fn().mockReturnValue(false)
       update = vi.fn()
       dispose = vi.fn()
+      setLogicalSize = vi.fn()
     },
     GameLoopController: class MockGameLoopController {
       start = vi.fn()
@@ -119,9 +121,9 @@ describe('CanvasController Assets', () => {
     mockCanvas.width = 800
     mockCanvas.height = 600
 
-    // Create mock callbacks
+    // Create mock callbacks with DPR (Issue #515)
     mockCallbacks = {
-      onRequestCanvasTab: vi.fn().mockResolvedValue(mockCanvas),
+      onRequestCanvasTab: vi.fn().mockResolvedValue({ canvas: mockCanvas, devicePixelRatio: 1 }),
       onCloseCanvasTab: vi.fn(),
     }
 

--- a/packages/lua-runtime/tests/CanvasController.audio.test.ts
+++ b/packages/lua-runtime/tests/CanvasController.audio.test.ts
@@ -28,6 +28,7 @@ vi.mock('@lua-learning/canvas-runtime', () => {
   return {
     CanvasRenderer: class MockCanvasRenderer {
       render = vi.fn()
+      configureScaling = vi.fn()
     },
     InputCapture: class MockInputCapture {
       isKeyDown = vi.fn().mockReturnValue(false)
@@ -46,6 +47,7 @@ vi.mock('@lua-learning/canvas-runtime', () => {
       isMouseButtonPressed = vi.fn().mockReturnValue(false)
       update = vi.fn()
       dispose = vi.fn()
+      setLogicalSize = vi.fn()
     },
     GameLoopController: class MockGameLoopController {
       start = vi.fn()
@@ -109,9 +111,9 @@ describe('CanvasController Audio', () => {
     mockCanvas.width = 800
     mockCanvas.height = 600
 
-    // Create mock callbacks
+    // Create mock callbacks with DPR (Issue #515)
     mockCallbacks = {
-      onRequestCanvasTab: vi.fn().mockResolvedValue(mockCanvas),
+      onRequestCanvasTab: vi.fn().mockResolvedValue({ canvas: mockCanvas, devicePixelRatio: 1 }),
       onCloseCanvasTab: vi.fn(),
       onError: vi.fn(),
     }

--- a/packages/lua-runtime/tests/CanvasController.drawing.test.ts
+++ b/packages/lua-runtime/tests/CanvasController.drawing.test.ts
@@ -28,6 +28,7 @@ vi.mock('@lua-learning/canvas-runtime', () => {
   return {
     CanvasRenderer: class MockCanvasRenderer {
       render = vi.fn()
+      configureScaling = vi.fn()
     },
     InputCapture: class MockInputCapture {
       isKeyDown = vi.fn().mockReturnValue(false)
@@ -46,6 +47,7 @@ vi.mock('@lua-learning/canvas-runtime', () => {
       isMouseButtonPressed = vi.fn().mockReturnValue(false)
       update = vi.fn()
       dispose = vi.fn()
+      setLogicalSize = vi.fn()
     },
     GameLoopController: class MockGameLoopController {
       start = vi.fn()

--- a/packages/lua-runtime/tests/CanvasController.transforms.test.ts
+++ b/packages/lua-runtime/tests/CanvasController.transforms.test.ts
@@ -28,6 +28,7 @@ vi.mock('@lua-learning/canvas-runtime', () => {
   return {
     CanvasRenderer: class MockCanvasRenderer {
       render = vi.fn()
+      configureScaling = vi.fn()
     },
     InputCapture: class MockInputCapture {
       isKeyDown = vi.fn().mockReturnValue(false)
@@ -46,6 +47,7 @@ vi.mock('@lua-learning/canvas-runtime', () => {
       isMouseButtonPressed = vi.fn().mockReturnValue(false)
       update = vi.fn()
       dispose = vi.fn()
+      setLogicalSize = vi.fn()
     },
     GameLoopController: class MockGameLoopController {
       start = vi.fn()

--- a/packages/shell-core/src/interfaces/ShellContext.ts
+++ b/packages/shell-core/src/interfaces/ShellContext.ts
@@ -35,11 +35,11 @@ export interface ShellContext {
 
   /**
    * Request a canvas tab to be opened.
-   * Returns the canvas element when the tab is ready.
+   * Returns the canvas element and device pixel ratio when the tab is ready.
    * @param canvasId - Unique identifier for the canvas tab
-   * @returns Promise resolving to the HTMLCanvasElement when ready
+   * @returns Promise resolving to the canvas element and DPR for HiDPI scaling
    */
-  onRequestCanvasTab?: (canvasId: string) => Promise<HTMLCanvasElement>
+  onRequestCanvasTab?: (canvasId: string) => Promise<{ canvas: HTMLCanvasElement; devicePixelRatio: number }>
 
   /**
    * Request a canvas tab to be closed.


### PR DESCRIPTION
## Summary

- Pass `devicePixelRatio` through the shell callback chain so canvas games in the editor use native resolution × DPR in Fit/Full scaling modes
- Eliminates blurriness on HiDPI displays by using canvas buffer scaling instead of CSS scaling
- Add runtime DPR update support for display switching scenarios

## Changes

### Shell Integration (callback chain)
- `ShellContext.onRequestCanvasTab` now returns `{ canvas, devicePixelRatio }`
- `IDELayout` → `CanvasTabContent` → `CanvasGamePanel` callback chain updated to pass DPR

### Canvas Runtime
- `CanvasRenderer.configureScaling(width, height, dpr)` - scales canvas buffer for HiDPI
- `InputCapture.setLogicalSize(width, height)` - maps mouse coordinates correctly
- `LuaCanvasProcess.setDevicePixelRatio(dpr)` - runtime DPR updates

### Lua Runtime
- `CanvasController.start()` extracts DPR from callback and configures scaling

## Test plan

- [x] Unit tests pass (712 lua-runtime tests, 2213 website tests)
- [x] Build passes
- [x] HiDPI tests added for DPR configuration (DPR=1, DPR=2, fractional DPR=1.5)
- [ ] Manual test on HiDPI display to verify visual crispness

Closes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)