### PR TITLE
feat: Add canvas window persistence and reuse

### DIFF
--- a/lua-learning-website/src/components/IDELayout/IDELayout.tsx
+++ b/lua-learning-website/src/components/IDELayout/IDELayout.tsx
@@ -318,7 +318,7 @@ function IDELayoutInner({
   // Canvas window management for shell-based canvas.start() with --canvas=window
   const {
     openCanvasWindow,
-    closeCanvasWindow,
+    disconnectCanvasWindow,
     registerWindowCloseHandler,
     unregisterWindowCloseHandler,
     registerWindowReloadHandler,
@@ -358,10 +358,11 @@ function IDELayoutInner({
     [openCanvasWindow]
   )
 
-  // Handle canvas window close from shell (canvas.stop() or Ctrl+C)
+  // Handle canvas window disconnect from shell (canvas.stop() or Ctrl+C)
+  // This keeps the window open with "No canvas connected" overlay for reuse
   const handleCloseCanvasWindow = useCallback((canvasId: string) => {
-    closeCanvasWindow(canvasId)
-  }, [closeCanvasWindow])
+    disconnectCanvasWindow(canvasId)
+  }, [disconnectCanvasWindow])
 
   // Register a handler to be called when reload is requested from the UI
   const registerCanvasReloadHandler = useCallback((canvasId: string, handler: () => void) => {

--- a/lua-learning-website/src/hooks/canvasWindowTemplate.ts
+++ b/lua-learning-website/src/hooks/canvasWindowTemplate.ts
@@ -123,6 +123,7 @@ export function generateCanvasWindowHTML(screenMode?: ScreenMode, noToolbar?: bo
       justify-content: center;
       align-items: center;
       overflow: hidden;
+      position: relative;
     }
 
     /* Scaling modes */
@@ -149,6 +150,45 @@ export function generateCanvasWindowHTML(screenMode?: ScreenMode, noToolbar?: bo
       display: block;
       background: #000;
     }
+
+    /* Disconnected overlay */
+    .disconnected-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(26, 26, 46, 0.95);
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      z-index: 100;
+    }
+    .disconnected-overlay.hidden {
+      display: none;
+    }
+    .disconnected-message {
+      text-align: center;
+      color: #a0a0b0;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+    .disconnected-icon {
+      font-size: 48px;
+      display: block;
+      margin-bottom: 16px;
+    }
+    .disconnected-message p {
+      margin: 8px 0;
+      font-size: 18px;
+    }
+    .disconnected-hint {
+      font-size: 13px !important;
+      color: #6d6d8c;
+    }
+    .toolbar button:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
   </style>
 </head>
 <body>
@@ -167,6 +207,13 @@ export function generateCanvasWindowHTML(screenMode?: ScreenMode, noToolbar?: bo
   </div>
   <div id="canvas-container" class="canvas-container ${scaleClass}">
     <canvas id="game-canvas" width="800" height="600" tabindex="0"></canvas>
+    <div id="disconnected-overlay" class="disconnected-overlay hidden">
+      <div class="disconnected-message">
+        <span class="disconnected-icon">&#x23F8;</span>
+        <p>No canvas connected</p>
+        <p class="disconnected-hint">Run a canvas script to reconnect</p>
+      </div>
+    </div>
   </div>
   <script>
     (function() {
@@ -177,6 +224,7 @@ export function generateCanvasWindowHTML(screenMode?: ScreenMode, noToolbar?: bo
       var playBtn = document.getElementById('play-btn');
       var stopBtn = document.getElementById('stop-btn');
       var stepBtn = document.getElementById('step-btn');
+      var disconnectedOverlay = document.getElementById('disconnected-overlay');
 
       if (select) {
         select.addEventListener('change', function() {
@@ -245,6 +293,22 @@ export function generateCanvasWindowHTML(screenMode?: ScreenMode, noToolbar?: bo
             playBtn.classList.remove('hidden');
             stepBtn.classList.remove('hidden');
           }
+        } else if (event.data && event.data.type === 'canvas-disconnected') {
+          // Show overlay and disable toolbar buttons
+          disconnectedOverlay.classList.remove('hidden');
+          reloadBtn.disabled = true;
+          pauseBtn.disabled = true;
+          playBtn.disabled = true;
+          stopBtn.disabled = true;
+          stepBtn.disabled = true;
+        } else if (event.data && event.data.type === 'canvas-connected') {
+          // Hide overlay and re-enable toolbar buttons
+          disconnectedOverlay.classList.add('hidden');
+          reloadBtn.disabled = false;
+          pauseBtn.disabled = false;
+          playBtn.disabled = false;
+          stopBtn.disabled = false;
+          stepBtn.disabled = false;
         }
       });
     })();


### PR DESCRIPTION
## Summary

- When a canvas process stops, the popup window now stays open with a "No canvas connected" overlay
- When a new canvas starts, it reuses the existing popup window instead of creating a new one
- Toolbar buttons are disabled when disconnected, re-enabled when connected

## Changes

- **useCanvasWindowManager.ts**: Added `isConnected` state and `disconnectCanvasWindow()` function
- **canvasWindowTemplate.ts**: Added overlay HTML, CSS, and message handlers
- **IDELayout.tsx**: Wired up the disconnect callback

## Test Plan

### Automated Tests (48 passing)
- disconnectCanvasWindow sends canvas-disconnected message
- disconnectCanvasWindow does NOT close window  
- openCanvasWindow reuses existing window
- openCanvasWindow sends canvas-connected message when reusing
- beforeunload only calls handler when connected
- HTML includes disconnected overlay and handlers

### Manual Testing
- [ ] Start canvas with --canvas=window, verify popup opens
- [ ] Stop canvas (Ctrl+C), verify overlay appears with "No canvas connected"
- [ ] Verify toolbar buttons disabled when disconnected
- [ ] Run canvas again, verify overlay disappears and canvas works
- [ ] Close disconnected window manually, verify no errors
- [ ] Close connected window, verify process stops

Fixes #556

---
Generated with [Claude Code](https://claude.com/claude-code)