### PR TITLE
fix: Transfer fonts to canvas popup windows

### DIFF
--- a/lua-learning-website/src/components/IDELayout/IDELayout.tsx
+++ b/lua-learning-website/src/components/IDELayout/IDELayout.tsx
@@ -335,6 +335,7 @@ function IDELayoutInner({
     updateWindowControlState,
     showErrorOverlay,
     clearErrorOverlay,
+    transferFontsToWindow,
   } = useCanvasWindowManager()
 
   // Listen for Lua file save events to trigger auto-reload on canvas windows
@@ -506,6 +507,8 @@ function IDELayoutInner({
       clearErrorOverlay(canvasId)
       clearCanvasTabError(canvasId)
     },
+    // Transfer fonts to popup window (only needed for window mode)
+    transferFontsToWindow,
     // Canvas tab execution control handlers
     registerCanvasPauseHandler,
     registerCanvasPlayHandler,
@@ -536,6 +539,7 @@ function IDELayoutInner({
     clearErrorOverlay,
     showCanvasTabError,
     clearCanvasTabError,
+    transferFontsToWindow,
     registerCanvasPauseHandler,
     registerCanvasPlayHandler,
     registerCanvasStopHandler,

--- a/lua-learning-website/src/hooks/canvasWindowTemplate.ts
+++ b/lua-learning-website/src/hooks/canvasWindowTemplate.ts
@@ -390,6 +390,18 @@ export function generateCanvasWindowHTML(screenMode?: ScreenMode, noToolbar?: bo
           if (errorOverlay) {
             errorOverlay.classList.add('hidden');
           }
+        } else if (event.data && event.data.type === 'canvas-fonts') {
+          // Load fonts transferred from main window (popup has isolated document.fonts)
+          (event.data.fonts || []).forEach(function(fontInfo) {
+            try {
+              var base64 = fontInfo.dataUrl.split(',')[1];
+              var binary = atob(base64);
+              var buffer = new ArrayBuffer(binary.length);
+              var view = new Uint8Array(buffer);
+              for (var i = 0; i < binary.length; i++) view[i] = binary.charCodeAt(i);
+              new FontFace(fontInfo.name, buffer).load().then(function(f) { document.fonts.add(f); });
+            } catch (e) { console.error('Failed to load font:', fontInfo.name, e); }
+          });
         }
       });
     })();

