### PR TITLE
refactor: Extract DrawingAPI from CanvasController (#575)

### DIFF
--- a/packages/lua-runtime/src/DrawingAPI.ts
+++ b/packages/lua-runtime/src/DrawingAPI.ts
@@ -1,0 +1,216 @@
+/**
+ * DrawingAPI - Facade for canvas drawing primitive operations.
+ *
+ * This class manages drawing-related canvas operations including:
+ * - Canvas clearing (clear, clearRect)
+ * - Color and line width settings (setColor, setLineWidth)
+ * - Shape primitives (drawRect, fillRect, drawCircle, fillCircle, drawLine)
+ * - Text rendering (drawText, strokeText)
+ *
+ * It uses callback dependency injection for addDrawCommand() to integrate
+ * with the CanvasController's command queue.
+ */
+
+import type { DrawCommand } from '@lua-learning/canvas-runtime'
+
+/**
+ * Options for text drawing methods.
+ */
+export interface TextOptions {
+  fontSize?: number
+  fontFamily?: string
+  maxWidth?: number
+}
+
+/**
+ * Interface for DrawingAPI public methods.
+ */
+export interface IDrawingAPI {
+  // Canvas clearing
+  clear(): void
+  clearRect(x: number, y: number, width: number, height: number): void
+
+  // Color and line settings
+  setColor(r: number, g: number, b: number, a?: number): void
+  setLineWidth(width: number): void
+
+  // Shape primitives
+  drawRect(x: number, y: number, width: number, height: number): void
+  fillRect(x: number, y: number, width: number, height: number): void
+  drawCircle(x: number, y: number, radius: number): void
+  fillCircle(x: number, y: number, radius: number): void
+  drawLine(x1: number, y1: number, x2: number, y2: number): void
+
+  // Text rendering
+  drawText(x: number, y: number, text: string, options?: TextOptions): void
+  strokeText(x: number, y: number, text: string, options?: TextOptions): void
+}
+
+/**
+ * Facade for canvas drawing primitive operations.
+ * Provides null-safe access to drawing operations via callback dependency injection.
+ */
+export class DrawingAPI implements IDrawingAPI {
+  private addDrawCommand: ((cmd: DrawCommand) => void) | null = null
+
+  /**
+   * Set the callback for adding draw commands.
+   * Required for all drawing operations to take effect.
+   * @param fn - Callback to add a draw command, or null to disable
+   */
+  setAddDrawCommand(fn: ((cmd: DrawCommand) => void) | null): void {
+    this.addDrawCommand = fn
+  }
+
+  // ============================================================================
+  // Canvas Clearing Methods
+  // ============================================================================
+
+  /**
+   * Clear the entire canvas.
+   */
+  clear(): void {
+    this.addDrawCommand?.({ type: 'clear' })
+  }
+
+  /**
+   * Clear a rectangular area of the canvas to transparent.
+   * @param x - X coordinate of the top-left corner
+   * @param y - Y coordinate of the top-left corner
+   * @param width - Width of the rectangle
+   * @param height - Height of the rectangle
+   */
+  clearRect(x: number, y: number, width: number, height: number): void {
+    this.addDrawCommand?.({ type: 'clearRect', x, y, width, height })
+  }
+
+  // ============================================================================
+  // Color and Line Width Methods
+  // ============================================================================
+
+  /**
+   * Set the drawing color using RGB(A) values.
+   * @param r - Red component (0-255)
+   * @param g - Green component (0-255)
+   * @param b - Blue component (0-255)
+   * @param a - Optional alpha component (0-255 or 0-1 depending on renderer)
+   */
+  setColor(r: number, g: number, b: number, a?: number): void {
+    const command: DrawCommand = { type: 'setColor', r, g, b }
+    if (a !== undefined && a !== null) {
+      (command as { type: 'setColor'; r: number; g: number; b: number; a?: number }).a = a
+    }
+    this.addDrawCommand?.(command)
+  }
+
+  /**
+   * Set the line width for stroke operations.
+   * @param width - Line width in pixels
+   */
+  setLineWidth(width: number): void {
+    this.addDrawCommand?.({ type: 'setLineWidth', width })
+  }
+
+  // ============================================================================
+  // Shape Primitive Methods
+  // ============================================================================
+
+  /**
+   * Draw a rectangle outline.
+   * @param x - X coordinate of the top-left corner
+   * @param y - Y coordinate of the top-left corner
+   * @param width - Width of the rectangle
+   * @param height - Height of the rectangle
+   */
+  drawRect(x: number, y: number, width: number, height: number): void {
+    this.addDrawCommand?.({ type: 'rect', x, y, width, height })
+  }
+
+  /**
+   * Draw a filled rectangle.
+   * @param x - X coordinate of the top-left corner
+   * @param y - Y coordinate of the top-left corner
+   * @param width - Width of the rectangle
+   * @param height - Height of the rectangle
+   */
+  fillRect(x: number, y: number, width: number, height: number): void {
+    this.addDrawCommand?.({ type: 'fillRect', x, y, width, height })
+  }
+
+  /**
+   * Draw a circle outline.
+   * @param x - X coordinate of the center
+   * @param y - Y coordinate of the center
+   * @param radius - Radius of the circle
+   */
+  drawCircle(x: number, y: number, radius: number): void {
+    this.addDrawCommand?.({ type: 'circle', x, y, radius })
+  }
+
+  /**
+   * Draw a filled circle.
+   * @param x - X coordinate of the center
+   * @param y - Y coordinate of the center
+   * @param radius - Radius of the circle
+   */
+  fillCircle(x: number, y: number, radius: number): void {
+    this.addDrawCommand?.({ type: 'fillCircle', x, y, radius })
+  }
+
+  /**
+   * Draw a line between two points.
+   * @param x1 - X coordinate of the start point
+   * @param y1 - Y coordinate of the start point
+   * @param x2 - X coordinate of the end point
+   * @param y2 - Y coordinate of the end point
+   */
+  drawLine(x1: number, y1: number, x2: number, y2: number): void {
+    this.addDrawCommand?.({ type: 'line', x1, y1, x2, y2 })
+  }
+
+  // ============================================================================
+  // Text Rendering Methods
+  // ============================================================================
+
+  /**
+   * Draw filled text at the specified position.
+   * @param x - X coordinate
+   * @param y - Y coordinate
+   * @param text - Text to draw
+   * @param options - Optional font overrides for this text only
+   */
+  drawText(x: number, y: number, text: string, options?: TextOptions): void {
+    const command: DrawCommand = { type: 'text', x, y, text }
+    if (options?.fontSize !== undefined) {
+      (command as { fontSize?: number }).fontSize = options.fontSize
+    }
+    if (options?.fontFamily !== undefined) {
+      (command as { fontFamily?: string }).fontFamily = options.fontFamily
+    }
+    if (options?.maxWidth !== undefined) {
+      (command as { maxWidth?: number }).maxWidth = options.maxWidth
+    }
+    this.addDrawCommand?.(command)
+  }
+
+  /**
+   * Draw text outline (stroke) at the specified position.
+   * @param x - X coordinate
+   * @param y - Y coordinate
+   * @param text - Text to draw
+   * @param options - Optional font overrides for this text only
+   */
+  strokeText(x: number, y: number, text: string, options?: TextOptions): void {
+    const command: DrawCommand = { type: 'strokeText', x, y, text }
+    if (options?.fontSize !== undefined) {
+      (command as { fontSize?: number }).fontSize = options.fontSize
+    }
+    if (options?.fontFamily !== undefined) {
+      (command as { fontFamily?: string }).fontFamily = options.fontFamily
+    }
+    if (options?.maxWidth !== undefined) {
+      (command as { maxWidth?: number }).maxWidth = options.maxWidth
+    }
+    this.addDrawCommand?.(command)
+  }
+}

--- a/packages/lua-runtime/tests/DrawingAPI.test.ts
+++ b/packages/lua-runtime/tests/DrawingAPI.test.ts
@@ -1,0 +1,676 @@
+/* eslint-disable max-lines */
+/**
+ * Tests for DrawingAPI class - Facade for canvas drawing primitive operations.
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { DrawingAPI } from '../src/DrawingAPI'
+import type { DrawCommand } from '@lua-learning/canvas-runtime'
+
+describe('DrawingAPI', () => {
+  let drawingAPI: DrawingAPI
+  let mockAddDrawCommand: ReturnType<typeof vi.fn<[DrawCommand], void>>
+
+  beforeEach(() => {
+    drawingAPI = new DrawingAPI()
+    mockAddDrawCommand = vi.fn()
+  })
+
+  describe('construction', () => {
+    it('should construct with no arguments', () => {
+      expect(drawingAPI).toBeDefined()
+    })
+  })
+
+  describe('setAddDrawCommand', () => {
+    it('should allow setting the draw command callback', () => {
+      drawingAPI.setAddDrawCommand(mockAddDrawCommand)
+      drawingAPI.clear()
+      expect(mockAddDrawCommand).toHaveBeenCalled()
+    })
+
+    it('should allow setting callback to null', () => {
+      drawingAPI.setAddDrawCommand(mockAddDrawCommand)
+      drawingAPI.setAddDrawCommand(null)
+      drawingAPI.clear()
+      expect(mockAddDrawCommand).not.toHaveBeenCalled()
+    })
+
+    it('should not throw when addDrawCommand is null', () => {
+      expect(() => drawingAPI.clear()).not.toThrow()
+      expect(() => drawingAPI.clearRect(0, 0, 100, 100)).not.toThrow()
+      expect(() => drawingAPI.setColor(255, 0, 0)).not.toThrow()
+      expect(() => drawingAPI.setColor(255, 0, 0, 128)).not.toThrow()
+      expect(() => drawingAPI.setLineWidth(5)).not.toThrow()
+      expect(() => drawingAPI.drawRect(0, 0, 100, 100)).not.toThrow()
+      expect(() => drawingAPI.fillRect(0, 0, 100, 100)).not.toThrow()
+      expect(() => drawingAPI.drawCircle(50, 50, 25)).not.toThrow()
+      expect(() => drawingAPI.fillCircle(50, 50, 25)).not.toThrow()
+      expect(() => drawingAPI.drawLine(0, 0, 100, 100)).not.toThrow()
+      expect(() => drawingAPI.drawText(10, 10, 'Hello')).not.toThrow()
+      expect(() => drawingAPI.strokeText(10, 10, 'Hello')).not.toThrow()
+    })
+  })
+
+  describe('canvas clearing methods', () => {
+    beforeEach(() => {
+      drawingAPI.setAddDrawCommand(mockAddDrawCommand)
+    })
+
+    describe('clear', () => {
+      it('should add clear command', () => {
+        drawingAPI.clear()
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({ type: 'clear' })
+      })
+
+      it('should call clear multiple times', () => {
+        drawingAPI.clear()
+        drawingAPI.clear()
+        expect(mockAddDrawCommand).toHaveBeenCalledTimes(2)
+      })
+    })
+
+    describe('clearRect', () => {
+      it('should add clearRect command with coordinates', () => {
+        drawingAPI.clearRect(10, 20, 100, 200)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'clearRect',
+          x: 10,
+          y: 20,
+          width: 100,
+          height: 200,
+        })
+      })
+
+      it('should handle zero values', () => {
+        drawingAPI.clearRect(0, 0, 0, 0)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'clearRect',
+          x: 0,
+          y: 0,
+          width: 0,
+          height: 0,
+        })
+      })
+
+      it('should handle negative coordinates', () => {
+        drawingAPI.clearRect(-10, -20, 100, 100)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'clearRect',
+          x: -10,
+          y: -20,
+          width: 100,
+          height: 100,
+        })
+      })
+    })
+  })
+
+  describe('color and line width methods', () => {
+    beforeEach(() => {
+      drawingAPI.setAddDrawCommand(mockAddDrawCommand)
+    })
+
+    describe('setColor', () => {
+      it('should add setColor command with RGB values', () => {
+        drawingAPI.setColor(255, 128, 64)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'setColor',
+          r: 255,
+          g: 128,
+          b: 64,
+        })
+      })
+
+      it('should add setColor command with RGBA values', () => {
+        drawingAPI.setColor(255, 128, 64, 200)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'setColor',
+          r: 255,
+          g: 128,
+          b: 64,
+          a: 200,
+        })
+      })
+
+      it('should handle zero alpha', () => {
+        drawingAPI.setColor(255, 0, 0, 0)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'setColor',
+          r: 255,
+          g: 0,
+          b: 0,
+          a: 0,
+        })
+      })
+
+      it('should not include alpha when undefined', () => {
+        drawingAPI.setColor(100, 150, 200, undefined)
+        const call = mockAddDrawCommand.mock.calls[0][0]
+        expect(call).toEqual({ type: 'setColor', r: 100, g: 150, b: 200 })
+        expect('a' in call).toBe(false)
+      })
+
+      it('should not include alpha when null', () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        drawingAPI.setColor(100, 150, 200, null as any)
+        const call = mockAddDrawCommand.mock.calls[0][0]
+        expect(call).toEqual({ type: 'setColor', r: 100, g: 150, b: 200 })
+        expect('a' in call).toBe(false)
+      })
+
+      it('should handle edge case color values', () => {
+        drawingAPI.setColor(0, 0, 0)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'setColor',
+          r: 0,
+          g: 0,
+          b: 0,
+        })
+
+        mockAddDrawCommand.mockClear()
+        drawingAPI.setColor(255, 255, 255)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'setColor',
+          r: 255,
+          g: 255,
+          b: 255,
+        })
+      })
+    })
+
+    describe('setLineWidth', () => {
+      it('should add setLineWidth command', () => {
+        drawingAPI.setLineWidth(5)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'setLineWidth',
+          width: 5,
+        })
+      })
+
+      it('should handle various line widths', () => {
+        drawingAPI.setLineWidth(1)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'setLineWidth',
+          width: 1,
+        })
+
+        mockAddDrawCommand.mockClear()
+        drawingAPI.setLineWidth(0.5)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'setLineWidth',
+          width: 0.5,
+        })
+
+        mockAddDrawCommand.mockClear()
+        drawingAPI.setLineWidth(10)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'setLineWidth',
+          width: 10,
+        })
+      })
+
+      it('should handle zero line width', () => {
+        drawingAPI.setLineWidth(0)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'setLineWidth',
+          width: 0,
+        })
+      })
+    })
+  })
+
+  describe('shape primitive methods', () => {
+    beforeEach(() => {
+      drawingAPI.setAddDrawCommand(mockAddDrawCommand)
+    })
+
+    describe('drawRect', () => {
+      it('should add rect command', () => {
+        drawingAPI.drawRect(10, 20, 100, 50)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'rect',
+          x: 10,
+          y: 20,
+          width: 100,
+          height: 50,
+        })
+      })
+
+      it('should handle zero dimensions', () => {
+        drawingAPI.drawRect(0, 0, 0, 0)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'rect',
+          x: 0,
+          y: 0,
+          width: 0,
+          height: 0,
+        })
+      })
+
+      it('should handle negative coordinates', () => {
+        drawingAPI.drawRect(-50, -50, 100, 100)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'rect',
+          x: -50,
+          y: -50,
+          width: 100,
+          height: 100,
+        })
+      })
+    })
+
+    describe('fillRect', () => {
+      it('should add fillRect command', () => {
+        drawingAPI.fillRect(10, 20, 100, 50)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'fillRect',
+          x: 10,
+          y: 20,
+          width: 100,
+          height: 50,
+        })
+      })
+
+      it('should handle floating point values', () => {
+        drawingAPI.fillRect(10.5, 20.5, 100.5, 50.5)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'fillRect',
+          x: 10.5,
+          y: 20.5,
+          width: 100.5,
+          height: 50.5,
+        })
+      })
+    })
+
+    describe('drawCircle', () => {
+      it('should add circle command', () => {
+        drawingAPI.drawCircle(50, 50, 25)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'circle',
+          x: 50,
+          y: 50,
+          radius: 25,
+        })
+      })
+
+      it('should handle zero radius', () => {
+        drawingAPI.drawCircle(100, 100, 0)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'circle',
+          x: 100,
+          y: 100,
+          radius: 0,
+        })
+      })
+
+      it('should handle large radius', () => {
+        drawingAPI.drawCircle(0, 0, 1000)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'circle',
+          x: 0,
+          y: 0,
+          radius: 1000,
+        })
+      })
+    })
+
+    describe('fillCircle', () => {
+      it('should add fillCircle command', () => {
+        drawingAPI.fillCircle(50, 50, 25)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'fillCircle',
+          x: 50,
+          y: 50,
+          radius: 25,
+        })
+      })
+
+      it('should handle negative coordinates', () => {
+        drawingAPI.fillCircle(-100, -100, 50)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'fillCircle',
+          x: -100,
+          y: -100,
+          radius: 50,
+        })
+      })
+    })
+
+    describe('drawLine', () => {
+      it('should add line command', () => {
+        drawingAPI.drawLine(0, 0, 100, 100)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'line',
+          x1: 0,
+          y1: 0,
+          x2: 100,
+          y2: 100,
+        })
+      })
+
+      it('should handle horizontal line', () => {
+        drawingAPI.drawLine(0, 50, 100, 50)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'line',
+          x1: 0,
+          y1: 50,
+          x2: 100,
+          y2: 50,
+        })
+      })
+
+      it('should handle vertical line', () => {
+        drawingAPI.drawLine(50, 0, 50, 100)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'line',
+          x1: 50,
+          y1: 0,
+          x2: 50,
+          y2: 100,
+        })
+      })
+
+      it('should handle zero-length line (same point)', () => {
+        drawingAPI.drawLine(50, 50, 50, 50)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'line',
+          x1: 50,
+          y1: 50,
+          x2: 50,
+          y2: 50,
+        })
+      })
+
+      it('should handle negative coordinates', () => {
+        drawingAPI.drawLine(-50, -50, 50, 50)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'line',
+          x1: -50,
+          y1: -50,
+          x2: 50,
+          y2: 50,
+        })
+      })
+    })
+  })
+
+  describe('text rendering methods', () => {
+    beforeEach(() => {
+      drawingAPI.setAddDrawCommand(mockAddDrawCommand)
+    })
+
+    describe('drawText', () => {
+      it('should add text command with basic parameters', () => {
+        drawingAPI.drawText(10, 20, 'Hello World')
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'text',
+          x: 10,
+          y: 20,
+          text: 'Hello World',
+        })
+      })
+
+      it('should handle empty text', () => {
+        drawingAPI.drawText(0, 0, '')
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'text',
+          x: 0,
+          y: 0,
+          text: '',
+        })
+      })
+
+      it('should add fontSize option when provided', () => {
+        drawingAPI.drawText(10, 20, 'Hello', { fontSize: 24 })
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'text',
+          x: 10,
+          y: 20,
+          text: 'Hello',
+          fontSize: 24,
+        })
+      })
+
+      it('should add fontFamily option when provided', () => {
+        drawingAPI.drawText(10, 20, 'Hello', { fontFamily: 'Arial' })
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'text',
+          x: 10,
+          y: 20,
+          text: 'Hello',
+          fontFamily: 'Arial',
+        })
+      })
+
+      it('should add maxWidth option when provided', () => {
+        drawingAPI.drawText(10, 20, 'Hello', { maxWidth: 100 })
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'text',
+          x: 10,
+          y: 20,
+          text: 'Hello',
+          maxWidth: 100,
+        })
+      })
+
+      it('should add all options when provided', () => {
+        drawingAPI.drawText(10, 20, 'Hello', {
+          fontSize: 24,
+          fontFamily: 'Arial',
+          maxWidth: 100,
+        })
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'text',
+          x: 10,
+          y: 20,
+          text: 'Hello',
+          fontSize: 24,
+          fontFamily: 'Arial',
+          maxWidth: 100,
+        })
+      })
+
+      it('should handle partial options', () => {
+        drawingAPI.drawText(10, 20, 'Hello', { fontSize: 32 })
+        const call = mockAddDrawCommand.mock.calls[0][0]
+        expect(call).toEqual({
+          type: 'text',
+          x: 10,
+          y: 20,
+          text: 'Hello',
+          fontSize: 32,
+        })
+        expect('fontFamily' in call).toBe(false)
+        expect('maxWidth' in call).toBe(false)
+      })
+
+      it('should handle undefined options', () => {
+        drawingAPI.drawText(10, 20, 'Hello', undefined)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'text',
+          x: 10,
+          y: 20,
+          text: 'Hello',
+        })
+      })
+
+      it('should handle special characters in text', () => {
+        drawingAPI.drawText(0, 0, 'Hello\nWorld\t!')
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'text',
+          x: 0,
+          y: 0,
+          text: 'Hello\nWorld\t!',
+        })
+      })
+
+      it('should handle unicode text', () => {
+        drawingAPI.drawText(0, 0, 'Hello \u4e16\u754c')
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'text',
+          x: 0,
+          y: 0,
+          text: 'Hello \u4e16\u754c',
+        })
+      })
+    })
+
+    describe('strokeText', () => {
+      it('should add strokeText command with basic parameters', () => {
+        drawingAPI.strokeText(10, 20, 'Hello World')
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'strokeText',
+          x: 10,
+          y: 20,
+          text: 'Hello World',
+        })
+      })
+
+      it('should handle empty text', () => {
+        drawingAPI.strokeText(0, 0, '')
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'strokeText',
+          x: 0,
+          y: 0,
+          text: '',
+        })
+      })
+
+      it('should add fontSize option when provided', () => {
+        drawingAPI.strokeText(10, 20, 'Hello', { fontSize: 24 })
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'strokeText',
+          x: 10,
+          y: 20,
+          text: 'Hello',
+          fontSize: 24,
+        })
+      })
+
+      it('should add fontFamily option when provided', () => {
+        drawingAPI.strokeText(10, 20, 'Hello', { fontFamily: 'Arial' })
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'strokeText',
+          x: 10,
+          y: 20,
+          text: 'Hello',
+          fontFamily: 'Arial',
+        })
+      })
+
+      it('should add maxWidth option when provided', () => {
+        drawingAPI.strokeText(10, 20, 'Hello', { maxWidth: 100 })
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'strokeText',
+          x: 10,
+          y: 20,
+          text: 'Hello',
+          maxWidth: 100,
+        })
+      })
+
+      it('should add all options when provided', () => {
+        drawingAPI.strokeText(10, 20, 'Hello', {
+          fontSize: 24,
+          fontFamily: 'Arial',
+          maxWidth: 100,
+        })
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'strokeText',
+          x: 10,
+          y: 20,
+          text: 'Hello',
+          fontSize: 24,
+          fontFamily: 'Arial',
+          maxWidth: 100,
+        })
+      })
+
+      it('should handle partial options', () => {
+        drawingAPI.strokeText(10, 20, 'Hello', { maxWidth: 200 })
+        const call = mockAddDrawCommand.mock.calls[0][0]
+        expect(call).toEqual({
+          type: 'strokeText',
+          x: 10,
+          y: 20,
+          text: 'Hello',
+          maxWidth: 200,
+        })
+        expect('fontSize' in call).toBe(false)
+        expect('fontFamily' in call).toBe(false)
+      })
+    })
+  })
+
+  describe('edge cases', () => {
+    beforeEach(() => {
+      drawingAPI.setAddDrawCommand(mockAddDrawCommand)
+    })
+
+    it('should handle rapid consecutive calls', () => {
+      drawingAPI.clear()
+      drawingAPI.setColor(255, 0, 0)
+      drawingAPI.fillRect(0, 0, 100, 100)
+      drawingAPI.setColor(0, 255, 0)
+      drawingAPI.fillCircle(50, 50, 25)
+      expect(mockAddDrawCommand).toHaveBeenCalledTimes(5)
+    })
+
+    it('should maintain command order', () => {
+      drawingAPI.clear()
+      drawingAPI.setColor(255, 0, 0)
+      drawingAPI.setLineWidth(5)
+      drawingAPI.drawRect(10, 10, 100, 100)
+
+      expect(mockAddDrawCommand).toHaveBeenCalledTimes(4)
+      expect(mockAddDrawCommand.mock.calls[0][0].type).toBe('clear')
+      expect(mockAddDrawCommand.mock.calls[1][0].type).toBe('setColor')
+      expect(mockAddDrawCommand.mock.calls[2][0].type).toBe('setLineWidth')
+      expect(mockAddDrawCommand.mock.calls[3][0].type).toBe('rect')
+    })
+
+    it('should handle all methods being called with null callback', () => {
+      const api = new DrawingAPI()
+      // No callback set, all methods should be no-ops
+      expect(() => {
+        api.clear()
+        api.clearRect(0, 0, 100, 100)
+        api.setColor(255, 0, 0)
+        api.setColor(255, 0, 0, 128)
+        api.setLineWidth(5)
+        api.drawRect(0, 0, 100, 100)
+        api.fillRect(0, 0, 100, 100)
+        api.drawCircle(50, 50, 25)
+        api.fillCircle(50, 50, 25)
+        api.drawLine(0, 0, 100, 100)
+        api.drawText(10, 10, 'Hello')
+        api.drawText(10, 10, 'Hello', { fontSize: 24, fontFamily: 'Arial', maxWidth: 100 })
+        api.strokeText(10, 10, 'Hello')
+        api.strokeText(10, 10, 'Hello', { fontSize: 24, fontFamily: 'Arial', maxWidth: 100 })
+      }).not.toThrow()
+    })
+
+    it('should handle switching callback to null mid-operation', () => {
+      drawingAPI.clear()
+      expect(mockAddDrawCommand).toHaveBeenCalledTimes(1)
+
+      drawingAPI.setAddDrawCommand(null)
+      drawingAPI.fillRect(0, 0, 100, 100)
+      expect(mockAddDrawCommand).toHaveBeenCalledTimes(1) // Still 1, no new calls
+    })
+
+    it('should handle floating point coordinates', () => {
+      drawingAPI.drawLine(0.5, 0.5, 100.5, 100.5)
+      expect(mockAddDrawCommand).toHaveBeenCalledWith({
+        type: 'line',
+        x1: 0.5,
+        y1: 0.5,
+        x2: 100.5,
+        y2: 100.5,
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Extract 11 drawing primitive methods from CanvasController into a dedicated DrawingAPI class
- Follow the established extraction pattern used by StyleAPI and PathAPI
- Use callback dependency injection (setAddDrawCommand) for command queue integration

## Methods Extracted

| Category | Methods |
|----------|---------|
| Clearing | `clear()`, `clearRect()` |
| Color/Line | `setColor()`, `setLineWidth()` |
| Shapes | `drawRect()`, `fillRect()`, `drawCircle()`, `fillCircle()`, `drawLine()` |
| Text | `drawText()`, `strokeText()` |

## Test Plan

- [x] 55 unit tests for DrawingAPI (all pass)
- [x] 100% mutation test coverage (26/26 mutants killed)
- [x] All 1101 lua-runtime tests pass
- [x] Lint passes
- [x] Build succeeds

Closes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)