### PR TITLE
fix: Prevent browser drag on canvas during click-and-drag

### DIFF
--- a/lua-learning-website/src/components/CanvasGamePanel/CanvasGamePanel.module.css
+++ b/lua-learning-website/src/components/CanvasGamePanel/CanvasGamePanel.module.css
@@ -171,6 +171,8 @@
   border: 1px solid var(--theme-border);
   background: #000;
   outline: none;
+  user-select: none;
+  -webkit-user-drag: none;
 }
 
 /* Auto-fit mode: scale canvas down to fit while maintaining aspect ratio (never scales up) */

--- a/lua-learning-website/src/hooks/canvasWindowTemplate.test.ts
+++ b/lua-learning-website/src/hooks/canvasWindowTemplate.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { generateCanvasWindowHTML } from './canvasWindowTemplate'
+
+describe('canvasWindowTemplate', () => {
+  describe('drag prevention CSS', () => {
+    it('should include user-select: none on canvas', () => {
+      const html = generateCanvasWindowHTML()
+      expect(html).toContain('user-select: none')
+    })
+
+    it('should include -webkit-user-drag: none on canvas', () => {
+      const html = generateCanvasWindowHTML()
+      expect(html).toContain('-webkit-user-drag: none')
+    })
+  })
+})

--- a/lua-learning-website/src/hooks/canvasWindowTemplate.ts
+++ b/lua-learning-website/src/hooks/canvasWindowTemplate.ts
@@ -149,6 +149,8 @@ export function generateCanvasWindowHTML(screenMode?: ScreenMode, noToolbar?: bo
     canvas {
       display: block;
       background: #000;
+      user-select: none;
+      -webkit-user-drag: none;
     }
 
     /* Disconnected overlay */

--- a/packages/canvas-runtime/src/renderer/InputCapture.ts
+++ b/packages/canvas-runtime/src/renderer/InputCapture.ts
@@ -47,6 +47,7 @@ export class InputCapture {
   private readonly handleMouseDown: (e: MouseEvent) => void;
   private readonly handleMouseUp: (e: MouseEvent) => void;
   private readonly handleContextMenu: (e: MouseEvent) => void;
+  private readonly handleDragStart: (e: Event) => void;
   private readonly handleBlur: () => void;
 
   constructor(target: HTMLElement) {
@@ -77,6 +78,7 @@ export class InputCapture {
     this.handleMouseDown = this.onMouseDown.bind(this);
     this.handleMouseUp = this.onMouseUp.bind(this);
     this.handleContextMenu = this.onContextMenu.bind(this);
+    this.handleDragStart = this.onDragStart.bind(this);
     this.handleBlur = this.onBlur.bind(this);
 
     // Add event listeners
@@ -86,6 +88,7 @@ export class InputCapture {
     target.addEventListener('mousedown', this.handleMouseDown);
     target.addEventListener('mouseup', this.handleMouseUp);
     target.addEventListener('contextmenu', this.handleContextMenu);
+    target.addEventListener('dragstart', this.handleDragStart);
     target.addEventListener('blur', this.handleBlur);
   }
 
@@ -348,6 +351,7 @@ export class InputCapture {
     this.target.removeEventListener('mousedown', this.handleMouseDown);
     this.target.removeEventListener('mouseup', this.handleMouseUp);
     this.target.removeEventListener('contextmenu', this.handleContextMenu);
+    this.target.removeEventListener('dragstart', this.handleDragStart);
     this.target.removeEventListener('blur', this.handleBlur);
   }
 
@@ -416,6 +420,7 @@ export class InputCapture {
   }
 
   private onMouseDown(event: MouseEvent): void {
+    event.preventDefault();
     if (!this.mouseButtonsDown.has(event.button)) {
       this.mouseButtonsPressed.add(event.button);
       this.mouseButtonsPressedDirty = true;
@@ -431,6 +436,11 @@ export class InputCapture {
 
   private onContextMenu(event: MouseEvent): void {
     // Prevent browser context menu so right-click can be used in games
+    event.preventDefault();
+  }
+
+  private onDragStart(event: Event): void {
+    // Prevent browser drag-and-drop so click-and-drag works in games
     event.preventDefault();
   }
 

--- a/packages/canvas-runtime/tests/renderer/InputCapture.test.ts
+++ b/packages/canvas-runtime/tests/renderer/InputCapture.test.ts
@@ -564,6 +564,63 @@ describe('InputCapture', () => {
     });
   });
 
+  describe('drag prevention', () => {
+    it('should prevent default on mousedown', () => {
+      const event = new MouseEvent('mousedown', {
+        button: 0,
+        bubbles: true,
+        cancelable: true,
+      });
+      const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+
+      target.dispatchEvent(event);
+
+      expect(preventDefaultSpy).toHaveBeenCalled();
+    });
+
+    it('should prevent default on dragstart', () => {
+      const event = new Event('dragstart', {
+        bubbles: true,
+        cancelable: true,
+      });
+      const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+
+      target.dispatchEvent(event);
+
+      expect(preventDefaultSpy).toHaveBeenCalled();
+    });
+
+    it('should remove dragstart listener on dispose', () => {
+      const newCapture = new InputCapture(target);
+      newCapture.dispose();
+
+      const event = new Event('dragstart', {
+        bubbles: true,
+        cancelable: true,
+      });
+      const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+
+      target.dispatchEvent(event);
+
+      // The default InputCapture from beforeEach still listens,
+      // but newCapture should not. We verify by creating a fresh target.
+      const freshTarget = document.createElement('div');
+      document.body.appendChild(freshTarget);
+      const freshCapture = new InputCapture(freshTarget);
+      freshCapture.dispose();
+
+      const freshEvent = new Event('dragstart', {
+        bubbles: true,
+        cancelable: true,
+      });
+      const freshSpy = vi.spyOn(freshEvent, 'preventDefault');
+      freshTarget.dispatchEvent(freshEvent);
+
+      expect(freshSpy).not.toHaveBeenCalled();
+      document.body.removeChild(freshTarget);
+    });
+  });
+
   describe('focus handling', () => {
     it('should clear keys on blur to prevent stuck keys', () => {
       target.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyA' }));

--- a/packages/export/src/HtmlGenerator.ts
+++ b/packages/export/src/HtmlGenerator.ts
@@ -53,6 +53,8 @@ export class HtmlGenerator {
     canvas {
       display: block;
       image-rendering: pixelated;
+      user-select: none;
+      -webkit-user-drag: none;
     }`
 
     switch (scale) {

--- a/packages/export/src/runtime/canvas-inline.generated.ts
+++ b/packages/export/src/runtime/canvas-inline.generated.ts
@@ -3274,6 +3274,7 @@ return localstorage
       state.mouseY = displayY * (state.canvas.height / rect.height);
     };
     const handleMouseDown = (e) => {
+      e.preventDefault();
       if (!state.mouseButtonsDown.has(e.button)) {
         state.mouseButtonsPressed.add(e.button);
       }
@@ -3285,12 +3286,16 @@ return localstorage
     const handleContextMenu = (e) => {
       e.preventDefault();
     };
+    const handleDragStart = (e) => {
+      e.preventDefault();
+    };
     document.addEventListener("keydown", handleKeyDown);
     document.addEventListener("keyup", handleKeyUp);
     state.canvas.addEventListener("mousemove", handleMouseMove);
     state.canvas.addEventListener("mousedown", handleMouseDown);
     state.canvas.addEventListener("mouseup", handleMouseUp);
     state.canvas.addEventListener("contextmenu", handleContextMenu);
+    state.canvas.addEventListener("dragstart", handleDragStart);
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
       document.removeEventListener("keyup", handleKeyUp);
@@ -3298,6 +3303,7 @@ return localstorage
       state.canvas.removeEventListener("mousedown", handleMouseDown);
       state.canvas.removeEventListener("mouseup", handleMouseUp);
       state.canvas.removeEventListener("contextmenu", handleContextMenu);
+      state.canvas.removeEventListener("dragstart", handleDragStart);
     };
   }
   function pollGamepads(state) {

--- a/packages/export/src/runtime/canvas-standalone.ts
+++ b/packages/export/src/runtime/canvas-standalone.ts
@@ -205,6 +205,7 @@ export function setupInputListeners(state: CanvasRuntimeState): () => void {
   }
 
   const handleMouseDown = (e: MouseEvent) => {
+    e.preventDefault()
     if (!state.mouseButtonsDown.has(e.button)) {
       state.mouseButtonsPressed.add(e.button)
     }
@@ -220,12 +221,18 @@ export function setupInputListeners(state: CanvasRuntimeState): () => void {
     e.preventDefault()
   }
 
+  const handleDragStart = (e: Event) => {
+    // Prevent browser drag-and-drop so click-and-drag works in games
+    e.preventDefault()
+  }
+
   document.addEventListener('keydown', handleKeyDown)
   document.addEventListener('keyup', handleKeyUp)
   state.canvas.addEventListener('mousemove', handleMouseMove)
   state.canvas.addEventListener('mousedown', handleMouseDown)
   state.canvas.addEventListener('mouseup', handleMouseUp)
   state.canvas.addEventListener('contextmenu', handleContextMenu)
+  state.canvas.addEventListener('dragstart', handleDragStart)
 
   // Return cleanup function
   return () => {
@@ -235,6 +242,7 @@ export function setupInputListeners(state: CanvasRuntimeState): () => void {
     state.canvas.removeEventListener('mousedown', handleMouseDown)
     state.canvas.removeEventListener('mouseup', handleMouseUp)
     state.canvas.removeEventListener('contextmenu', handleContextMenu)
+    state.canvas.removeEventListener('dragstart', handleDragStart)
   }
 }
 

--- a/packages/export/tests/HtmlGenerator.test.ts
+++ b/packages/export/tests/HtmlGenerator.test.ts
@@ -164,6 +164,18 @@ describe('HtmlGenerator', () => {
       expect(html).toContain('#000000')
     })
 
+    it('should include drag prevention CSS on canvas element', () => {
+      const generator = new HtmlGenerator(createOptions())
+      const config = createConfig()
+      const luaFiles: CollectedFile[] = []
+      const assets: CollectedAsset[] = []
+
+      const html = generator.generateCanvas(config, luaFiles, assets)
+
+      expect(html).toContain('user-select: none')
+      expect(html).toContain('-webkit-user-drag: none')
+    })
+
     it('should use default dimensions when canvas config is undefined', () => {
       const generator = new HtmlGenerator(createOptions())
       const config: ProjectConfig = {

--- a/packages/export/tests/runtime/canvas-standalone.test.ts
+++ b/packages/export/tests/runtime/canvas-standalone.test.ts
@@ -103,6 +103,53 @@ describe('canvas-standalone', () => {
       }
     })
 
+    describe('drag prevention', () => {
+      it('should prevent default on mousedown', () => {
+        setupInputListeners(state)
+
+        const event = new MouseEvent('mousedown', {
+          button: 0,
+          bubbles: true,
+          cancelable: true,
+        })
+        const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+
+        canvas.dispatchEvent(event)
+
+        expect(preventDefaultSpy).toHaveBeenCalled()
+      })
+
+      it('should prevent default on dragstart', () => {
+        setupInputListeners(state)
+
+        const event = new Event('dragstart', {
+          bubbles: true,
+          cancelable: true,
+        })
+        const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+
+        canvas.dispatchEvent(event)
+
+        expect(preventDefaultSpy).toHaveBeenCalled()
+      })
+
+      it('should remove dragstart listener on cleanup', () => {
+        const cleanup = setupInputListeners(state)
+
+        cleanup()
+
+        const event = new Event('dragstart', {
+          bubbles: true,
+          cancelable: true,
+        })
+        const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+
+        canvas.dispatchEvent(event)
+
+        expect(preventDefaultSpy).not.toHaveBeenCalled()
+      })
+    })
+
     describe('contextmenu handling', () => {
       it('should prevent the browser context menu on right-click', () => {
         setupInputListeners(state)


### PR DESCRIPTION
## Summary
- Adds defense-in-depth drag prevention across all four canvas contexts (editor, popup window, exported HTML)
- CSS: `user-select: none` + `-webkit-user-drag: none` on canvas elements
- JS: `preventDefault()` on `dragstart` event and `mousedown` event to stop browser HTML5 drag-and-drop

Closes #628

## Test plan
- [x] Unit tests for `InputCapture.ts` drag prevention (3 tests: mousedown preventDefault, dragstart preventDefault, dispose cleanup)
- [x] Unit tests for `canvas-standalone.ts` drag prevention (3 tests: mousedown preventDefault, dragstart preventDefault, cleanup)
- [x] Unit test for `HtmlGenerator.ts` CSS properties in exported HTML
- [x] Unit tests for `canvasWindowTemplate.ts` CSS properties in popup window
- [x] All 2411 unit tests pass
- [x] Lint passes
- [x] Build succeeds
- [x] 322/328 E2E tests pass (4 pre-existing flaky failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)