--- a/lua-learning-website/src/hooks/useCanvasWindowManager.ts
+++ b/lua-learning-website/src/hooks/useCanvasWindowManager.ts
@@ -84,6 +84,8 @@ export interface UseCanvasWindowManagerReturn {
   showErrorOverlay: (canvasId: string, error: string) => void
   /** Clear/hide error overlay in a popup window */
   clearErrorOverlay: (canvasId: string) => void
+  /** Transfer font data to a popup window for loading in its isolated document.fonts */
+  transferFontsToWindow: (canvasId: string, fonts: Array<{ name: string; dataUrl: string }>) => void
 }
 
 /**
@@ -429,6 +431,21 @@ export function useCanvasWindowManager(): UseCanvasWindowManagerReturn {
     }
   }, [])
 
+  /**
+   * Transfer font data to a popup window.
+   * Popup windows have isolated document.fonts collections, so fonts loaded
+   * in the main window need to be transferred and reloaded in the popup.
+   */
+  const transferFontsToWindow = useCallback((canvasId: string, fonts: Array<{ name: string; dataUrl: string }>) => {
+    const windowState = windowsRef.current.get(canvasId)
+    if (windowState) {
+      windowState.window.postMessage(
+        { type: 'canvas-fonts', fonts },
+        '*'
+      )
+    }
+  }, [])
+
   // Cleanup on unmount
   useEffect(() => {
     return () => {
@@ -454,5 +471,6 @@ export function useCanvasWindowManager(): UseCanvasWindowManagerReturn {
     updateWindowControlState,
     showErrorOverlay,
     clearErrorOverlay,
+    transferFontsToWindow,
   }
 }

--- a/lua-learning-website/src/hooks/useShell.ts
+++ b/lua-learning-website/src/hooks/useShell.ts
@@ -207,6 +207,14 @@ export interface ShellCanvasCallbacks {
    * @param canvasId - The canvas ID
    */
   clearErrorOverlay?: (canvasId: string) => void
+  /**
+   * Transfer font data to a canvas window (popup).
+   * Popup windows have isolated document.fonts collections, so fonts loaded
+   * in the main window need to be transferred and reloaded in the popup.
+   * @param canvasId - The canvas ID
+   * @param fonts - Array of font data with name and base64 data URL
+   */
+  transferFontsToWindow?: (canvasId: string, fonts: Array<{ name: string; dataUrl: string }>) => void
 }
 
 /**
@@ -415,6 +423,8 @@ export function useShell(fileSystem: UseShellFileSystem, options?: UseShellOptio
         // Error overlay callbacks for canvas windows and tabs
         showErrorOverlay: options?.canvasCallbacks?.showErrorOverlay,
         clearErrorOverlay: options?.canvasCallbacks?.clearErrorOverlay,
+        // Font transfer for canvas windows (popup windows have isolated document.fonts)
+        transferFontsToWindow: options?.canvasCallbacks?.transferFontsToWindow,
         // Editor integration callback for 'open' command
         onRequestOpenFile: options?.onRequestOpenFile,
         // Filesystem change notification for UI refresh (e.g., file tree)

--- a/packages/lua-runtime/src/LuaCommand.ts
+++ b/packages/lua-runtime/src/LuaCommand.ts
@@ -184,6 +184,8 @@ export class LuaCommand implements ICommand {
             // Error overlay for canvas windows
             showErrorOverlay: context.showErrorOverlay,
             clearErrorOverlay: context.clearErrorOverlay,
+            // Font transfer for canvas windows (popup windows have isolated document.fonts)
+            transferFontsToWindow: context.transferFontsToWindow,
             // Canvas tab execution control handlers (pause/play/stop/step)
             registerCanvasPauseHandler: context.registerCanvasPauseHandler,
             registerCanvasPlayHandler: context.registerCanvasPlayHandler,

--- a/packages/lua-runtime/src/LuaScriptProcess.ts
+++ b/packages/lua-runtime/src/LuaScriptProcess.ts
@@ -454,6 +454,12 @@ __clear_execution_hook()
           LuaEngineFactory.flushOutput(this.engine)
         }
       },
+      // Route font transfer to window callbacks when in window mode
+      // Tab mode doesn't need this - fonts are already in the same document
+      transferFontsToWindow:
+        canvasMode === 'window'
+          ? originalCallbacks.transferFontsToWindow
+          : undefined,
     }
 
     this.canvasController = new CanvasController(routedCallbacks)

--- a/packages/shell-core/src/interfaces/ShellContext.ts
+++ b/packages/shell-core/src/interfaces/ShellContext.ts
@@ -243,6 +243,15 @@ export interface ShellContext {
   clearErrorOverlay?: (canvasId: string) => void
 
   /**
+   * Transfer font data to a canvas window (popup).
+   * Popup windows have isolated document.fonts collections, so fonts loaded
+   * in the main window need to be transferred and reloaded in the popup.
+   * @param canvasId - Unique identifier for the canvas window
+   * @param fonts - Array of font data with name and base64 data URL
+   */
+  transferFontsToWindow?: (canvasId: string, fonts: Array<{ name: string; dataUrl: string }>) => void
+
+  /**
    * Request a file to be opened in the editor.
    * Called by the 'open' command to integrate with an IDE or editor.
    * Optional - when undefined, the open command will report that


### PR DESCRIPTION
## Summary
- Fixes fonts not loading in Canvas Window (popup) mode while they work in Tab and Export modes
- Root cause: Popup windows have isolated `document.fonts` collections, so fonts loaded in the main window weren't available in the popup

## Solution
- Store font data as base64 data URLs when fonts are loaded in CanvasController
- Transfer font data to popup windows via postMessage after canvas starts
- Convert base64 back to ArrayBuffer in the popup window and load fonts using FontFace API

## Test plan
- [x] Canvas Tab mode: fonts still work (regression check)
- [x] Canvas Window mode: custom fonts now render correctly (main fix)
- [x] Build passes
- [x] Lint passes

Fixes #562

🤖 Generated with [Claude Code](https://claude.ai/code)