### PR TITLE
fix(#537): Fix Stop button remaining visible after immediate process exit

### DIFF
--- a/lua-learning-website/src/hooks/useProcessManager.ts
+++ b/lua-learning-website/src/hooks/useProcessManager.ts
@@ -99,8 +99,12 @@ export function useProcessManager(
       }
     }
 
-    pm.startProcess(process)
+    // Set running state BEFORE starting the process.
+    // This ensures that if the process exits immediately (e.g., file not found),
+    // the onProcessExit callback sets isProcessRunning to false AFTER this true,
+    // and React batches both updates with false winning (last update wins).
     setIsProcessRunning(true)
+    pm.startProcess(process)
   }, [])
 
   const stopProcess = useCallback((): void => {


### PR DESCRIPTION
## Summary
- Fixed race condition where Stop button remained visible after running `lua <nonexistent>` 
- Root cause: `setIsProcessRunning(true)` was called AFTER `pm.startProcess()`, causing React to batch updates with the wrong order
- Fix: Reorder calls so `setIsProcessRunning(true)` comes before `pm.startProcess()`

## Test plan
- [x] Unit test added: "should handle process that exits immediately during start (file not found scenario)"
- [x] All 18 useProcessManager tests pass
- [x] Full test suite passes (2331 tests)
- [x] Lint passes
- [x] Build succeeds  
- [x] Mutation testing passes (60% score, above 50% threshold)
- [ ] Manual test: Run `lua nonexistent` in shell - verify stop button doesn't appear after error message

Closes #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)