### PR TITLE
refactor: CanvasController refactor cleanup (#577)

### DIFF
--- a/lua-learning-website/eslint.config.js
+++ b/lua-learning-website/eslint.config.js
@@ -53,4 +53,19 @@ export default defineConfig([
       ],
     },
   },
+  // Facade file exception: CanvasController delegates to 7 extracted APIs
+  // and requires ~1,100 lines of delegation methods for backward compatibility
+  {
+    files: ['**/packages/lua-runtime/src/CanvasController.ts'],
+    rules: {
+      'max-lines': [
+        'error',
+        {
+          max: 2000,
+          skipBlankLines: true,
+          skipComments: true,
+        },
+      ],
+    },
+  },
 ])

--- a/packages/lua-runtime/eslint.config.js
+++ b/packages/lua-runtime/eslint.config.js
@@ -46,4 +46,19 @@ export default defineConfig([
       ],
     },
   },
+  // Facade file exception: CanvasController delegates to 7 extracted APIs
+  // and requires ~1,100 lines of delegation methods for backward compatibility
+  {
+    files: ['src/CanvasController.ts'],
+    rules: {
+      'max-lines': [
+        'error',
+        {
+          max: 2000,
+          skipBlankLines: true,
+          skipComments: true,
+        },
+      ],
+    },
+  },
 ])

--- a/packages/lua-runtime/src/CanvasController.ts
+++ b/packages/lua-runtime/src/CanvasController.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 /**
  * Canvas controller for managing canvas lifecycle from within LuaScriptProcess.
  *


### PR DESCRIPTION
## Summary
- Add ESLint per-file override for CanvasController.ts with 2000 line limit
- Remove `/* eslint-disable max-lines */` directive from CanvasController.ts
- Acknowledges facade pattern: ~1,100 lines of delegation methods forwarding to 7 extracted APIs

## Test plan
- [x] All 1840 unit tests pass
- [x] Lint passes with no errors (ESLint override working correctly)
- [x] Production build succeeds

Closes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)