### PR TITLE
fix: Allow F11/F12 to pass through canvas preventDefault

### DIFF
--- a/packages/canvas-runtime/src/renderer/InputCapture.ts
+++ b/packages/canvas-runtime/src/renderer/InputCapture.ts
@@ -355,8 +355,11 @@ export class InputCapture {
     this.target.removeEventListener('blur', this.handleBlur);
   }
 
+  /** Keys that should always pass through to the browser (e.g., F11 fullscreen, F12 DevTools). */
+  private static readonly BROWSER_RESERVED_KEYS = new Set(['F11', 'F12']);
+
   private onKeyDown(event: KeyboardEvent): void {
-    if (!event.ctrlKey && !event.metaKey) {
+    if (!event.ctrlKey && !event.metaKey && !InputCapture.BROWSER_RESERVED_KEYS.has(event.code)) {
       event.preventDefault();
     }
     if (!this.keysDown.has(event.code)) {
@@ -368,7 +371,7 @@ export class InputCapture {
   }
 
   private onKeyUp(event: KeyboardEvent): void {
-    if (!event.ctrlKey && !event.metaKey) {
+    if (!event.ctrlKey && !event.metaKey && !InputCapture.BROWSER_RESERVED_KEYS.has(event.code)) {
       event.preventDefault();
     }
     this.keysDown.delete(event.code);

--- a/packages/canvas-runtime/tests/renderer/InputCapture.test.ts
+++ b/packages/canvas-runtime/tests/renderer/InputCapture.test.ts
@@ -821,6 +821,34 @@ describe('InputCapture', () => {
       target.dispatchEvent(event);
       expect(spy).not.toHaveBeenCalled();
     });
+
+    it('should NOT prevent default on keydown for browser-reserved keys (F11, F12)', () => {
+      const keys = ['F11', 'F12'];
+      for (const code of keys) {
+        const event = new KeyboardEvent('keydown', {
+          code,
+          bubbles: true,
+          cancelable: true,
+        });
+        const spy = vi.spyOn(event, 'preventDefault');
+        target.dispatchEvent(event);
+        expect(spy).not.toHaveBeenCalled();
+      }
+    });
+
+    it('should NOT prevent default on keyup for browser-reserved keys (F11, F12)', () => {
+      const keys = ['F11', 'F12'];
+      for (const code of keys) {
+        const event = new KeyboardEvent('keyup', {
+          code,
+          bubbles: true,
+          cancelable: true,
+        });
+        const spy = vi.spyOn(event, 'preventDefault');
+        target.dispatchEvent(event);
+        expect(spy).not.toHaveBeenCalled();
+      }
+    });
   });
 
   describe('focus handling', () => {

--- a/packages/export/src/runtime/canvas-inline.generated.ts
+++ b/packages/export/src/runtime/canvas-inline.generated.ts
@@ -3253,9 +3253,10 @@ return localstorage
       lineDashSegments: []
     };
   }
+  var BROWSER_RESERVED_KEYS = /* @__PURE__ */ new Set(["F11", "F12"]);
   function setupInputListeners(state) {
     const handleKeyDown = (e) => {
-      if (!e.ctrlKey && !e.metaKey) {
+      if (!e.ctrlKey && !e.metaKey && !BROWSER_RESERVED_KEYS.has(e.code)) {
         e.preventDefault();
       }
       if (!state.keysDown.has(e.code)) {
@@ -3266,7 +3267,7 @@ return localstorage
       state.keysDownDirty = true;
     };
     const handleKeyUp = (e) => {
-      if (!e.ctrlKey && !e.metaKey) {
+      if (!e.ctrlKey && !e.metaKey && !BROWSER_RESERVED_KEYS.has(e.code)) {
         e.preventDefault();
       }
       state.keysDown.delete(e.code);

--- a/packages/export/src/runtime/canvas-standalone.ts
+++ b/packages/export/src/runtime/canvas-standalone.ts
@@ -176,12 +176,15 @@ export function createCanvasRuntimeState(
   }
 }
 
+/** Keys that should always pass through to the browser (e.g., F11 fullscreen, F12 DevTools). */
+const BROWSER_RESERVED_KEYS = new Set(['F11', 'F12'])
+
 /**
  * Set up input event listeners for the canvas.
  */
 export function setupInputListeners(state: CanvasRuntimeState): () => void {
   const handleKeyDown = (e: KeyboardEvent) => {
-    if (!e.ctrlKey && !e.metaKey) {
+    if (!e.ctrlKey && !e.metaKey && !BROWSER_RESERVED_KEYS.has(e.code)) {
       e.preventDefault()
     }
     if (!state.keysDown.has(e.code)) {
@@ -193,7 +196,7 @@ export function setupInputListeners(state: CanvasRuntimeState): () => void {
   }
 
   const handleKeyUp = (e: KeyboardEvent) => {
-    if (!e.ctrlKey && !e.metaKey) {
+    if (!e.ctrlKey && !e.metaKey && !BROWSER_RESERVED_KEYS.has(e.code)) {
       e.preventDefault()
     }
     state.keysDown.delete(e.code)

--- a/packages/export/tests/runtime/canvas-standalone.test.ts
+++ b/packages/export/tests/runtime/canvas-standalone.test.ts
@@ -252,6 +252,42 @@ describe('canvas-standalone', () => {
         expect(preventDefaultSpy).not.toHaveBeenCalled()
       })
 
+      it('should NOT call preventDefault on keydown for browser-reserved keys (F11, F12)', () => {
+        cleanup = setupInputListeners(state)
+
+        const keys = ['F11', 'F12']
+        for (const code of keys) {
+          const event = new KeyboardEvent('keydown', {
+            code,
+            bubbles: true,
+            cancelable: true,
+          })
+          const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+
+          document.dispatchEvent(event)
+
+          expect(preventDefaultSpy).not.toHaveBeenCalled()
+        }
+      })
+
+      it('should NOT call preventDefault on keyup for browser-reserved keys (F11, F12)', () => {
+        cleanup = setupInputListeners(state)
+
+        const keys = ['F11', 'F12']
+        for (const code of keys) {
+          const event = new KeyboardEvent('keyup', {
+            code,
+            bubbles: true,
+            cancelable: true,
+          })
+          const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+
+          document.dispatchEvent(event)
+
+          expect(preventDefaultSpy).not.toHaveBeenCalled()
+        }
+      })
+
       it('should not call preventDefault on keydown after cleanup', () => {
         cleanup = setupInputListeners(state)
 


### PR DESCRIPTION
## Summary
- Adds a `BROWSER_RESERVED_KEYS` allowlist (`F11`, `F12`) that bypasses `preventDefault()` in canvas keyboard handlers
- Applies to both `InputCapture` (editor runtime) and `canvas-standalone` (export runtime)
- Regenerated `canvas-inline.generated.ts` to include the fix in inline exports

Closes #633

## Test plan
- [x] Unit tests verify F11/F12 do NOT have `preventDefault()` called on keydown and keyup
- [x] Unit tests verify existing prevented keys (Tab, Arrow, Escape, Space) still work
- [x] Mutation testing: InputCapture 78.73% (all mutants on changed lines killed), canvas-standalone 95.05%
- [x] Lint passes, build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)