### PR TITLE
feat(#525): Add F12 and F11 keyboard shortcuts to Electron app

### DIFF
--- a/packages/electron-wrapper/main.js
+++ b/packages/electron-wrapper/main.js
@@ -33,6 +33,20 @@ function createWindow() {
   // Load the hosted application
   win.loadURL(HOSTED_URL);
 
+  // Handle keyboard shortcuts
+  win.webContents.on('before-input-event', (event, input) => {
+    // F12: Toggle DevTools
+    if (input.key === 'F12') {
+      win.webContents.toggleDevTools();
+      event.preventDefault();
+    }
+    // F11: Toggle fullscreen
+    if (input.key === 'F11') {
+      win.setFullScreen(!win.isFullScreen());
+      event.preventDefault();
+    }
+  });
+
   // Restrict navigation to the app domain only
   win.webContents.on('will-navigate', (event, url) => {
     const parsedUrl = new URL(url);


### PR DESCRIPTION
## Summary

- Add F12 keyboard shortcut to toggle DevTools for debugging white screen issues
- Add F11 keyboard shortcut to toggle fullscreen mode
- Use `before-input-event` listener in Electron main process to capture keypresses

## Test plan

- [ ] Build Electron app with `npm run build` in packages/electron-wrapper
- [ ] Launch the standalone app
- [ ] Press F12 to verify DevTools opens
- [ ] Press F12 again to verify DevTools closes (toggle behavior)
- [ ] Press F11 to verify fullscreen mode activates
- [ ] Press F11 again to verify windowed mode restores
- [ ] Test on Windows (primary target platform)

Closes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)