### PR TITLE
fix(#510): Prevent browser context menu on right-click in exported projects

### DIFF
--- a/packages/export/src/runtime/canvas-inline.generated.ts
+++ b/packages/export/src/runtime/canvas-inline.generated.ts
@@ -2881,17 +2881,22 @@ return setmetatable({
     const handleMouseUp = (e) => {
       state.mouseButtonsDown.delete(e.button);
     };
+    const handleContextMenu = (e) => {
+      e.preventDefault();
+    };
     document.addEventListener("keydown", handleKeyDown);
     document.addEventListener("keyup", handleKeyUp);
     state.canvas.addEventListener("mousemove", handleMouseMove);
     state.canvas.addEventListener("mousedown", handleMouseDown);
     state.canvas.addEventListener("mouseup", handleMouseUp);
+    state.canvas.addEventListener("contextmenu", handleContextMenu);
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
       document.removeEventListener("keyup", handleKeyUp);
       state.canvas.removeEventListener("mousemove", handleMouseMove);
       state.canvas.removeEventListener("mousedown", handleMouseDown);
       state.canvas.removeEventListener("mouseup", handleMouseUp);
+      state.canvas.removeEventListener("contextmenu", handleContextMenu);
     };
   }
   function startGameLoop(state) {

--- a/packages/export/src/runtime/canvas-standalone.ts
+++ b/packages/export/src/runtime/canvas-standalone.ts
@@ -131,11 +131,17 @@ export function setupInputListeners(state: CanvasRuntimeState): () => void {
     state.mouseButtonsDown.delete(e.button)
   }
 
+  const handleContextMenu = (e: MouseEvent) => {
+    // Prevent browser context menu so right-click can be used in games
+    e.preventDefault()
+  }
+
   document.addEventListener('keydown', handleKeyDown)
   document.addEventListener('keyup', handleKeyUp)
   state.canvas.addEventListener('mousemove', handleMouseMove)
   state.canvas.addEventListener('mousedown', handleMouseDown)
   state.canvas.addEventListener('mouseup', handleMouseUp)
+  state.canvas.addEventListener('contextmenu', handleContextMenu)
 
   // Return cleanup function
   return () => {
@@ -144,6 +150,7 @@ export function setupInputListeners(state: CanvasRuntimeState): () => void {
     state.canvas.removeEventListener('mousemove', handleMouseMove)
     state.canvas.removeEventListener('mousedown', handleMouseDown)
     state.canvas.removeEventListener('mouseup', handleMouseUp)
+    state.canvas.removeEventListener('contextmenu', handleContextMenu)
   }
 }
 

--- a/packages/export/tests/runtime/canvas-standalone.test.ts
+++ b/packages/export/tests/runtime/canvas-standalone.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock the lua-runtime package to avoid resolution issues
+vi.mock('@lua-learning/lua-runtime', () => ({
+  canvasLuaCoreCode: '',
+  canvasLuaPathCode: '',
+  canvasLuaStylingCode: '',
+  canvasLuaTextCode: '',
+  canvasLuaInputCode: '',
+  canvasLuaAudioCode: '',
+  LUA_HC_CODE: '',
+}))
+
+import {
+  setupInputListeners,
+  type CanvasRuntimeState,
+} from '../../src/runtime/canvas-standalone'
+
+describe('canvas-standalone', () => {
+  describe('setupInputListeners', () => {
+    let canvas: HTMLCanvasElement
+    let state: CanvasRuntimeState
+
+    beforeEach(() => {
+      // Create a mock canvas element
+      canvas = document.createElement('canvas')
+      canvas.width = 800
+      canvas.height = 600
+
+      // Create a minimal state object for testing setupInputListeners
+      // We only need the canvas property for input listener tests
+      state = {
+        canvas,
+        ctx: {} as CanvasRenderingContext2D,
+        isRunning: false,
+        tickCallback: null,
+        lastFrameTime: 0,
+        deltaTime: 0,
+        totalTime: 0,
+        keysDown: new Set<string>(),
+        keysPressed: new Set<string>(),
+        mouseX: 0,
+        mouseY: 0,
+        mouseButtonsDown: new Set<number>(),
+        mouseButtonsPressed: new Set<number>(),
+        currentFontSize: 16,
+        currentFontFamily: 'monospace',
+        stopResolve: null,
+        audioAssets: new Map(),
+      }
+    })
+
+    describe('contextmenu handling', () => {
+      it('should prevent the browser context menu on right-click', () => {
+        setupInputListeners(state)
+
+        const event = new MouseEvent('contextmenu', {
+          bubbles: true,
+          cancelable: true,
+        })
+        const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+
+        canvas.dispatchEvent(event)
+
+        expect(preventDefaultSpy).toHaveBeenCalled()
+      })
+
+      it('should remove contextmenu listener when cleanup is called', () => {
+        const cleanup = setupInputListeners(state)
+
+        // Call cleanup
+        cleanup()
+
+        // Create a new event after cleanup
+        const event = new MouseEvent('contextmenu', {
+          bubbles: true,
+          cancelable: true,
+        })
+        const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+
+        canvas.dispatchEvent(event)
+
+        // preventDefault should NOT be called after cleanup
+        expect(preventDefaultSpy).not.toHaveBeenCalled()
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add contextmenu event handler to exported projects runtime to prevent browser context menu on right-click
- The fix for #257 was applied to InputCapture.ts (main app) but not to canvas-standalone.ts (exported projects)
- Now exported HTML files prevent the browser context menu when right-clicking on the canvas

## Changes
- Added `handleContextMenu` function to `setupInputListeners` in `canvas-standalone.ts`
- Registered contextmenu listener on canvas element  
- Added cleanup to remove listener when cleanup function is called
- Added unit tests for contextmenu handling

## Test plan
- [ ] Export a canvas project to HTML
- [ ] Open the exported HTML file in a browser
- [ ] Right-click on the canvas - browser context menu should NOT appear
- [ ] Verify right-click input is still captured by the game (button 2)

Fixes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)