### PR TITLE
refactor: Extract AssetManager from CanvasController (#571)

### DIFF
--- a/packages/lua-runtime/src/AssetManager.ts
+++ b/packages/lua-runtime/src/AssetManager.ts
@@ -1,0 +1,598 @@
+/**
+ * AssetManager - Manages asset registration, loading, and lifecycle.
+ *
+ * This class extracts asset management responsibilities from CanvasController,
+ * handling:
+ * - Asset path registration and directory scanning
+ * - Image, font, and audio asset registration
+ * - Asset loading from filesystem
+ * - Asset dimension queries
+ * - Font data transfer for popup windows
+ *
+ * Following the InputAPI pattern, this class provides a clean interface
+ * for asset management with proper state tracking.
+ */
+
+import {
+  ImageCache,
+  FontCache,
+  AssetLoader,
+} from '@lua-learning/canvas-runtime'
+import type {
+  AssetManifest,
+  DiscoveredFile,
+  AssetHandle,
+  AudioAssetHandle,
+} from '@lua-learning/canvas-runtime'
+import type { IFileSystem } from '@lua-learning/shell-core'
+import { createImageFromData, createFontFromData } from './canvasErrorFormatter'
+import type { IAudioEngine } from './audio/IAudioEngine'
+import { WebAudioEngine } from './audio/WebAudioEngine'
+
+/**
+ * Audio asset definition for tracking registered sound/music assets.
+ */
+export interface AudioAssetDefinition {
+  name: string
+  filename: string
+  type: 'sound' | 'music'
+}
+
+/**
+ * Audio asset manifest: maps asset names to their definitions.
+ */
+export type AudioAssetManifest = Map<string, AudioAssetDefinition>
+
+/**
+ * Interface for AssetManager to enable testing flexibility.
+ * Defines the subset of methods that external code interacts with.
+ */
+export interface IAssetManager {
+  // State tracking
+  markStarted(): void
+  isStarted(): boolean
+
+  // Path registration
+  addAssetPath(path: string): void
+
+  // Image/Font asset registration
+  loadImageAsset(name: string, filename: string): AssetHandle
+  loadFontAsset(name: string, filename: string): AssetHandle
+  isFontLoaded(name: string): boolean
+  getAssetManifest(): AssetManifest
+
+  // Audio asset registration
+  loadSoundAsset(name: string, filename: string): AudioAssetHandle
+  loadMusicAsset(name: string, filename: string): AudioAssetHandle
+  getAudioAssetManifest(): AudioAssetManifest
+  getAudioEngine(): IAudioEngine | null
+
+  // Asset loading
+  loadAssets(fileSystem: IFileSystem, scriptDirectory: string): Promise<void>
+
+  // Query methods
+  getAssetWidth(nameOrHandle: string | AssetHandle): number
+  getAssetHeight(nameOrHandle: string | AssetHandle): number
+  hasAsset(name: string): boolean
+
+  // Cache access
+  getImageCache(): ImageCache | null
+  getFontCache(): FontCache | null
+
+  // Font transfer
+  getFontDataForTransfer(): Array<{ name: string; dataUrl: string }>
+}
+
+/**
+ * AssetManager class that manages all asset-related operations.
+ * Extracted from CanvasController to improve separation of concerns.
+ */
+export class AssetManager implements IAssetManager {
+  // Asset manifest: registered asset definitions (legacy API)
+  private assetManifest: AssetManifest = new Map()
+
+  // Asset paths: directories to scan for assets (new API)
+  private assetPaths: string[] = []
+
+  // Discovered files: files found in scanned paths, keyed by filename
+  private discoveredFiles: Map<string, DiscoveredFile> = new Map()
+
+  // Track whether files have been loaded (for load_image after start validation)
+  private filesLoaded = false
+
+  // Image cache for loaded images
+  private imageCache: ImageCache | null = null
+
+  // Font cache for loaded fonts
+  private fontCache: FontCache | null = null
+
+  // Font data for transfer to popup windows (stores base64 data URLs)
+  // Popup windows have their own isolated document.fonts collection,
+  // so we need to transfer font data and reload fonts there
+  private fontDataForTransfer: Map<string, { name: string; dataUrl: string }> = new Map()
+
+  // Asset dimensions: width/height for each loaded asset
+  private assetDimensions: Map<string, { width: number; height: number }> = new Map()
+
+  // Audio engine for sound effects and music
+  private audioEngine: IAudioEngine | null = null
+
+  // Audio asset manifest: registered audio asset definitions
+  private audioAssetManifest: AudioAssetManifest = new Map()
+
+  // Track whether start() has been called (prevents adding assets after start)
+  private started = false
+
+  // --- State Tracking ---
+
+  /**
+   * Mark the asset manager as started.
+   * After this, no new asset paths can be added.
+   */
+  markStarted(): void {
+    this.started = true
+  }
+
+  /**
+   * Check if the asset manager has been started.
+   */
+  isStarted(): boolean {
+    return this.started
+  }
+
+  // --- Path Registration ---
+
+  /**
+   * Register a directory path to scan for assets.
+   * All image and font files in the directory (and subdirectories) will be discovered
+   * and made available for loading via loadImageAsset() or loadFontAsset().
+   *
+   * Must be called BEFORE canvas.start().
+   *
+   * @param path - Directory path to scan (relative to script or absolute)
+   * @throws Error if called after canvas.start()
+   */
+  addAssetPath(path: string): void {
+    // During hot reload, paths may be re-added - just skip if already present
+    // This check MUST come before the started check to allow reload to work
+    if (this.assetPaths.includes(path)) {
+      return
+    }
+
+    if (this.started) {
+      throw new Error('Cannot add asset paths after canvas.start()')
+    }
+
+    this.assetPaths.push(path)
+  }
+
+  // --- Image/Font Asset Registration ---
+
+  /**
+   * Create a named reference to an image file discovered via add_path().
+   * Can be called before or after canvas.start().
+   *
+   * @param name - Unique name to reference this image
+   * @param filename - Filename of the image (must exist in a scanned path)
+   * @returns AssetHandle that can be used in draw_image() or other functions
+   * @throws Error if file not found after start() or if name already exists
+   */
+  loadImageAsset(name: string, filename: string): AssetHandle {
+    // If we've already loaded files, validate that the file exists
+    if (this.filesLoaded) {
+      if (!this.discoveredFiles.has(filename)) {
+        const scannedPaths = this.assetPaths.join(', ') || '(none)'
+        throw new Error(
+          `Image file '${filename}' not found in asset paths. Scanned paths: ${scannedPaths}`
+        )
+      }
+    }
+
+    // Check for duplicate name (but allow re-mapping same name)
+    if (this.assetManifest.has(name)) {
+      const existing = this.assetManifest.get(name)!
+      // If mapping to a different file, warn but allow it
+      if (existing.path !== filename) {
+        console.warn(`Asset name '${name}' is being remapped from '${existing.path}' to '${filename}'`)
+      }
+    }
+
+    // Create the asset mapping
+    // For now, we use the filename as the path - loadAssets will resolve it from discoveredFiles
+    this.assetManifest.set(name, { name, path: filename, type: 'image' })
+
+    // Return a handle
+    return {
+      _type: 'image',
+      _name: name,
+      _file: filename,
+    }
+  }
+
+  /**
+   * Create a named reference to a font file discovered via add_path().
+   * Can be called before or after canvas.start().
+   *
+   * @param name - Unique name to reference this font (use with set_font_family)
+   * @param filename - Filename of the font (must exist in a scanned path)
+   * @returns AssetHandle that can be used to reference the font
+   * @throws Error if file not found after start() or if name already exists
+   */
+  loadFontAsset(name: string, filename: string): AssetHandle {
+    // If we've already loaded files, validate that the file exists
+    if (this.filesLoaded) {
+      if (!this.discoveredFiles.has(filename)) {
+        const scannedPaths = this.assetPaths.join(', ') || '(none)'
+        throw new Error(
+          `Font file '${filename}' not found in asset paths. Scanned paths: ${scannedPaths}`
+        )
+      }
+    }
+
+    // Check for duplicate name
+    if (this.assetManifest.has(name)) {
+      const existing = this.assetManifest.get(name)!
+      if (existing.path !== filename) {
+        console.warn(`Asset name '${name}' is being remapped from '${existing.path}' to '${filename}'`)
+      }
+    }
+
+    // Create the asset mapping
+    this.assetManifest.set(name, { name, path: filename, type: 'font' })
+
+    // Return a handle
+    return {
+      _type: 'font',
+      _name: name,
+      _file: filename,
+    }
+  }
+
+  /**
+   * Check if a font asset has been loaded.
+   * @param name - Name of the font asset
+   * @returns true if the font is loaded and available
+   */
+  isFontLoaded(name: string): boolean {
+    return this.fontCache?.has(name) ?? false
+  }
+
+  /**
+   * Get the asset manifest (definitions registered via registerAsset).
+   */
+  getAssetManifest(): AssetManifest {
+    return this.assetManifest
+  }
+
+  // --- Audio Asset Registration ---
+
+  /**
+   * Create a named reference to a sound effect file discovered via add_path().
+   * Must be called before canvas.start().
+   *
+   * @param name - Unique name to reference this sound
+   * @param filename - Filename of the audio file (must exist in a scanned path)
+   * @returns AudioAssetHandle that can be used with play_sound()
+   * @throws Error if called after canvas.start()
+   */
+  loadSoundAsset(name: string, filename: string): AudioAssetHandle {
+    // During hot reload, assets may be re-registered - return existing handle
+    const existing = this.audioAssetManifest.get(name)
+    if (existing && existing.filename === filename) {
+      return {
+        _type: 'sound',
+        _name: name,
+        _file: filename,
+      }
+    }
+
+    if (this.started) {
+      throw new Error('Cannot load audio assets after canvas.start()')
+    }
+
+    // Register in the audio manifest
+    this.audioAssetManifest.set(name, {
+      name,
+      filename,
+      type: 'sound',
+    })
+
+    // Return a handle
+    return {
+      _type: 'sound',
+      _name: name,
+      _file: filename,
+    }
+  }
+
+  /**
+   * Create a named reference to a music file discovered via add_path().
+   * Must be called before canvas.start().
+   *
+   * @param name - Unique name to reference this music track
+   * @param filename - Filename of the audio file (must exist in a scanned path)
+   * @returns AudioAssetHandle that can be used with play_music()
+   * @throws Error if called after canvas.start()
+   */
+  loadMusicAsset(name: string, filename: string): AudioAssetHandle {
+    // During hot reload, assets may be re-registered - return existing handle
+    const existing = this.audioAssetManifest.get(name)
+    if (existing && existing.filename === filename) {
+      return {
+        _type: 'music',
+        _name: name,
+        _file: filename,
+      }
+    }
+
+    if (this.started) {
+      throw new Error('Cannot load audio assets after canvas.start()')
+    }
+
+    // Register in the audio manifest
+    this.audioAssetManifest.set(name, {
+      name,
+      filename,
+      type: 'music',
+    })
+
+    // Return a handle
+    return {
+      _type: 'music',
+      _name: name,
+      _file: filename,
+    }
+  }
+
+  /**
+   * Get the audio engine for sound/music playback.
+   * Returns null if the canvas has not been started or has no audio assets.
+   */
+  getAudioEngine(): IAudioEngine | null {
+    return this.audioEngine
+  }
+
+  /**
+   * Get the audio asset manifest (definitions registered via loadSoundAsset/loadMusicAsset).
+   */
+  getAudioAssetManifest(): AudioAssetManifest {
+    return this.audioAssetManifest
+  }
+
+  // --- Asset Loading ---
+
+  /**
+   * Load all registered assets from the filesystem.
+   *
+   * Scans directories registered via addAssetPath() and loads assets
+   * that were mapped via loadImageAsset()/loadFontAsset().
+   *
+   * Must be called before start() for assets to be available.
+   *
+   * @param fileSystem - The filesystem to load assets from
+   * @param scriptDirectory - The directory containing the script (for relative paths)
+   * @throws Error if any asset fails to load
+   */
+  async loadAssets(fileSystem: IFileSystem, scriptDirectory: string): Promise<void> {
+    // Create loader and caches
+    const loader = new AssetLoader(fileSystem, scriptDirectory)
+    this.imageCache = new ImageCache()
+    this.fontCache = new FontCache()
+
+    // Step 1: Scan all registered asset paths and discover files
+    for (const path of this.assetPaths) {
+      try {
+        const files = loader.scanDirectory(path)
+        for (const file of files) {
+          // Store by relativePath - supports both bare filenames and subdirectory paths
+          // e.g., "blue_ship.png" or "images/blue_ship.png"
+          // First path wins on collision
+          if (!this.discoveredFiles.has(file.relativePath)) {
+            this.discoveredFiles.set(file.relativePath, file)
+          } else {
+            console.warn(
+              `Asset file '${file.relativePath}' found in multiple paths. ` +
+              `Using ${this.discoveredFiles.get(file.relativePath)!.fullPath}, ` +
+              `ignoring ${file.fullPath}`
+            )
+          }
+        }
+      } catch (error) {
+        // Re-throw with more context
+        const message = error instanceof Error ? error.message : String(error)
+        throw new Error(`Failed to scan asset path '${path}': ${message}`)
+      }
+    }
+
+    // Mark files as loaded so subsequent load_image/load_font calls can validate
+    this.filesLoaded = true
+
+    // Skip if no assets to load (images, fonts, or audio)
+    if (this.assetManifest.size === 0 && this.discoveredFiles.size === 0 && this.audioAssetManifest.size === 0) {
+      return
+    }
+
+    // Step 2: Load each asset from the manifest
+    for (const definition of this.assetManifest.values()) {
+      // Resolve the actual path:
+      // - If the path is in discoveredFiles (new API), use the full path
+      // - Otherwise, use the path directly (legacy API)
+      let resolvedPath = definition.path
+      const discovered = this.discoveredFiles.get(definition.path)
+      if (discovered) {
+        resolvedPath = discovered.fullPath
+      }
+
+      // Create a modified definition with the resolved path
+      const resolvedDefinition = { ...definition, path: resolvedPath }
+
+      try {
+        const loadedAsset = await loader.loadAsset(resolvedDefinition)
+
+        if (definition.type === 'image') {
+          // Convert ArrayBuffer to HTMLImageElement and store in cache
+          // Note: We get dimensions from the loaded image element rather than
+          // the AssetLoader because image-size doesn't work in the browser
+          const image = await createImageFromData(loadedAsset.data, loadedAsset.mimeType)
+          this.imageCache.set(definition.name, image)
+
+          // Store dimensions from the loaded image (browser-native)
+          this.assetDimensions.set(definition.name, {
+            width: image.width,
+            height: image.height,
+          })
+        } else if (definition.type === 'font') {
+          // Load font using FontFace API and add to document
+          const font = await createFontFromData(definition.name, loadedAsset.data)
+          this.fontCache.set(definition.name, font)
+
+          // Store font data as base64 for transfer to popup windows
+          // Popup windows have isolated document.fonts and need fonts reloaded
+          const dataUrl = this.arrayBufferToDataUrl(loadedAsset.data, loadedAsset.mimeType ?? 'font/ttf')
+          this.fontDataForTransfer.set(definition.name, {
+            name: definition.name,
+            dataUrl,
+          })
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        throw new Error(`Failed to load asset '${definition.name}': ${message}`)
+      }
+    }
+
+    // Step 3: Load audio assets if any are registered
+    if (this.audioAssetManifest.size > 0) {
+      // Initialize the audio engine
+      this.audioEngine = new WebAudioEngine()
+      await this.audioEngine.initialize()
+
+      // Load each audio asset
+      for (const audioDef of this.audioAssetManifest.values()) {
+        // Resolve the audio file path from discovered files
+        const discovered = this.discoveredFiles.get(audioDef.filename)
+        if (!discovered) {
+          const scannedPaths = this.assetPaths.join(', ') || '(none)'
+          throw new Error(
+            `Audio file '${audioDef.filename}' not found in asset paths. Scanned paths: ${scannedPaths}`
+          )
+        }
+
+        try {
+          const loadedAsset = await loader.loadAsset({
+            name: audioDef.name,
+            path: discovered.fullPath,
+            type: 'audio',
+          })
+
+          // Decode the audio data
+          await this.audioEngine.decodeAudio(audioDef.name, loadedAsset.data)
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          throw new Error(`Failed to load audio asset '${audioDef.name}': ${message}`)
+        }
+      }
+    }
+  }
+
+  // --- Query Methods ---
+
+  /**
+   * Get the width of a loaded asset.
+   * @param nameOrHandle - Name of the asset (string) or AssetHandle
+   * @returns Width in pixels
+   * @throws Error if asset is unknown
+   */
+  getAssetWidth(nameOrHandle: string | AssetHandle): number {
+    const name = this.extractAssetName(nameOrHandle)
+    const dims = this.assetDimensions.get(name)
+    if (!dims) {
+      throw new Error(`Unknown asset '${name}' - did you call canvas.assets.load_image()?`)
+    }
+    return dims.width
+  }
+
+  /**
+   * Get the height of a loaded asset.
+   * @param nameOrHandle - Name of the asset (string) or AssetHandle
+   * @returns Height in pixels
+   * @throws Error if asset is unknown
+   */
+  getAssetHeight(nameOrHandle: string | AssetHandle): number {
+    const name = this.extractAssetName(nameOrHandle)
+    const dims = this.assetDimensions.get(name)
+    if (!dims) {
+      throw new Error(`Unknown asset '${name}' - did you call canvas.assets.load_image()?`)
+    }
+    return dims.height
+  }
+
+  /**
+   * Check if an asset with the given name has been loaded.
+   * @param name - Name of the asset
+   * @returns true if the asset exists in the dimensions map
+   */
+  hasAsset(name: string): boolean {
+    return this.assetDimensions.has(name)
+  }
+
+  // --- Cache Access ---
+
+  /**
+   * Get the image cache for the renderer.
+   * @returns ImageCache instance or null if not loaded
+   */
+  getImageCache(): ImageCache | null {
+    return this.imageCache
+  }
+
+  /**
+   * Get the font cache for the renderer.
+   * @returns FontCache instance or null if not loaded
+   */
+  getFontCache(): FontCache | null {
+    return this.fontCache
+  }
+
+  // --- Font Transfer ---
+
+  /**
+   * Get font data for transfer to a popup window.
+   * Popup windows have isolated document.fonts collections, so fonts loaded
+   * in the main window need to be transferred and reloaded in the popup.
+   * @returns Array of font data with name and base64 data URL
+   */
+  getFontDataForTransfer(): Array<{ name: string; dataUrl: string }> {
+    return Array.from(this.fontDataForTransfer.values())
+  }
+
+  // --- Private Helpers ---
+
+  /**
+   * Extract the asset name from a string or AssetHandle.
+   * @param nameOrHandle - String name or AssetHandle
+   * @returns The asset name as a string
+   */
+  private extractAssetName(nameOrHandle: string | AssetHandle): string {
+    if (typeof nameOrHandle === 'string') {
+      return nameOrHandle
+    }
+    return nameOrHandle._name
+  }
+
+  /**
+   * Convert an ArrayBuffer to a base64 data URL.
+   * Used for transferring font data to popup windows via postMessage.
+   * @param buffer - The binary data to convert
+   * @param mimeType - The MIME type for the data URL
+   * @returns Base64-encoded data URL
+   */
+  private arrayBufferToDataUrl(buffer: ArrayBuffer, mimeType: string): string {
+    const bytes = new Uint8Array(buffer)
+    let binary = ''
+    for (let i = 0; i < bytes.length; i++) {
+      binary += String.fromCharCode(bytes[i])
+    }
+    const base64 = btoa(binary)
+    return `data:${mimeType};base64,${base64}`
+  }
+}

--- a/packages/lua-runtime/src/CanvasController.ts
+++ b/packages/lua-runtime/src/CanvasController.ts
@@ -15,11 +15,9 @@ import {
   CanvasRenderer,
   InputCapture,
   GameLoopController,
-  ImageCache,
-  FontCache,
-  AssetLoader,
 } from '@lua-learning/canvas-runtime'
 import { InputAPI } from './InputAPI'
+import { AssetManager } from './AssetManager'
 import type {
   DrawCommand,
   InputState,
@@ -31,30 +29,15 @@ import type {
   CanvasTextBaseline,
   CanvasDirection,
   FillRule,
-  DiscoveredFile,
   AssetHandle,
   AudioAssetHandle,
 } from '@lua-learning/canvas-runtime'
 import { isAssetHandle } from '@lua-learning/canvas-runtime'
 import type { IFileSystem, ScreenMode } from '@lua-learning/shell-core'
-import { formatOnDrawError, createImageFromData, createFontFromData } from './canvasErrorFormatter'
+import { formatOnDrawError } from './canvasErrorFormatter'
 import type { IAudioEngine } from './audio/IAudioEngine'
-import { WebAudioEngine } from './audio/WebAudioEngine'
 import type { HotReloadMode } from './LuaCommand'
-
-/**
- * Audio asset definition for tracking registered sound/music assets.
- */
-export interface AudioAssetDefinition {
-  name: string
-  filename: string
-  type: 'sound' | 'music'
-}
-
-/**
- * Audio asset manifest: maps asset names to their definitions.
- */
-export type AudioAssetManifest = Map<string, AudioAssetDefinition>
+import type { AudioAssetManifest } from './AssetManager'
 
 /**
  * Callbacks for canvas tab management.
@@ -255,37 +238,11 @@ export class CanvasController {
   // Reload callback - calls canvas.reload() in Lua environment
   private reloadCallback: (() => void) | null = null
 
-  // Track whether start() has been called (prevents adding assets after start)
-  private started = false
-
   // Track whether start() is currently in progress (prevents concurrent start calls)
   private startInProgress = false
 
-  // Asset manifest: registered asset definitions (legacy API)
-  private assetManifest: AssetManifest = new Map()
-
-  // Asset paths: directories to scan for assets (new API)
-  private assetPaths: string[] = []
-
-  // Discovered files: files found in scanned paths, keyed by filename
-  private discoveredFiles: Map<string, DiscoveredFile> = new Map()
-
-  // Track whether files have been loaded (for load_image after start validation)
-  private filesLoaded = false
-
-  // Image cache for loaded images
-  private imageCache: ImageCache | null = null
-
-  // Font cache for loaded fonts
-  private fontCache: FontCache | null = null
-
-  // Font data for transfer to popup windows (stores base64 data URLs)
-  // Popup windows have their own isolated document.fonts collection,
-  // so we need to transfer font data and reload fonts there
-  private fontDataForTransfer: Map<string, { name: string; dataUrl: string }> = new Map()
-
-  // Asset dimensions: width/height for each loaded asset
-  private assetDimensions: Map<string, { width: number; height: number }> = new Map()
+  // Asset manager - handles all asset registration, loading, and lifecycle
+  private assetManager: AssetManager = new AssetManager()
 
   // Font state
   private currentFontSize: number = 16
@@ -304,12 +261,6 @@ export class CanvasController {
   // Offscreen canvas for text measurement
   private measureCanvas: HTMLCanvasElement | null = null
   private measureCtx: CanvasRenderingContext2D | null = null
-
-  // Audio engine for sound effects and music
-  private audioEngine: IAudioEngine | null = null
-
-  // Audio asset manifest: registered audio asset definitions
-  private audioAssetManifest: AudioAssetManifest = new Map()
 
   constructor(callbacks: CanvasCallbacks, canvasId = 'canvas-main') {
     this.callbacks = callbacks
@@ -420,16 +371,16 @@ export class CanvasController {
     }
 
     // Mark as started (prevents adding new assets) and in progress
-    this.started = true
+    this.assetManager.markStarted()
     this.startInProgress = true
 
     // Auto-load assets if they are registered but not yet loaded
-    const hasAssets = this.assetManifest.size > 0 || this.audioAssetManifest.size > 0
-    if (hasAssets && !this.imageCache) {
+    const hasAssets = this.assetManager.getAssetManifest().size > 0 || this.assetManager.getAudioAssetManifest().size > 0
+    if (hasAssets && !this.assetManager.getImageCache()) {
       if (!this.callbacks.fileSystem) {
         throw new Error('Assets were registered but no filesystem is available to load them')
       }
-      await this.loadAssets(
+      await this.assetManager.loadAssets(
         this.callbacks.fileSystem,
         this.callbacks.scriptDirectory ?? '/'
       )
@@ -441,8 +392,9 @@ export class CanvasController {
     // Transfer fonts to popup window if applicable
     // Popup windows have isolated document.fonts collections, so fonts
     // loaded in the main window need to be transferred and reloaded there
-    if (this.fontDataForTransfer.size > 0 && this.callbacks.transferFontsToWindow) {
-      this.callbacks.transferFontsToWindow(this.canvasId, this.getFontDataForTransfer())
+    const fontData = this.assetManager.getFontDataForTransfer()
+    if (fontData.length > 0 && this.callbacks.transferFontsToWindow) {
+      this.callbacks.transferFontsToWindow(this.canvasId, fontData)
     }
 
     // Register close handler so UI can stop us when tab is closed
@@ -468,7 +420,7 @@ export class CanvasController {
     this.callbacks.registerCanvasStepHandler?.(this.canvasId, () => this.step())
 
     // Initialize renderer with image cache (if assets were loaded), input capture, and game loop
-    this.renderer = new CanvasRenderer(this.canvas, this.imageCache ?? undefined)
+    this.renderer = new CanvasRenderer(this.canvas, this.assetManager.getImageCache() ?? undefined)
     this.inputCapture = new InputCapture(this.canvas)
     this.inputAPI.setInputCapture(this.inputCapture)
     this.gameLoop = new GameLoopController(this.onFrame.bind(this))
@@ -545,9 +497,9 @@ export class CanvasController {
     this.canvas = null
 
     // Clean up audio engine
-    if (this.audioEngine) {
-      this.audioEngine.dispose()
-      this.audioEngine = null
+    const audioEngine = this.assetManager.getAudioEngine()
+    if (audioEngine) {
+      audioEngine.dispose()
     }
 
     // Reset startInProgress flag
@@ -1335,212 +1287,72 @@ export class CanvasController {
 
   // --- Asset Path API ---
 
+  // --- Asset Management API (delegated to AssetManager) ---
+
   /**
    * Add a directory path to scan for assets.
-   * All image and font files in the directory (and subdirectories) will be discovered
-   * and made available for loading via loadImageAsset() or loadFontAsset().
-   *
-   * Must be called BEFORE canvas.start().
-   *
-   * @param path - Directory path to scan (relative to script or absolute)
-   * @throws Error if called after canvas.start()
+   * Delegates to AssetManager.
    */
   addAssetPath(path: string): void {
-    // During hot reload, paths may be re-added - just skip if already present
-    // This check MUST come before the started check to allow reload to work
-    if (this.assetPaths.includes(path)) {
-      return
-    }
-
-    if (this.started) {
-      throw new Error('Cannot add asset paths after canvas.start()')
-    }
-
-    this.assetPaths.push(path)
+    this.assetManager.addAssetPath(path)
   }
 
   /**
    * Create a named reference to an image file discovered via add_path().
-   * Can be called before or after canvas.start().
-   *
-   * @param name - Unique name to reference this image
-   * @param filename - Filename of the image (must exist in a scanned path)
-   * @returns AssetHandle that can be used in draw_image() or other functions
-   * @throws Error if file not found after start() or if name already exists
+   * Delegates to AssetManager.
    */
   loadImageAsset(name: string, filename: string): AssetHandle {
-    // If we've already loaded files, validate that the file exists
-    if (this.filesLoaded) {
-      if (!this.discoveredFiles.has(filename)) {
-        const scannedPaths = this.assetPaths.join(', ') || '(none)'
-        throw new Error(
-          `Image file '${filename}' not found in asset paths. Scanned paths: ${scannedPaths}`
-        )
-      }
-    }
-
-    // Check for duplicate name (but allow re-mapping same name)
-    if (this.assetManifest.has(name)) {
-      const existing = this.assetManifest.get(name)!
-      // If mapping to a different file, warn but allow it
-      if (existing.path !== filename) {
-        console.warn(`Asset name '${name}' is being remapped from '${existing.path}' to '${filename}'`)
-      }
-    }
-
-    // Create the asset mapping
-    // For now, we use the filename as the path - loadAssets will resolve it from discoveredFiles
-    this.assetManifest.set(name, { name, path: filename, type: 'image' })
-
-    // Return a handle
-    return {
-      _type: 'image',
-      _name: name,
-      _file: filename,
-    }
+    return this.assetManager.loadImageAsset(name, filename)
   }
 
   /**
    * Create a named reference to a font file discovered via add_path().
-   * Can be called before or after canvas.start().
-   *
-   * @param name - Unique name to reference this font (use with set_font_family)
-   * @param filename - Filename of the font (must exist in a scanned path)
-   * @returns AssetHandle that can be used to reference the font
-   * @throws Error if file not found after start() or if name already exists
+   * Delegates to AssetManager.
    */
   loadFontAsset(name: string, filename: string): AssetHandle {
-    // If we've already loaded files, validate that the file exists
-    if (this.filesLoaded) {
-      if (!this.discoveredFiles.has(filename)) {
-        const scannedPaths = this.assetPaths.join(', ') || '(none)'
-        throw new Error(
-          `Font file '${filename}' not found in asset paths. Scanned paths: ${scannedPaths}`
-        )
-      }
-    }
-
-    // Check for duplicate name
-    if (this.assetManifest.has(name)) {
-      const existing = this.assetManifest.get(name)!
-      if (existing.path !== filename) {
-        console.warn(`Asset name '${name}' is being remapped from '${existing.path}' to '${filename}'`)
-      }
-    }
-
-    // Create the asset mapping
-    this.assetManifest.set(name, { name, path: filename, type: 'font' })
-
-    // Return a handle
-    return {
-      _type: 'font',
-      _name: name,
-      _file: filename,
-    }
+    return this.assetManager.loadFontAsset(name, filename)
   }
 
   /**
    * Check if a font asset has been loaded.
-   * @param name - Name of the font asset
-   * @returns true if the font is loaded and available
+   * Delegates to AssetManager.
    */
   isFontLoaded(name: string): boolean {
-    return this.fontCache?.has(name) ?? false
+    return this.assetManager.isFontLoaded(name)
   }
 
   /**
    * Get the asset manifest (definitions registered via registerAsset).
+   * Delegates to AssetManager.
    */
   getAssetManifest(): AssetManifest {
-    return this.assetManifest
+    return this.assetManager.getAssetManifest()
   }
 
-  // --- Audio Asset API ---
+  // --- Audio Asset API (delegated to AssetManager) ---
 
   /**
    * Create a named reference to a sound effect file discovered via add_path().
-   * Must be called before canvas.start().
-   *
-   * @param name - Unique name to reference this sound
-   * @param filename - Filename of the audio file (must exist in a scanned path)
-   * @returns AudioAssetHandle that can be used with play_sound()
-   * @throws Error if called after canvas.start()
+   * Delegates to AssetManager.
    */
   loadSoundAsset(name: string, filename: string): AudioAssetHandle {
-    // During hot reload, assets may be re-registered - return existing handle
-    const existing = this.audioAssetManifest.get(name)
-    if (existing && existing.filename === filename) {
-      return {
-        _type: 'sound',
-        _name: name,
-        _file: filename,
-      }
-    }
-
-    if (this.started) {
-      throw new Error('Cannot load audio assets after canvas.start()')
-    }
-
-    // Register in the audio manifest
-    this.audioAssetManifest.set(name, {
-      name,
-      filename,
-      type: 'sound',
-    })
-
-    // Return a handle
-    return {
-      _type: 'sound',
-      _name: name,
-      _file: filename,
-    }
+    return this.assetManager.loadSoundAsset(name, filename)
   }
 
   /**
    * Create a named reference to a music file discovered via add_path().
-   * Must be called before canvas.start().
-   *
-   * @param name - Unique name to reference this music track
-   * @param filename - Filename of the audio file (must exist in a scanned path)
-   * @returns AudioAssetHandle that can be used with play_music()
-   * @throws Error if called after canvas.start()
+   * Delegates to AssetManager.
    */
   loadMusicAsset(name: string, filename: string): AudioAssetHandle {
-    // During hot reload, assets may be re-registered - return existing handle
-    const existing = this.audioAssetManifest.get(name)
-    if (existing && existing.filename === filename) {
-      return {
-        _type: 'music',
-        _name: name,
-        _file: filename,
-      }
-    }
-
-    if (this.started) {
-      throw new Error('Cannot load audio assets after canvas.start()')
-    }
-
-    // Register in the audio manifest
-    this.audioAssetManifest.set(name, {
-      name,
-      filename,
-      type: 'music',
-    })
-
-    // Return a handle
-    return {
-      _type: 'music',
-      _name: name,
-      _file: filename,
-    }
+    return this.assetManager.loadMusicAsset(name, filename)
   }
 
   /**
    * Get the audio engine for sound/music playback.
-   * Returns null if the canvas has not been started or has no audio assets.
+   * Delegates to AssetManager.
    */
   getAudioEngine(): IAudioEngine | null {
-    return this.audioEngine
+    return this.assetManager.getAudioEngine()
   }
 
   /**
@@ -1553,142 +1365,26 @@ export class CanvasController {
 
   /**
    * Get the audio asset manifest (definitions registered via loadSoundAsset/loadMusicAsset).
+   * Delegates to AssetManager.
    */
   getAudioAssetManifest(): AudioAssetManifest {
-    return this.audioAssetManifest
+    return this.assetManager.getAudioAssetManifest()
   }
 
   /**
    * Load all registered assets from the filesystem.
-   *
-   * Scans directories registered via addAssetPath() and loads assets
-   * that were mapped via loadImageAsset()/loadFontAsset().
-   *
-   * Must be called before start() for assets to be available.
-   *
-   * @param fileSystem - The filesystem to load assets from
-   * @param scriptDirectory - The directory containing the script (for relative paths)
-   * @throws Error if any asset fails to load
+   * Delegates to AssetManager.
    */
   async loadAssets(fileSystem: IFileSystem, scriptDirectory: string): Promise<void> {
-    // Create loader and caches
-    const loader = new AssetLoader(fileSystem, scriptDirectory)
-    this.imageCache = new ImageCache()
-    this.fontCache = new FontCache()
+    await this.assetManager.loadAssets(fileSystem, scriptDirectory)
+  }
 
-    // Step 1: Scan all registered asset paths and discover files
-    for (const path of this.assetPaths) {
-      try {
-        const files = loader.scanDirectory(path)
-        for (const file of files) {
-          // Store by relativePath - supports both bare filenames and subdirectory paths
-          // e.g., "blue_ship.png" or "images/blue_ship.png"
-          // First path wins on collision
-          if (!this.discoveredFiles.has(file.relativePath)) {
-            this.discoveredFiles.set(file.relativePath, file)
-          } else {
-            console.warn(
-              `Asset file '${file.relativePath}' found in multiple paths. ` +
-              `Using ${this.discoveredFiles.get(file.relativePath)!.fullPath}, ` +
-              `ignoring ${file.fullPath}`
-            )
-          }
-        }
-      } catch (error) {
-        // Re-throw with more context
-        const message = error instanceof Error ? error.message : String(error)
-        throw new Error(`Failed to scan asset path '${path}': ${message}`)
-      }
-    }
-
-    // Mark files as loaded so subsequent load_image/load_font calls can validate
-    this.filesLoaded = true
-
-    // Skip if no assets to load
-    if (this.assetManifest.size === 0 && this.discoveredFiles.size === 0) {
-      return
-    }
-
-    // Step 2: Load each asset from the manifest
-    for (const definition of this.assetManifest.values()) {
-      // Resolve the actual path:
-      // - If the path is in discoveredFiles (new API), use the full path
-      // - Otherwise, use the path directly (legacy API)
-      let resolvedPath = definition.path
-      const discovered = this.discoveredFiles.get(definition.path)
-      if (discovered) {
-        resolvedPath = discovered.fullPath
-      }
-
-      // Create a modified definition with the resolved path
-      const resolvedDefinition = { ...definition, path: resolvedPath }
-
-      try {
-        const loadedAsset = await loader.loadAsset(resolvedDefinition)
-
-        if (definition.type === 'image') {
-          // Convert ArrayBuffer to HTMLImageElement and store in cache
-          // Note: We get dimensions from the loaded image element rather than
-          // the AssetLoader because image-size doesn't work in the browser
-          const image = await createImageFromData(loadedAsset.data, loadedAsset.mimeType)
-          this.imageCache.set(definition.name, image)
-
-          // Store dimensions from the loaded image (browser-native)
-          this.assetDimensions.set(definition.name, {
-            width: image.width,
-            height: image.height,
-          })
-        } else if (definition.type === 'font') {
-          // Load font using FontFace API and add to document
-          const font = await createFontFromData(definition.name, loadedAsset.data)
-          this.fontCache.set(definition.name, font)
-
-          // Store font data as base64 for transfer to popup windows
-          // Popup windows have isolated document.fonts and need fonts reloaded
-          const dataUrl = this.arrayBufferToDataUrl(loadedAsset.data, loadedAsset.mimeType ?? 'font/ttf')
-          this.fontDataForTransfer.set(definition.name, {
-            name: definition.name,
-            dataUrl,
-          })
-        }
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error)
-        throw new Error(`Failed to load asset '${definition.name}': ${message}`)
-      }
-    }
-
-    // Step 3: Load audio assets if any are registered
-    if (this.audioAssetManifest.size > 0) {
-      // Initialize the audio engine
-      this.audioEngine = new WebAudioEngine()
-      await this.audioEngine.initialize()
-
-      // Load each audio asset
-      for (const audioDef of this.audioAssetManifest.values()) {
-        // Resolve the audio file path from discovered files
-        const discovered = this.discoveredFiles.get(audioDef.filename)
-        if (!discovered) {
-          const scannedPaths = this.assetPaths.join(', ') || '(none)'
-          throw new Error(
-            `Audio file '${audioDef.filename}' not found in asset paths. Scanned paths: ${scannedPaths}`
-          )
-        }
-
-        try {
-          const loadedAsset = await loader.loadAsset({
-            name: audioDef.name,
-            path: discovered.fullPath,
-            type: 'audio',
-          })
-
-          // Decode the audio data
-          await this.audioEngine.decodeAudio(audioDef.name, loadedAsset.data)
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error)
-          throw new Error(`Failed to load audio asset '${audioDef.name}': ${message}`)
-        }
-      }
-    }
+  /**
+   * Get font data for transfer to a popup window.
+   * Delegates to AssetManager.
+   */
+  getFontDataForTransfer(): Array<{ name: string; dataUrl: string }> {
+    return this.assetManager.getFontDataForTransfer()
   }
 
   /**
@@ -1723,7 +1419,7 @@ export class CanvasController {
     const name = isAssetHandle(nameOrHandle) ? nameOrHandle._name : nameOrHandle
 
     // Verify asset is registered
-    if (!this.assetDimensions.has(name)) {
+    if (!this.assetManager.hasAsset(name)) {
       throw new Error(`Unknown asset '${name}' - did you call canvas.assets.load_image()?`)
     }
 
@@ -1744,32 +1440,18 @@ export class CanvasController {
 
   /**
    * Get the width of a loaded asset.
-   * @param nameOrHandle - Name of the asset (string) or AssetHandle
-   * @returns Width in pixels
-   * @throws Error if asset is unknown
+   * Delegates to AssetManager.
    */
   getAssetWidth(nameOrHandle: string | AssetHandle): number {
-    const name = isAssetHandle(nameOrHandle) ? nameOrHandle._name : nameOrHandle
-    const dims = this.assetDimensions.get(name)
-    if (!dims) {
-      throw new Error(`Unknown asset '${name}' - did you call canvas.assets.load_image()?`)
-    }
-    return dims.width
+    return this.assetManager.getAssetWidth(nameOrHandle)
   }
 
   /**
    * Get the height of a loaded asset.
-   * @param nameOrHandle - Name of the asset (string) or AssetHandle
-   * @returns Height in pixels
-   * @throws Error if asset is unknown
+   * Delegates to AssetManager.
    */
   getAssetHeight(nameOrHandle: string | AssetHandle): number {
-    const name = isAssetHandle(nameOrHandle) ? nameOrHandle._name : nameOrHandle
-    const dims = this.assetDimensions.get(name)
-    if (!dims) {
-      throw new Error(`Unknown asset '${name}' - did you call canvas.assets.load_image()?`)
-    }
-    return dims.height
+    return this.assetManager.getAssetHeight(nameOrHandle)
   }
 
   // --- Hit Testing API ---
@@ -2033,35 +1715,6 @@ export class CanvasController {
     const path = this.pathRegistry.get(pathId)
     if (!path) return false
     return this.renderer?.isPointInStroke(path, x, y) ?? false
-  }
-
-  // --- Font Transfer API (for popup windows) ---
-
-  /**
-   * Get font data for transfer to a popup window.
-   * Popup windows have isolated document.fonts collections, so fonts loaded
-   * in the main window need to be transferred and reloaded in the popup.
-   * @returns Array of font data with name and base64 data URL
-   */
-  getFontDataForTransfer(): Array<{ name: string; dataUrl: string }> {
-    return Array.from(this.fontDataForTransfer.values())
-  }
-
-  /**
-   * Convert an ArrayBuffer to a base64 data URL.
-   * Used for transferring font data to popup windows via postMessage.
-   * @param buffer - The binary data to convert
-   * @param mimeType - The MIME type for the data URL
-   * @returns Base64-encoded data URL
-   */
-  private arrayBufferToDataUrl(buffer: ArrayBuffer, mimeType: string): string {
-    const bytes = new Uint8Array(buffer)
-    let binary = ''
-    for (let i = 0; i < bytes.length; i++) {
-      binary += String.fromCharCode(bytes[i])
-    }
-    const base64 = btoa(binary)
-    return `data:${mimeType};base64,${base64}`
   }
 
   // --- Internal ---

--- a/packages/lua-runtime/src/index.ts
+++ b/packages/lua-runtime/src/index.ts
@@ -57,5 +57,8 @@ export { XTERM_INLINE_JS, XTERM_INLINE_CSS } from './xterm-inline.generated'
 // Canvas controller for shell-based canvas (non-worker)
 export { CanvasController, type CanvasCallbacks } from './CanvasController'
 
+// Asset manager for asset registration, loading, and lifecycle
+export { AssetManager, type IAssetManager, type AudioAssetManifest } from './AssetManager'
+
 // Input API for keyboard, mouse, and gamepad input handling
 export { InputAPI, type IInputCapture } from './InputAPI'

--- a/packages/lua-runtime/tests/AssetManager.test.ts
+++ b/packages/lua-runtime/tests/AssetManager.test.ts
@@ -1,0 +1,1079 @@
+/**
+ * Tests for AssetManager class - Asset registration, loading, and lifecycle.
+ * Follows TDD methodology: tests written before implementation.
+ * @vitest-environment jsdom
+ */
+/* eslint-disable max-lines */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { AssetManager } from '../src/AssetManager'
+import type { IFileSystem } from '@lua-learning/shell-core'
+
+// Mock Path2D for jsdom environment (which doesn't have Path2D)
+class MockPath2D {
+  commands: unknown[] = []
+  moveTo(x: number, y: number) { this.commands.push(['moveTo', x, y]) }
+  lineTo(x: number, y: number) { this.commands.push(['lineTo', x, y]) }
+  closePath() { this.commands.push(['closePath']) }
+}
+(globalThis as unknown as { Path2D: typeof MockPath2D }).Path2D = MockPath2D
+
+// Mock FontFace for jsdom environment (which doesn't have FontFace)
+class MockFontFace {
+  family: string
+  constructor(family: string, _source: ArrayBuffer | string) {
+    this.family = family
+  }
+  load() { return Promise.resolve(this) }
+}
+(globalThis as unknown as { FontFace: typeof MockFontFace }).FontFace = MockFontFace
+
+// Mock document.fonts for jsdom environment
+Object.defineProperty(document, 'fonts', {
+  value: {
+    add: vi.fn(),
+    delete: vi.fn(),
+    clear: vi.fn(),
+    has: vi.fn().mockReturnValue(false),
+  },
+  writable: true,
+})
+
+// Store mock instances for testing
+let mockImageCacheInstance: {
+  set: ReturnType<typeof vi.fn>
+  get: ReturnType<typeof vi.fn>
+  has: ReturnType<typeof vi.fn>
+  clear: ReturnType<typeof vi.fn>
+} | null = null
+
+let mockFontCacheInstance: {
+  set: ReturnType<typeof vi.fn>
+  get: ReturnType<typeof vi.fn>
+  has: ReturnType<typeof vi.fn>
+  getLoadedFonts: ReturnType<typeof vi.fn>
+  clear: ReturnType<typeof vi.fn>
+} | null = null
+
+let mockAssetLoaderInstance: {
+  loadAsset: ReturnType<typeof vi.fn>
+  resolvePath: ReturnType<typeof vi.fn>
+  scanDirectory: ReturnType<typeof vi.fn>
+} | null = null
+
+// Error injection flags for testing error paths
+let mockScanDirectoryError: Error | string | null = null
+let mockLoadAssetError: Error | null = null
+
+// Helper functions to set mock instances (avoids 'this' alias lint error)
+function setImageCacheInstance(instance: typeof mockImageCacheInstance): void {
+  mockImageCacheInstance = instance
+}
+
+function setFontCacheInstance(instance: typeof mockFontCacheInstance): void {
+  mockFontCacheInstance = instance
+}
+
+function setAssetLoaderInstance(instance: typeof mockAssetLoaderInstance): void {
+  mockAssetLoaderInstance = instance
+}
+
+// Helper functions for error injection
+function getScanDirectoryError(): Error | string | null {
+  return mockScanDirectoryError
+}
+
+function getLoadAssetError(): Error | null {
+  return mockLoadAssetError
+}
+
+// Mock the canvas-runtime imports
+vi.mock('@lua-learning/canvas-runtime', () => {
+  return {
+    ImageCache: class MockImageCache {
+      set = vi.fn()
+      get = vi.fn()
+      has = vi.fn()
+      clear = vi.fn()
+      constructor() {
+        setImageCacheInstance(this)
+      }
+    },
+    FontCache: class MockFontCache {
+      set = vi.fn()
+      get = vi.fn()
+      has = vi.fn().mockReturnValue(false)
+      getLoadedFonts = vi.fn().mockReturnValue([])
+      clear = vi.fn()
+      constructor() {
+        setFontCacheInstance(this)
+      }
+    },
+    AssetLoader: class MockAssetLoader {
+      loadAsset = vi.fn().mockImplementation(() => {
+        const error = getLoadAssetError()
+        if (error) {
+          return Promise.reject(error)
+        }
+        return Promise.resolve({
+          name: 'test',
+          data: new ArrayBuffer(8),
+          width: 64,
+          height: 64,
+          mimeType: 'image/png',
+        })
+      })
+      resolvePath = vi.fn((path: string) => (path.startsWith('/') ? path : `/test/${path}`))
+      scanDirectory = vi.fn().mockImplementation(() => {
+        const error = getScanDirectoryError()
+        if (error) {
+          throw error
+        }
+        return [
+          { filename: 'player.png', fullPath: '/sprites/player.png', type: 'image' as const, basePath: 'sprites', relativePath: 'player.png' },
+          { filename: 'enemy.png', fullPath: '/sprites/enemy.png', type: 'image' as const, basePath: 'sprites', relativePath: 'enemy.png' },
+        ]
+      })
+      constructor(_fs: IFileSystem, _scriptDir: string) {
+        setAssetLoaderInstance(this)
+      }
+    },
+    isAssetHandle: (obj: unknown): obj is { _type: string; _name: string; _file: string } => {
+      return typeof obj === 'object' && obj !== null && '_type' in obj && '_name' in obj
+    },
+  }
+})
+
+// Mock the audio engine
+vi.mock('../src/audio/WebAudioEngine', () => ({
+  WebAudioEngine: class MockWebAudioEngine {
+    initialize = vi.fn().mockResolvedValue(undefined)
+    decodeAudio = vi.fn().mockResolvedValue(undefined)
+    dispose = vi.fn()
+  },
+}))
+
+/**
+ * Creates a mock filesystem for testing.
+ */
+function createMockFileSystem(): IFileSystem {
+  return {
+    exists: vi.fn().mockReturnValue(true),
+    isFile: vi.fn().mockReturnValue(true),
+    isDirectory: vi.fn().mockReturnValue(false),
+    readFile: vi.fn().mockReturnValue(''),
+    writeFile: vi.fn(),
+    deleteFile: vi.fn(),
+    createDirectory: vi.fn(),
+    deleteDirectory: vi.fn(),
+    listDirectory: vi.fn().mockReturnValue([]),
+    readBinaryFile: vi.fn().mockReturnValue(new Uint8Array([1, 2, 3])),
+    writeBinaryFile: vi.fn(),
+    copyFile: vi.fn(),
+    moveFile: vi.fn(),
+    rename: vi.fn(),
+  }
+}
+
+describe('AssetManager', () => {
+  let assetManager: AssetManager
+  let originalImage: typeof Image
+
+  beforeEach(() => {
+    // Reset mock instances
+    mockImageCacheInstance = null
+    mockFontCacheInstance = null
+    mockAssetLoaderInstance = null
+
+    assetManager = new AssetManager()
+
+    // Mock the Image class to simulate immediate loading
+    originalImage = global.Image
+    global.Image = class MockImage {
+      onload: (() => void) | null = null
+      onerror: (() => void) | null = null
+      src = ''
+      width = 64
+      height = 64
+
+      constructor() {
+        // Simulate async image load completion
+        setTimeout(() => {
+          if (this.onload) this.onload()
+        }, 0)
+      }
+    } as unknown as typeof Image
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    global.Image = originalImage
+    // Reset error injection flags
+    mockScanDirectoryError = null
+    mockLoadAssetError = null
+  })
+
+  describe('construction', () => {
+    it('should construct with default state', () => {
+      expect(assetManager).toBeDefined()
+      expect(assetManager.isStarted()).toBe(false)
+      expect(assetManager.getAssetManifest().size).toBe(0)
+      expect(assetManager.getAudioAssetManifest().size).toBe(0)
+      expect(assetManager.getImageCache()).toBeNull()
+      expect(assetManager.getFontCache()).toBeNull()
+      expect(assetManager.getAudioEngine()).toBeNull()
+    })
+  })
+
+  describe('state tracking', () => {
+    describe('markStarted', () => {
+      it('should mark the asset manager as started', () => {
+        expect(assetManager.isStarted()).toBe(false)
+        assetManager.markStarted()
+        expect(assetManager.isStarted()).toBe(true)
+      })
+
+      it('should prevent adding asset paths after started', () => {
+        assetManager.markStarted()
+        expect(() => assetManager.addAssetPath('sprites')).toThrow(
+          'Cannot add asset paths after canvas.start()'
+        )
+      })
+    })
+
+    describe('isStarted', () => {
+      it('should return false initially', () => {
+        expect(assetManager.isStarted()).toBe(false)
+      })
+
+      it('should return true after markStarted', () => {
+        assetManager.markStarted()
+        expect(assetManager.isStarted()).toBe(true)
+      })
+    })
+  })
+
+  describe('path registration', () => {
+    describe('addAssetPath', () => {
+      it('should register an asset path', async () => {
+        const mockFileSystem = createMockFileSystem()
+        assetManager.addAssetPath('sprites')
+        assetManager.loadImageAsset('player', 'player.png')
+
+        await assetManager.loadAssets(mockFileSystem, '/game')
+
+        expect(mockAssetLoaderInstance!.scanDirectory).toHaveBeenCalledWith('sprites')
+      })
+
+      it('should register multiple asset paths', async () => {
+        const mockFileSystem = createMockFileSystem()
+        assetManager.addAssetPath('sprites')
+        assetManager.addAssetPath('fonts')
+        assetManager.loadImageAsset('player', 'player.png')
+
+        await assetManager.loadAssets(mockFileSystem, '/game')
+
+        expect(mockAssetLoaderInstance!.scanDirectory).toHaveBeenCalledWith('sprites')
+        expect(mockAssetLoaderInstance!.scanDirectory).toHaveBeenCalledWith('fonts')
+      })
+
+      it('should throw if called after started', () => {
+        assetManager.markStarted()
+        expect(() => assetManager.addAssetPath('sprites')).toThrow(
+          'Cannot add asset paths after canvas.start()'
+        )
+      })
+
+      it('should skip duplicate paths during hot reload', () => {
+        assetManager.addAssetPath('sprites')
+        assetManager.addAssetPath('sprites') // Should not throw, just skip
+        // If we didn't skip, this would cause issues or duplicates
+      })
+
+      it('should allow duplicate paths even after started (for hot reload)', () => {
+        assetManager.addAssetPath('sprites')
+        assetManager.markStarted()
+        // Should not throw because the path already exists
+        assetManager.addAssetPath('sprites')
+      })
+    })
+  })
+
+  describe('image asset registration', () => {
+    describe('loadImageAsset', () => {
+      it('should register an image asset with name and filename', () => {
+        assetManager.addAssetPath('sprites')
+        const handle = assetManager.loadImageAsset('player', 'player.png')
+
+        expect(handle).toEqual({
+          _type: 'image',
+          _name: 'player',
+          _file: 'player.png',
+        })
+
+        const manifest = assetManager.getAssetManifest()
+        expect(manifest.has('player')).toBe(true)
+        expect(manifest.get('player')).toEqual({
+          name: 'player',
+          path: 'player.png',
+          type: 'image',
+        })
+      })
+
+      it('should allow registering multiple image assets', () => {
+        assetManager.addAssetPath('sprites')
+        assetManager.loadImageAsset('player', 'player.png')
+        assetManager.loadImageAsset('enemy', 'enemy.png')
+
+        const manifest = assetManager.getAssetManifest()
+        expect(manifest.size).toBe(2)
+        expect(manifest.has('player')).toBe(true)
+        expect(manifest.has('enemy')).toBe(true)
+      })
+
+      it('should allow overwriting asset with same name', () => {
+        assetManager.addAssetPath('sprites')
+        assetManager.loadImageAsset('player', 'old.png')
+        assetManager.loadImageAsset('player', 'new.png')
+
+        const manifest = assetManager.getAssetManifest()
+        expect(manifest.size).toBe(1)
+        expect(manifest.get('player')?.path).toBe('new.png')
+      })
+
+      it('should return a valid AssetHandle', () => {
+        assetManager.addAssetPath('sprites')
+        const handle = assetManager.loadImageAsset('test', 'test.png')
+
+        expect(handle._type).toBe('image')
+        expect(handle._name).toBe('test')
+        expect(handle._file).toBe('test.png')
+      })
+    })
+  })
+
+  describe('font asset registration', () => {
+    describe('loadFontAsset', () => {
+      it('should register a font asset with name and filename', () => {
+        assetManager.addAssetPath('fonts')
+        const handle = assetManager.loadFontAsset('GameFont', 'pixel.ttf')
+
+        expect(handle).toEqual({
+          _type: 'font',
+          _name: 'GameFont',
+          _file: 'pixel.ttf',
+        })
+
+        const manifest = assetManager.getAssetManifest()
+        expect(manifest.has('GameFont')).toBe(true)
+        expect(manifest.get('GameFont')).toEqual({
+          name: 'GameFont',
+          path: 'pixel.ttf',
+          type: 'font',
+        })
+      })
+
+      it('should allow overwriting font with same name', () => {
+        assetManager.addAssetPath('fonts')
+        assetManager.loadFontAsset('GameFont', 'old.ttf')
+        assetManager.loadFontAsset('GameFont', 'new.ttf')
+
+        const manifest = assetManager.getAssetManifest()
+        expect(manifest.size).toBe(1)
+        expect(manifest.get('GameFont')?.path).toBe('new.ttf')
+      })
+    })
+
+    describe('isFontLoaded', () => {
+      it('should return false when font cache is null', () => {
+        expect(assetManager.isFontLoaded('TestFont')).toBe(false)
+      })
+
+      it('should delegate to font cache when available', async () => {
+        const mockFileSystem = createMockFileSystem()
+        assetManager.addAssetPath('fonts')
+        assetManager.loadFontAsset('TestFont', 'test.ttf')
+        await assetManager.loadAssets(mockFileSystem, '/game')
+
+        // Font cache should now exist
+        expect(mockFontCacheInstance).not.toBeNull()
+
+        // Configure mock to return true for has()
+        mockFontCacheInstance!.has.mockReturnValue(true)
+        expect(assetManager.isFontLoaded('TestFont')).toBe(true)
+
+        // Configure mock to return false for has()
+        mockFontCacheInstance!.has.mockReturnValue(false)
+        expect(assetManager.isFontLoaded('OtherFont')).toBe(false)
+      })
+    })
+  })
+
+  describe('audio asset registration', () => {
+    describe('loadSoundAsset', () => {
+      it('should register a sound asset', () => {
+        assetManager.addAssetPath('sounds')
+        const handle = assetManager.loadSoundAsset('explosion', 'boom.wav')
+
+        expect(handle).toEqual({
+          _type: 'sound',
+          _name: 'explosion',
+          _file: 'boom.wav',
+        })
+
+        const manifest = assetManager.getAudioAssetManifest()
+        expect(manifest.has('explosion')).toBe(true)
+        expect(manifest.get('explosion')).toEqual({
+          name: 'explosion',
+          filename: 'boom.wav',
+          type: 'sound',
+        })
+      })
+
+      it('should throw if called after started', () => {
+        assetManager.markStarted()
+        expect(() => assetManager.loadSoundAsset('explosion', 'boom.wav')).toThrow(
+          'Cannot load audio assets after canvas.start()'
+        )
+      })
+
+      it('should return existing handle during hot reload', () => {
+        assetManager.addAssetPath('sounds')
+        const handle1 = assetManager.loadSoundAsset('explosion', 'boom.wav')
+        assetManager.markStarted()
+        // During hot reload, re-registering same asset should return handle
+        const handle2 = assetManager.loadSoundAsset('explosion', 'boom.wav')
+
+        expect(handle2).toEqual(handle1)
+      })
+    })
+
+    describe('loadMusicAsset', () => {
+      it('should register a music asset', () => {
+        assetManager.addAssetPath('music')
+        const handle = assetManager.loadMusicAsset('theme', 'theme.mp3')
+
+        expect(handle).toEqual({
+          _type: 'music',
+          _name: 'theme',
+          _file: 'theme.mp3',
+        })
+
+        const manifest = assetManager.getAudioAssetManifest()
+        expect(manifest.has('theme')).toBe(true)
+        expect(manifest.get('theme')).toEqual({
+          name: 'theme',
+          filename: 'theme.mp3',
+          type: 'music',
+        })
+      })
+
+      it('should throw if called after started', () => {
+        assetManager.markStarted()
+        expect(() => assetManager.loadMusicAsset('theme', 'theme.mp3')).toThrow(
+          'Cannot load audio assets after canvas.start()'
+        )
+      })
+
+      it('should return existing handle during hot reload', () => {
+        assetManager.addAssetPath('music')
+        const handle1 = assetManager.loadMusicAsset('theme', 'theme.mp3')
+        assetManager.markStarted()
+        // During hot reload, re-registering same asset should return handle
+        const handle2 = assetManager.loadMusicAsset('theme', 'theme.mp3')
+
+        expect(handle2).toEqual(handle1)
+      })
+    })
+
+    describe('getAudioEngine', () => {
+      it('should return null before loading', () => {
+        expect(assetManager.getAudioEngine()).toBeNull()
+      })
+    })
+
+    describe('getAudioAssetManifest', () => {
+      it('should return empty map initially', () => {
+        expect(assetManager.getAudioAssetManifest().size).toBe(0)
+      })
+
+      it('should return manifest with registered assets', () => {
+        assetManager.addAssetPath('audio')
+        assetManager.loadSoundAsset('boom', 'boom.wav')
+        assetManager.loadMusicAsset('theme', 'theme.mp3')
+
+        const manifest = assetManager.getAudioAssetManifest()
+        expect(manifest.size).toBe(2)
+        expect(manifest.has('boom')).toBe(true)
+        expect(manifest.has('theme')).toBe(true)
+      })
+    })
+  })
+
+  describe('asset loading', () => {
+    let mockFileSystem: IFileSystem
+
+    beforeEach(() => {
+      mockFileSystem = createMockFileSystem()
+    })
+
+    it('should not throw if no assets registered', async () => {
+      await expect(assetManager.loadAssets(mockFileSystem, '/game')).resolves.not.toThrow()
+    })
+
+    it('should scan registered paths and load discovered files', async () => {
+      assetManager.addAssetPath('sprites')
+      assetManager.loadImageAsset('player', 'player.png')
+
+      await assetManager.loadAssets(mockFileSystem, '/game')
+
+      expect(mockAssetLoaderInstance).not.toBeNull()
+      expect(mockAssetLoaderInstance!.scanDirectory).toHaveBeenCalledWith('sprites')
+    })
+
+    it('should store loaded images in ImageCache', async () => {
+      assetManager.addAssetPath('sprites')
+      assetManager.loadImageAsset('player', 'player.png')
+
+      await assetManager.loadAssets(mockFileSystem, '/game')
+
+      expect(mockImageCacheInstance).not.toBeNull()
+      expect(mockImageCacheInstance!.set).toHaveBeenCalledWith('player', expect.any(Object))
+    })
+
+    it('should create FontCache even with only images', async () => {
+      assetManager.addAssetPath('sprites')
+      assetManager.loadImageAsset('player', 'player.png')
+
+      await assetManager.loadAssets(mockFileSystem, '/game')
+
+      expect(assetManager.getFontCache()).not.toBeNull()
+    })
+  })
+
+  describe('query methods', () => {
+    let mockFileSystem: IFileSystem
+
+    beforeEach(() => {
+      mockFileSystem = createMockFileSystem()
+    })
+
+    describe('getAssetWidth', () => {
+      it('should return asset width after loading', async () => {
+        assetManager.addAssetPath('sprites')
+        assetManager.loadImageAsset('player', 'player.png')
+        await assetManager.loadAssets(mockFileSystem, '/game')
+
+        expect(assetManager.getAssetWidth('player')).toBe(64)
+      })
+
+      it('should throw for unknown asset', () => {
+        expect(() => assetManager.getAssetWidth('unknown')).toThrow(
+          "Unknown asset 'unknown' - did you call canvas.assets.load_image()?"
+        )
+      })
+
+      it('should work with AssetHandle', async () => {
+        assetManager.addAssetPath('sprites')
+        const handle = assetManager.loadImageAsset('player', 'player.png')
+        await assetManager.loadAssets(mockFileSystem, '/game')
+
+        expect(assetManager.getAssetWidth(handle)).toBe(64)
+      })
+    })
+
+    describe('getAssetHeight', () => {
+      it('should return asset height after loading', async () => {
+        assetManager.addAssetPath('sprites')
+        assetManager.loadImageAsset('player', 'player.png')
+        await assetManager.loadAssets(mockFileSystem, '/game')
+
+        expect(assetManager.getAssetHeight('player')).toBe(64)
+      })
+
+      it('should throw for unknown asset', () => {
+        expect(() => assetManager.getAssetHeight('unknown')).toThrow(
+          "Unknown asset 'unknown' - did you call canvas.assets.load_image()?"
+        )
+      })
+
+      it('should work with AssetHandle', async () => {
+        assetManager.addAssetPath('sprites')
+        const handle = assetManager.loadImageAsset('player', 'player.png')
+        await assetManager.loadAssets(mockFileSystem, '/game')
+
+        expect(assetManager.getAssetHeight(handle)).toBe(64)
+      })
+    })
+
+    describe('hasAsset', () => {
+      it('should return false before loading', () => {
+        expect(assetManager.hasAsset('player')).toBe(false)
+      })
+
+      it('should return true after loading', async () => {
+        assetManager.addAssetPath('sprites')
+        assetManager.loadImageAsset('player', 'player.png')
+        await assetManager.loadAssets(mockFileSystem, '/game')
+
+        expect(assetManager.hasAsset('player')).toBe(true)
+      })
+
+      it('should return false for unregistered assets', async () => {
+        assetManager.addAssetPath('sprites')
+        assetManager.loadImageAsset('player', 'player.png')
+        await assetManager.loadAssets(mockFileSystem, '/game')
+
+        expect(assetManager.hasAsset('enemy')).toBe(false)
+      })
+    })
+  })
+
+  describe('cache access', () => {
+    let mockFileSystem: IFileSystem
+
+    beforeEach(() => {
+      mockFileSystem = createMockFileSystem()
+    })
+
+    describe('getImageCache', () => {
+      it('should return null before loading', () => {
+        expect(assetManager.getImageCache()).toBeNull()
+      })
+
+      it('should return ImageCache after loading', async () => {
+        assetManager.addAssetPath('sprites')
+        assetManager.loadImageAsset('player', 'player.png')
+        await assetManager.loadAssets(mockFileSystem, '/game')
+
+        expect(assetManager.getImageCache()).not.toBeNull()
+      })
+    })
+
+    describe('getFontCache', () => {
+      it('should return null before loading', () => {
+        expect(assetManager.getFontCache()).toBeNull()
+      })
+
+      it('should return FontCache after loading', async () => {
+        assetManager.addAssetPath('sprites')
+        assetManager.loadImageAsset('player', 'player.png')
+        await assetManager.loadAssets(mockFileSystem, '/game')
+
+        expect(assetManager.getFontCache()).not.toBeNull()
+      })
+    })
+  })
+
+  describe('font data transfer', () => {
+    let mockFileSystem: IFileSystem
+
+    beforeEach(() => {
+      mockFileSystem = createMockFileSystem()
+    })
+
+    describe('getFontDataForTransfer', () => {
+      it('should return empty array when no fonts loaded', () => {
+        expect(assetManager.getFontDataForTransfer()).toEqual([])
+      })
+
+      it('should return font data after loading fonts', async () => {
+        assetManager.addAssetPath('fonts')
+        assetManager.loadFontAsset('TestFont', 'test.ttf')
+
+        await assetManager.loadAssets(mockFileSystem, '/game')
+
+        const fontData = assetManager.getFontDataForTransfer()
+        expect(fontData).toHaveLength(1)
+        expect(fontData[0].name).toBe('TestFont')
+        expect(fontData[0].dataUrl).toMatch(/^data:[^;]+;base64,/)
+      })
+
+      it('should return multiple fonts', async () => {
+        assetManager.addAssetPath('fonts')
+        assetManager.loadFontAsset('Font1', 'font1.ttf')
+        assetManager.loadFontAsset('Font2', 'font2.otf')
+
+        await assetManager.loadAssets(mockFileSystem, '/game')
+
+        const fontData = assetManager.getFontDataForTransfer()
+        expect(fontData).toHaveLength(2)
+        expect(fontData.map(f => f.name)).toContain('Font1')
+        expect(fontData.map(f => f.name)).toContain('Font2')
+      })
+    })
+  })
+
+  describe('getAssetManifest', () => {
+    it('should return empty map initially', () => {
+      expect(assetManager.getAssetManifest().size).toBe(0)
+    })
+
+    it('should return the same map instance', () => {
+      const manifest1 = assetManager.getAssetManifest()
+      const manifest2 = assetManager.getAssetManifest()
+      expect(manifest1).toBe(manifest2)
+    })
+  })
+
+  describe('error paths after filesLoaded', () => {
+    let mockFileSystem: IFileSystem
+
+    beforeEach(() => {
+      mockFileSystem = createMockFileSystem()
+    })
+
+    describe('loadImageAsset after filesLoaded', () => {
+      it('should throw when file not found in discovered files', async () => {
+        // Setup: Load assets first to set filesLoaded=true
+        assetManager.addAssetPath('sprites')
+        assetManager.loadImageAsset('player', 'player.png')
+        await assetManager.loadAssets(mockFileSystem, '/game')
+
+        // Then try to load an image that wasn't discovered
+        expect(() => assetManager.loadImageAsset('missing', 'notfound.png')).toThrow(
+          "Image file 'notfound.png' not found in asset paths"
+        )
+      })
+
+      it('should include scanned paths in error message', async () => {
+        assetManager.addAssetPath('sprites')
+        assetManager.addAssetPath('images')
+        assetManager.loadImageAsset('player', 'player.png')
+        await assetManager.loadAssets(mockFileSystem, '/game')
+
+        expect(() => assetManager.loadImageAsset('missing', 'notfound.png')).toThrow(
+          /Scanned paths: sprites, images/
+        )
+      })
+
+      it('should show (none) when no paths were scanned', async () => {
+        // Load with no asset paths
+        await assetManager.loadAssets(mockFileSystem, '/game')
+
+        expect(() => assetManager.loadImageAsset('missing', 'notfound.png')).toThrow(
+          /Scanned paths: \(none\)/
+        )
+      })
+    })
+
+    describe('loadFontAsset after filesLoaded', () => {
+      it('should throw when file not found in discovered files', async () => {
+        assetManager.addAssetPath('fonts')
+        assetManager.loadFontAsset('TestFont', 'test.ttf')
+        await assetManager.loadAssets(mockFileSystem, '/game')
+
+        expect(() => assetManager.loadFontAsset('MissingFont', 'notfound.ttf')).toThrow(
+          "Font file 'notfound.ttf' not found in asset paths"
+        )
+      })
+
+      it('should include scanned paths in error message', async () => {
+        assetManager.addAssetPath('fonts')
+        assetManager.addAssetPath('assets')
+        assetManager.loadFontAsset('TestFont', 'test.ttf')
+        await assetManager.loadAssets(mockFileSystem, '/game')
+
+        expect(() => assetManager.loadFontAsset('MissingFont', 'notfound.ttf')).toThrow(
+          /Scanned paths: fonts, assets/
+        )
+      })
+    })
+  })
+
+  describe('asset remapping warnings', () => {
+    it('should warn when remapping image to different file', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      assetManager.addAssetPath('sprites')
+      assetManager.loadImageAsset('player', 'old.png')
+      assetManager.loadImageAsset('player', 'new.png')
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Asset name 'player' is being remapped from 'old.png' to 'new.png'")
+      )
+      warnSpy.mockRestore()
+    })
+
+    it('should not warn when remapping to same file', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      assetManager.addAssetPath('sprites')
+      assetManager.loadImageAsset('player', 'player.png')
+      assetManager.loadImageAsset('player', 'player.png')
+
+      expect(warnSpy).not.toHaveBeenCalled()
+      warnSpy.mockRestore()
+    })
+
+    it('should warn when remapping font to different file', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      assetManager.addAssetPath('fonts')
+      assetManager.loadFontAsset('GameFont', 'old.ttf')
+      assetManager.loadFontAsset('GameFont', 'new.ttf')
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Asset name 'GameFont' is being remapped from 'old.ttf' to 'new.ttf'")
+      )
+      warnSpy.mockRestore()
+    })
+
+    it('should not warn when remapping font to same file', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      assetManager.addAssetPath('fonts')
+      assetManager.loadFontAsset('GameFont', 'game.ttf')
+      assetManager.loadFontAsset('GameFont', 'game.ttf')
+
+      expect(warnSpy).not.toHaveBeenCalled()
+      warnSpy.mockRestore()
+    })
+  })
+
+  describe('loadAssets error handling', () => {
+    let mockFileSystem: IFileSystem
+
+    beforeEach(() => {
+      mockFileSystem = createMockFileSystem()
+      // Reset assetManager to fresh state
+      assetManager = new AssetManager()
+    })
+
+    it('should wrap scanDirectory errors with context', async () => {
+      // Set up error injection
+      mockScanDirectoryError = new Error('Directory not found')
+
+      assetManager.addAssetPath('broken_path')
+      assetManager.loadImageAsset('test', 'test.png')
+
+      await expect(assetManager.loadAssets(mockFileSystem, '/game'))
+        .rejects.toThrow(/Failed to scan asset path 'broken_path':.*Directory not found/)
+    })
+
+    it('should wrap loadAsset errors with context', async () => {
+      // Set up error injection
+      mockLoadAssetError = new Error('Corrupt file data')
+
+      assetManager.addAssetPath('sprites')
+      assetManager.loadImageAsset('corrupted', 'corrupted.png')
+
+      await expect(assetManager.loadAssets(mockFileSystem, '/game'))
+        .rejects.toThrow(/Failed to load asset 'corrupted':.*Corrupt file data/)
+    })
+
+    it('should wrap non-Error exceptions as strings', async () => {
+      // Set up error injection with a string (non-Error)
+      mockScanDirectoryError = 'String error message'
+
+      assetManager.addAssetPath('broken')
+      assetManager.loadImageAsset('test', 'test.png')
+
+      await expect(assetManager.loadAssets(mockFileSystem, '/game'))
+        .rejects.toThrow(/Failed to scan asset path 'broken': String error message/)
+    })
+  })
+
+  describe('audio asset loading errors', () => {
+    let mockFileSystem: IFileSystem
+
+    beforeEach(() => {
+      mockFileSystem = createMockFileSystem()
+    })
+
+    it('should throw when audio file not found in discovered files', async () => {
+      // The default mock returns only player.png and enemy.png
+      // So any audio file should not be found
+      assetManager = new AssetManager()
+      assetManager.addAssetPath('assets')
+      assetManager.loadSoundAsset('boom', 'boom.wav')
+
+      await expect(assetManager.loadAssets(mockFileSystem, '/game'))
+        .rejects.toThrow("Audio file 'boom.wav' not found in asset paths")
+    })
+
+    it('should include scanned paths in audio file not found error', async () => {
+      assetManager = new AssetManager()
+      assetManager.addAssetPath('sounds')
+      assetManager.addAssetPath('audio')
+      assetManager.loadSoundAsset('boom', 'boom.wav')
+
+      await expect(assetManager.loadAssets(mockFileSystem, '/game'))
+        .rejects.toThrow(/Scanned paths: sounds, audio/)
+    })
+
+    it('should show (none) in audio error when no paths scanned', async () => {
+      assetManager = new AssetManager()
+      assetManager.loadSoundAsset('boom', 'boom.wav')
+
+      await expect(assetManager.loadAssets(mockFileSystem, '/game'))
+        .rejects.toThrow(/Scanned paths: \(none\)/)
+    })
+  })
+
+  describe('arrayBufferToDataUrl verification', () => {
+    let mockFileSystem: IFileSystem
+
+    beforeEach(() => {
+      mockFileSystem = createMockFileSystem()
+    })
+
+    it('should produce valid data URL with base64 encoding', async () => {
+      // The default mock returns ArrayBuffer(8) for fonts
+      assetManager = new AssetManager()
+      assetManager.addAssetPath('fonts')
+      assetManager.loadFontAsset('TestFont', 'test.ttf')
+
+      await assetManager.loadAssets(mockFileSystem, '/game')
+
+      const fontData = assetManager.getFontDataForTransfer()
+      expect(fontData).toHaveLength(1)
+      // Should produce a valid data URL structure
+      expect(fontData[0].dataUrl).toMatch(/^data:[^;]+;base64,[A-Za-z0-9+/]*=*$/)
+      // Verify the font name is correct
+      expect(fontData[0].name).toBe('TestFont')
+    })
+
+    it('should produce different base64 for different data', async () => {
+      // Load first font
+      assetManager = new AssetManager()
+      assetManager.addAssetPath('fonts')
+      assetManager.loadFontAsset('Font1', 'font1.ttf')
+      assetManager.loadFontAsset('Font2', 'font2.ttf')
+
+      await assetManager.loadAssets(mockFileSystem, '/game')
+
+      const fontData = assetManager.getFontDataForTransfer()
+      expect(fontData).toHaveLength(2)
+
+      // Both fonts should have valid data URLs
+      for (const font of fontData) {
+        expect(font.dataUrl).toMatch(/^data:[^;]+;base64,/)
+      }
+    })
+
+    it('should include mimeType in data URL', async () => {
+      assetManager = new AssetManager()
+      assetManager.addAssetPath('fonts')
+      assetManager.loadFontAsset('TestFont', 'test.ttf')
+
+      await assetManager.loadAssets(mockFileSystem, '/game')
+
+      const fontData = assetManager.getFontDataForTransfer()
+      expect(fontData).toHaveLength(1)
+      // The mock returns 'image/png' as mimeType, but for fonts it should use the mime
+      expect(fontData[0].dataUrl).toContain('data:')
+      expect(fontData[0].dataUrl).toContain(';base64,')
+    })
+  })
+
+  describe('extractAssetName behavior', () => {
+    let mockFileSystem: IFileSystem
+
+    beforeEach(() => {
+      mockFileSystem = createMockFileSystem()
+      // Reset assetManager to fresh state
+      assetManager = new AssetManager()
+    })
+
+    it('should work with string names for getAssetWidth', async () => {
+      assetManager.addAssetPath('sprites')
+      assetManager.loadImageAsset('player', 'player.png')
+      await assetManager.loadAssets(mockFileSystem, '/game')
+
+      // Test with string - should work
+      expect(assetManager.getAssetWidth('player')).toBe(64)
+
+      // Verify throwing behavior with wrong name
+      expect(() => assetManager.getAssetWidth('wrong')).toThrow(
+        "Unknown asset 'wrong' - did you call canvas.assets.load_image()?"
+      )
+    })
+
+    it('should work with string names for getAssetHeight', async () => {
+      assetManager.addAssetPath('sprites')
+      assetManager.loadImageAsset('player', 'player.png')
+      await assetManager.loadAssets(mockFileSystem, '/game')
+
+      expect(assetManager.getAssetHeight('player')).toBe(64)
+
+      expect(() => assetManager.getAssetHeight('wrong')).toThrow(
+        "Unknown asset 'wrong' - did you call canvas.assets.load_image()?"
+      )
+    })
+
+    it('should work with AssetHandle for getAssetWidth', async () => {
+      assetManager.addAssetPath('sprites')
+      const handle = assetManager.loadImageAsset('player', 'player.png')
+      await assetManager.loadAssets(mockFileSystem, '/game')
+
+      // Test with handle - should work
+      expect(assetManager.getAssetWidth(handle)).toBe(64)
+
+      // Verify handle with wrong name throws
+      const badHandle = { _type: 'image', _name: 'nonexistent', _file: 'nonexistent.png' }
+      expect(() => assetManager.getAssetWidth(badHandle)).toThrow(
+        "Unknown asset 'nonexistent' - did you call canvas.assets.load_image()?"
+      )
+    })
+
+    it('should work with AssetHandle for getAssetHeight', async () => {
+      assetManager.addAssetPath('sprites')
+      const handle = assetManager.loadImageAsset('player', 'player.png')
+      await assetManager.loadAssets(mockFileSystem, '/game')
+
+      expect(assetManager.getAssetHeight(handle)).toBe(64)
+
+      const badHandle = { _type: 'image', _name: 'nonexistent', _file: 'nonexistent.png' }
+      expect(() => assetManager.getAssetHeight(badHandle)).toThrow(
+        "Unknown asset 'nonexistent' - did you call canvas.assets.load_image()?"
+      )
+    })
+  })
+
+  describe('duplicate files warning in loadAssets', () => {
+    let mockFileSystem: IFileSystem
+
+    beforeEach(() => {
+      mockFileSystem = createMockFileSystem()
+      // Reset assetManager to fresh state
+      assetManager = new AssetManager()
+    })
+
+    it('should warn when same file found in multiple asset paths', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      assetManager.addAssetPath('sprites1')
+      assetManager.addAssetPath('sprites2')
+      assetManager.loadImageAsset('player', 'player.png')
+
+      // The default mock returns same files for each scan
+      await assetManager.loadAssets(mockFileSystem, '/game')
+
+      // The mock returns same relativePath for both calls, so warning should fire
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Asset file 'player.png' found in multiple paths")
+      )
+
+      warnSpy.mockRestore()
+    })
+
+    it('should use first path on collision and mention both paths in warning', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      assetManager.addAssetPath('path1')
+      assetManager.addAssetPath('path2')
+      assetManager.loadImageAsset('player', 'player.png')
+
+      await assetManager.loadAssets(mockFileSystem, '/game')
+
+      // Check the warning mentions using first and ignoring second
+      expect(warnSpy).toHaveBeenCalled()
+      const warningMessage = warnSpy.mock.calls[0][0]
+      expect(warningMessage).toContain('Using')
+      expect(warningMessage).toContain('ignoring')
+
+      warnSpy.mockRestore()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Extract asset management responsibilities from CanvasController into a dedicated AssetManager class
- Create IAssetManager interface for improved testability and dependency injection
- Move asset path registration, image/font/audio asset loading, and cache access methods
- Add comprehensive unit tests (73 tests) with 81.20% mutation coverage
- Fix early return bug when only audio assets are registered (no image/font assets)

## Test plan
- [x] All 73 AssetManager unit tests pass
- [x] Mutation score: 81.20% (target: ≥80%)
- [x] All existing tests pass (2409 tests)
- [x] Build passes
- [x] Lint passes

Closes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)