### PR TITLE
refactor: Extract TransformAPI from CanvasController (#576)

### DIFF
--- a/packages/lua-runtime/src/CanvasController.ts
+++ b/packages/lua-runtime/src/CanvasController.ts
@@ -22,6 +22,7 @@ import { Path2DRegistry } from './Path2DRegistry'
 import { StyleAPI } from './StyleAPI'
 import { PathAPI } from './PathAPI'
 import { DrawingAPI } from './DrawingAPI'
+import { TransformAPI } from './TransformAPI'
 import type { TextOptions } from './DrawingAPI'
 import type {
   DrawCommand,
@@ -265,6 +266,9 @@ export class CanvasController {
   // Drawing API - handles drawing primitives (clear, shapes, text)
   private drawingAPI: DrawingAPI = new DrawingAPI()
 
+  // Transform API - handles transformation operations (translate, rotate, scale, etc.)
+  private transformAPI: TransformAPI = new TransformAPI()
+
   // Offscreen canvas for text measurement
   private measureCanvas: HTMLCanvasElement | null = null
   private measureCtx: CanvasRenderingContext2D | null = null
@@ -278,6 +282,8 @@ export class CanvasController {
     this.pathAPI.setAddDrawCommand((cmd) => this.addDrawCommand(cmd))
     // Set up DrawingAPI callback immediately so drawing methods work before start()
     this.drawingAPI.setAddDrawCommand((cmd) => this.addDrawCommand(cmd))
+    // Set up TransformAPI callback immediately so transform methods work before start()
+    this.transformAPI.setAddDrawCommand((cmd) => this.addDrawCommand(cmd))
   }
 
   /**
@@ -723,13 +729,13 @@ export class CanvasController {
     this.drawingAPI.strokeText(x, y, text, options)
   }
 
-  // --- Transformation API ---
+  // --- Transformation API (delegated to TransformAPI) ---
 
   /**
    * Translate (move) the canvas origin.
    */
   translate(dx: number, dy: number): void {
-    this.addDrawCommand({ type: 'translate', dx, dy })
+    this.transformAPI.translate(dx, dy)
   }
 
   /**
@@ -737,49 +743,49 @@ export class CanvasController {
    * @param angle - Rotation angle in radians
    */
   rotate(angle: number): void {
-    this.addDrawCommand({ type: 'rotate', angle })
+    this.transformAPI.rotate(angle)
   }
 
   /**
    * Scale the canvas from the current origin.
    */
   scale(sx: number, sy: number): void {
-    this.addDrawCommand({ type: 'scale', sx, sy })
+    this.transformAPI.scale(sx, sy)
   }
 
   /**
    * Save the current transformation state to the stack.
    */
   save(): void {
-    this.addDrawCommand({ type: 'save' })
+    this.transformAPI.save()
   }
 
   /**
    * Restore the most recently saved transformation state.
    */
   restore(): void {
-    this.addDrawCommand({ type: 'restore' })
+    this.transformAPI.restore()
   }
 
   /**
    * Multiply the current transformation matrix by the specified matrix.
    */
   transform(a: number, b: number, c: number, d: number, e: number, f: number): void {
-    this.addDrawCommand({ type: 'transform', a, b, c, d, e, f })
+    this.transformAPI.transform(a, b, c, d, e, f)
   }
 
   /**
    * Reset to identity matrix, then apply the specified transformation matrix.
    */
   setTransform(a: number, b: number, c: number, d: number, e: number, f: number): void {
-    this.addDrawCommand({ type: 'setTransform', a, b, c, d, e, f })
+    this.transformAPI.setTransform(a, b, c, d, e, f)
   }
 
   /**
    * Reset the transformation matrix to identity.
    */
   resetTransform(): void {
-    this.addDrawCommand({ type: 'resetTransform' })
+    this.transformAPI.resetTransform()
   }
 
   // --- Path API (delegated to PathAPI) ---

--- a/packages/lua-runtime/src/TransformAPI.ts
+++ b/packages/lua-runtime/src/TransformAPI.ts
@@ -1,0 +1,136 @@
+/**
+ * TransformAPI - Facade for canvas transformation operations.
+ *
+ * This class manages transformation-related canvas operations including:
+ * - Translation (translate)
+ * - Rotation (rotate)
+ * - Scaling (scale)
+ * - State save/restore (save, restore)
+ * - Matrix operations (transform, setTransform, resetTransform)
+ *
+ * It uses callback dependency injection for addDrawCommand() to integrate
+ * with the CanvasController's command queue.
+ */
+
+import type { DrawCommand } from '@lua-learning/canvas-runtime'
+
+/**
+ * Interface for TransformAPI public methods.
+ */
+export interface ITransformAPI {
+  // State management
+  save(): void
+  restore(): void
+
+  // Basic transformations
+  translate(dx: number, dy: number): void
+  rotate(angle: number): void
+  scale(sx: number, sy: number): void
+
+  // Matrix operations
+  transform(a: number, b: number, c: number, d: number, e: number, f: number): void
+  setTransform(a: number, b: number, c: number, d: number, e: number, f: number): void
+  resetTransform(): void
+}
+
+/**
+ * Facade for canvas transformation operations.
+ * Provides null-safe access to transformation operations via callback dependency injection.
+ */
+export class TransformAPI implements ITransformAPI {
+  private addDrawCommand: ((cmd: DrawCommand) => void) | null = null
+
+  /**
+   * Set the callback for adding draw commands.
+   * Required for all transformation operations to take effect.
+   * @param fn - Callback to add a draw command, or null to disable
+   */
+  setAddDrawCommand(fn: ((cmd: DrawCommand) => void) | null): void {
+    this.addDrawCommand = fn
+  }
+
+  // ============================================================================
+  // State Management Methods
+  // ============================================================================
+
+  /**
+   * Save the current transformation state to the stack.
+   */
+  save(): void {
+    this.addDrawCommand?.({ type: 'save' })
+  }
+
+  /**
+   * Restore the most recently saved transformation state.
+   */
+  restore(): void {
+    this.addDrawCommand?.({ type: 'restore' })
+  }
+
+  // ============================================================================
+  // Basic Transformation Methods
+  // ============================================================================
+
+  /**
+   * Translate (move) the canvas origin.
+   * @param dx - Horizontal translation distance
+   * @param dy - Vertical translation distance
+   */
+  translate(dx: number, dy: number): void {
+    this.addDrawCommand?.({ type: 'translate', dx, dy })
+  }
+
+  /**
+   * Rotate the canvas around the current origin.
+   * @param angle - Rotation angle in radians
+   */
+  rotate(angle: number): void {
+    this.addDrawCommand?.({ type: 'rotate', angle })
+  }
+
+  /**
+   * Scale the canvas from the current origin.
+   * @param sx - Horizontal scale factor
+   * @param sy - Vertical scale factor
+   */
+  scale(sx: number, sy: number): void {
+    this.addDrawCommand?.({ type: 'scale', sx, sy })
+  }
+
+  // ============================================================================
+  // Matrix Operation Methods
+  // ============================================================================
+
+  /**
+   * Multiply the current transformation matrix by the specified matrix.
+   * @param a - Horizontal scaling
+   * @param b - Horizontal skewing
+   * @param c - Vertical skewing
+   * @param d - Vertical scaling
+   * @param e - Horizontal translation
+   * @param f - Vertical translation
+   */
+  transform(a: number, b: number, c: number, d: number, e: number, f: number): void {
+    this.addDrawCommand?.({ type: 'transform', a, b, c, d, e, f })
+  }
+
+  /**
+   * Reset to identity matrix, then apply the specified transformation matrix.
+   * @param a - Horizontal scaling
+   * @param b - Horizontal skewing
+   * @param c - Vertical skewing
+   * @param d - Vertical scaling
+   * @param e - Horizontal translation
+   * @param f - Vertical translation
+   */
+  setTransform(a: number, b: number, c: number, d: number, e: number, f: number): void {
+    this.addDrawCommand?.({ type: 'setTransform', a, b, c, d, e, f })
+  }
+
+  /**
+   * Reset the transformation matrix to identity.
+   */
+  resetTransform(): void {
+    this.addDrawCommand?.({ type: 'resetTransform' })
+  }
+}

--- a/packages/lua-runtime/src/index.ts
+++ b/packages/lua-runtime/src/index.ts
@@ -71,3 +71,6 @@ export { StyleAPI, type IStyleAPI } from './StyleAPI'
 
 // Path API for path operations, hit testing support
 export { PathAPI, type IPathAPI, type FillRule } from './PathAPI'
+
+// Transform API for canvas transformations (translate, rotate, scale, etc.)
+export { TransformAPI, type ITransformAPI } from './TransformAPI'

--- a/packages/lua-runtime/tests/TransformAPI.test.ts
+++ b/packages/lua-runtime/tests/TransformAPI.test.ts
@@ -1,0 +1,470 @@
+/**
+ * Tests for TransformAPI class - Facade for canvas transformation operations.
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { TransformAPI } from '../src/TransformAPI'
+import type { DrawCommand } from '@lua-learning/canvas-runtime'
+
+describe('TransformAPI', () => {
+  let transformAPI: TransformAPI
+  let mockAddDrawCommand: ReturnType<typeof vi.fn<[DrawCommand], void>>
+
+  beforeEach(() => {
+    transformAPI = new TransformAPI()
+    mockAddDrawCommand = vi.fn()
+  })
+
+  describe('construction', () => {
+    it('should construct with no arguments', () => {
+      expect(transformAPI).toBeDefined()
+    })
+  })
+
+  describe('setAddDrawCommand', () => {
+    it('should allow setting the draw command callback', () => {
+      transformAPI.setAddDrawCommand(mockAddDrawCommand)
+      transformAPI.save()
+      expect(mockAddDrawCommand).toHaveBeenCalled()
+    })
+
+    it('should allow setting callback to null', () => {
+      transformAPI.setAddDrawCommand(mockAddDrawCommand)
+      transformAPI.setAddDrawCommand(null)
+      transformAPI.save()
+      expect(mockAddDrawCommand).not.toHaveBeenCalled()
+    })
+
+    it('should not throw when addDrawCommand is null', () => {
+      expect(() => transformAPI.save()).not.toThrow()
+      expect(() => transformAPI.restore()).not.toThrow()
+      expect(() => transformAPI.translate(10, 20)).not.toThrow()
+      expect(() => transformAPI.rotate(Math.PI)).not.toThrow()
+      expect(() => transformAPI.scale(2, 2)).not.toThrow()
+      expect(() => transformAPI.transform(1, 0, 0, 1, 0, 0)).not.toThrow()
+      expect(() => transformAPI.setTransform(1, 0, 0, 1, 0, 0)).not.toThrow()
+      expect(() => transformAPI.resetTransform()).not.toThrow()
+    })
+  })
+
+  describe('state management methods', () => {
+    beforeEach(() => {
+      transformAPI.setAddDrawCommand(mockAddDrawCommand)
+    })
+
+    describe('save', () => {
+      it('should add save command', () => {
+        transformAPI.save()
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({ type: 'save' })
+      })
+
+      it('should call save multiple times', () => {
+        transformAPI.save()
+        transformAPI.save()
+        expect(mockAddDrawCommand).toHaveBeenCalledTimes(2)
+      })
+    })
+
+    describe('restore', () => {
+      it('should add restore command', () => {
+        transformAPI.restore()
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({ type: 'restore' })
+      })
+
+      it('should call restore multiple times', () => {
+        transformAPI.restore()
+        transformAPI.restore()
+        expect(mockAddDrawCommand).toHaveBeenCalledTimes(2)
+      })
+    })
+  })
+
+  describe('basic transformation methods', () => {
+    beforeEach(() => {
+      transformAPI.setAddDrawCommand(mockAddDrawCommand)
+    })
+
+    describe('translate', () => {
+      it('should add translate command with dx and dy', () => {
+        transformAPI.translate(10, 20)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'translate',
+          dx: 10,
+          dy: 20,
+        })
+      })
+
+      it('should handle zero values', () => {
+        transformAPI.translate(0, 0)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'translate',
+          dx: 0,
+          dy: 0,
+        })
+      })
+
+      it('should handle negative values', () => {
+        transformAPI.translate(-50, -100)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'translate',
+          dx: -50,
+          dy: -100,
+        })
+      })
+
+      it('should handle floating point values', () => {
+        transformAPI.translate(10.5, 20.5)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'translate',
+          dx: 10.5,
+          dy: 20.5,
+        })
+      })
+    })
+
+    describe('rotate', () => {
+      it('should add rotate command with angle', () => {
+        transformAPI.rotate(Math.PI / 4)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'rotate',
+          angle: Math.PI / 4,
+        })
+      })
+
+      it('should handle zero angle', () => {
+        transformAPI.rotate(0)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'rotate',
+          angle: 0,
+        })
+      })
+
+      it('should handle negative angle', () => {
+        transformAPI.rotate(-Math.PI / 2)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'rotate',
+          angle: -Math.PI / 2,
+        })
+      })
+
+      it('should handle full rotation', () => {
+        transformAPI.rotate(2 * Math.PI)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'rotate',
+          angle: 2 * Math.PI,
+        })
+      })
+    })
+
+    describe('scale', () => {
+      it('should add scale command with sx and sy', () => {
+        transformAPI.scale(2, 3)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'scale',
+          sx: 2,
+          sy: 3,
+        })
+      })
+
+      it('should handle uniform scale', () => {
+        transformAPI.scale(2, 2)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'scale',
+          sx: 2,
+          sy: 2,
+        })
+      })
+
+      it('should handle scale factor of 1 (identity)', () => {
+        transformAPI.scale(1, 1)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'scale',
+          sx: 1,
+          sy: 1,
+        })
+      })
+
+      it('should handle scale factor of 0', () => {
+        transformAPI.scale(0, 0)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'scale',
+          sx: 0,
+          sy: 0,
+        })
+      })
+
+      it('should handle negative scale (flip)', () => {
+        transformAPI.scale(-1, -1)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'scale',
+          sx: -1,
+          sy: -1,
+        })
+      })
+
+      it('should handle fractional scale', () => {
+        transformAPI.scale(0.5, 0.25)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'scale',
+          sx: 0.5,
+          sy: 0.25,
+        })
+      })
+    })
+  })
+
+  describe('matrix operation methods', () => {
+    beforeEach(() => {
+      transformAPI.setAddDrawCommand(mockAddDrawCommand)
+    })
+
+    describe('transform', () => {
+      it('should add transform command with all matrix values', () => {
+        transformAPI.transform(1, 2, 3, 4, 5, 6)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'transform',
+          a: 1,
+          b: 2,
+          c: 3,
+          d: 4,
+          e: 5,
+          f: 6,
+        })
+      })
+
+      it('should handle identity matrix', () => {
+        transformAPI.transform(1, 0, 0, 1, 0, 0)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'transform',
+          a: 1,
+          b: 0,
+          c: 0,
+          d: 1,
+          e: 0,
+          f: 0,
+        })
+      })
+
+      it('should handle zero matrix', () => {
+        transformAPI.transform(0, 0, 0, 0, 0, 0)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'transform',
+          a: 0,
+          b: 0,
+          c: 0,
+          d: 0,
+          e: 0,
+          f: 0,
+        })
+      })
+
+      it('should handle negative values', () => {
+        transformAPI.transform(-1, -2, -3, -4, -5, -6)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'transform',
+          a: -1,
+          b: -2,
+          c: -3,
+          d: -4,
+          e: -5,
+          f: -6,
+        })
+      })
+
+      it('should handle floating point values', () => {
+        transformAPI.transform(1.5, 0.5, 0.5, 1.5, 10.5, 20.5)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'transform',
+          a: 1.5,
+          b: 0.5,
+          c: 0.5,
+          d: 1.5,
+          e: 10.5,
+          f: 20.5,
+        })
+      })
+    })
+
+    describe('setTransform', () => {
+      it('should add setTransform command with all matrix values', () => {
+        transformAPI.setTransform(1, 2, 3, 4, 5, 6)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'setTransform',
+          a: 1,
+          b: 2,
+          c: 3,
+          d: 4,
+          e: 5,
+          f: 6,
+        })
+      })
+
+      it('should handle identity matrix', () => {
+        transformAPI.setTransform(1, 0, 0, 1, 0, 0)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'setTransform',
+          a: 1,
+          b: 0,
+          c: 0,
+          d: 1,
+          e: 0,
+          f: 0,
+        })
+      })
+
+      it('should handle zero matrix', () => {
+        transformAPI.setTransform(0, 0, 0, 0, 0, 0)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'setTransform',
+          a: 0,
+          b: 0,
+          c: 0,
+          d: 0,
+          e: 0,
+          f: 0,
+        })
+      })
+
+      it('should handle negative values', () => {
+        transformAPI.setTransform(-1, -2, -3, -4, -5, -6)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'setTransform',
+          a: -1,
+          b: -2,
+          c: -3,
+          d: -4,
+          e: -5,
+          f: -6,
+        })
+      })
+
+      it('should handle floating point values', () => {
+        transformAPI.setTransform(1.5, 0.5, 0.5, 1.5, 10.5, 20.5)
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({
+          type: 'setTransform',
+          a: 1.5,
+          b: 0.5,
+          c: 0.5,
+          d: 1.5,
+          e: 10.5,
+          f: 20.5,
+        })
+      })
+    })
+
+    describe('resetTransform', () => {
+      it('should add resetTransform command', () => {
+        transformAPI.resetTransform()
+        expect(mockAddDrawCommand).toHaveBeenCalledWith({ type: 'resetTransform' })
+      })
+
+      it('should call resetTransform multiple times', () => {
+        transformAPI.resetTransform()
+        transformAPI.resetTransform()
+        expect(mockAddDrawCommand).toHaveBeenCalledTimes(2)
+      })
+    })
+  })
+
+  describe('edge cases', () => {
+    beforeEach(() => {
+      transformAPI.setAddDrawCommand(mockAddDrawCommand)
+    })
+
+    it('should handle rapid consecutive calls', () => {
+      transformAPI.save()
+      transformAPI.translate(10, 20)
+      transformAPI.rotate(Math.PI / 4)
+      transformAPI.scale(2, 2)
+      transformAPI.restore()
+      expect(mockAddDrawCommand).toHaveBeenCalledTimes(5)
+    })
+
+    it('should maintain command order', () => {
+      transformAPI.save()
+      transformAPI.translate(100, 100)
+      transformAPI.rotate(Math.PI)
+      transformAPI.scale(0.5, 0.5)
+      transformAPI.restore()
+
+      expect(mockAddDrawCommand).toHaveBeenCalledTimes(5)
+      expect(mockAddDrawCommand.mock.calls[0][0].type).toBe('save')
+      expect(mockAddDrawCommand.mock.calls[1][0].type).toBe('translate')
+      expect(mockAddDrawCommand.mock.calls[2][0].type).toBe('rotate')
+      expect(mockAddDrawCommand.mock.calls[3][0].type).toBe('scale')
+      expect(mockAddDrawCommand.mock.calls[4][0].type).toBe('restore')
+    })
+
+    it('should handle all methods being called with null callback', () => {
+      const api = new TransformAPI()
+      // No callback set, all methods should be no-ops
+      expect(() => {
+        api.save()
+        api.restore()
+        api.translate(10, 20)
+        api.rotate(Math.PI)
+        api.scale(2, 2)
+        api.transform(1, 0, 0, 1, 0, 0)
+        api.setTransform(1, 0, 0, 1, 0, 0)
+        api.resetTransform()
+      }).not.toThrow()
+    })
+
+    it('should handle switching callback to null mid-operation', () => {
+      transformAPI.save()
+      expect(mockAddDrawCommand).toHaveBeenCalledTimes(1)
+
+      transformAPI.setAddDrawCommand(null)
+      transformAPI.translate(10, 20)
+      expect(mockAddDrawCommand).toHaveBeenCalledTimes(1) // Still 1, no new calls
+    })
+
+    it('should handle nested save/restore', () => {
+      transformAPI.save()
+      transformAPI.translate(10, 20)
+      transformAPI.save()
+      transformAPI.rotate(Math.PI / 2)
+      transformAPI.restore()
+      transformAPI.restore()
+
+      expect(mockAddDrawCommand).toHaveBeenCalledTimes(6)
+      expect(mockAddDrawCommand.mock.calls[0][0].type).toBe('save')
+      expect(mockAddDrawCommand.mock.calls[1][0].type).toBe('translate')
+      expect(mockAddDrawCommand.mock.calls[2][0].type).toBe('save')
+      expect(mockAddDrawCommand.mock.calls[3][0].type).toBe('rotate')
+      expect(mockAddDrawCommand.mock.calls[4][0].type).toBe('restore')
+      expect(mockAddDrawCommand.mock.calls[5][0].type).toBe('restore')
+    })
+
+    it('should handle combined transformations', () => {
+      // Simulate a typical transformation workflow
+      transformAPI.save()
+      transformAPI.translate(100, 100)
+      transformAPI.rotate(Math.PI / 4)
+      transformAPI.scale(2, 2)
+      transformAPI.translate(-50, -50)
+      transformAPI.restore()
+
+      expect(mockAddDrawCommand).toHaveBeenCalledTimes(6)
+    })
+
+    it('should handle large values', () => {
+      transformAPI.translate(1000000, 1000000)
+      expect(mockAddDrawCommand).toHaveBeenCalledWith({
+        type: 'translate',
+        dx: 1000000,
+        dy: 1000000,
+      })
+    })
+
+    it('should handle very small values', () => {
+      transformAPI.scale(0.0001, 0.0001)
+      expect(mockAddDrawCommand).toHaveBeenCalledWith({
+        type: 'scale',
+        sx: 0.0001,
+        sy: 0.0001,
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Extract 8 transformation methods from CanvasController into dedicated TransformAPI class
- Follow established patterns from DrawingAPI, PathAPI, and StyleAPI extractions
- Add comprehensive unit tests (42 tests) with 100% mutation test coverage

## Methods Extracted
| Method | Parameters |
|--------|------------|
| translate | dx, dy |
| rotate | angle |
| scale | sx, sy |
| save | (none) |
| restore | (none) |
| transform | a, b, c, d, e, f |
| setTransform | a, b, c, d, e, f |
| resetTransform | (none) |

## Test plan
- [x] All 1143 unit tests pass
- [x] Lint passes
- [x] Build passes
- [x] Mutation test coverage: 100%

Closes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)