### PR TITLE
docs: add ANSI Consistency trigger rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,8 @@ All work happens in isolated worktrees. `/issue <n> begin` auto-creates worktree
 
 - **Canvas Consistency**: Changes to canvas behavior must be applied to BOTH the editor (`packages/canvas-runtime`) AND export (`packages/export/src/runtime`). Use shared code where possible; when not possible, implement in both and link the paired implementations.
 
+- **ANSI Consistency**: The ANSI editor and runtime share duplicated logic (compositing, text rasterization, types, serialization). **Run `/ansi` before making any changes** to files in `AnsiGraphicsEditor/`, `packages/lua-runtime/src/screen*`, `packages/lua-runtime/src/ansi*`, `packages/lua-runtime/src/textLayerGrid.ts`, or `packages/ansi-shared/`.
+
 See [docs/coding-standards.md](docs/coding-standards.md) for detailed guidelines.
 
 ### TDD is MANDATORY


### PR DESCRIPTION
## Summary
- Adds an ANSI Consistency bullet to the Code Architecture section of CLAUDE.md, mirroring the existing Canvas Consistency pattern
- Agents touching ANSI-related files will now be prompted to run `/ansi` for domain context first

## Test plan
- [x] Confirm the new rule appears in the Code Architecture section after Canvas Consistency
- [x] Confirm `/ansi` still appears in the Special Commands skill list

🤖 Generated with [Claude Code](https://claude.com/claude-code)