### PR TITLE
fix: Eliminate GC pressure from input handling

### DIFF
--- a/packages/export/src/runtime/canvas-bridge-types.ts
+++ b/packages/export/src/runtime/canvas-bridge-types.ts
@@ -54,6 +54,17 @@ export interface CanvasRuntimeState {
   stopResolve: (() => void) | null
   /** Previous gamepad button states for "just pressed" detection */
   previousGamepadButtons: number[][]
+
+  // Cached arrays to avoid allocation on every getKeysDown/getKeysPressed call.
+  // These arrays are reused and should not be mutated by callers.
+  /** Cached array of keys currently held down */
+  keysDownArray: string[]
+  /** Cached array of keys pressed this frame */
+  keysPressedArray: string[]
+  /** Dirty flag for keysDownArray */
+  keysDownDirty: boolean
+  /** Dirty flag for keysPressedArray */
+  keysPressedDirty: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary

- Implements object pooling and caching strategy to prevent frame drops caused by garbage collection during input handling
- Adds cached arrays with dirty flags for lazy synchronization in InputCapture and canvas-bridge-core
- Modifies pollGamepads() to reuse arrays and perform in-place copies instead of allocations
- Reduces allocations from 20+ arrays/objects per frame to near-zero in the input hot path

## Test plan

- [x] All 573 tests pass in canvas-runtime package
- [x] 7 new tests verify caching behavior (same object reference, array reuse, dirty flag sync)
- [x] Build succeeds for canvas-runtime and export packages
- [x] Lint passes
- [ ] Manual verification with Chrome DevTools Performance panel to confirm reduced GC activity

Closes #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)