### PR TITLE
feat: custom layer IDs for ANSI editor

### DIFF
--- a/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.module.css
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.module.css
@@ -737,8 +737,15 @@
   color: inherit;
 }
 
-.layerName {
+.layerNameColumn {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-width: 0;
+}
+
+.layerName {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -755,6 +762,39 @@
   padding: 0 2px;
   outline: none;
   user-select: text;
+}
+
+.layerIdSubtitle {
+  font-size: 11px;
+  font-family: monospace;
+  color: var(--theme-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.2;
+}
+
+.layerIdInput {
+  width: 100%;
+  font-size: 11px;
+  font-family: monospace;
+  background-color: var(--theme-bg-primary);
+  color: var(--theme-text-primary);
+  border: 1px solid var(--theme-accent-primary);
+  border-radius: 2px;
+  padding: 0 2px;
+  outline: none;
+  user-select: text;
+}
+
+.layerIdInputError {
+  border-color: #ff4444;
+}
+
+.layerIdError {
+  font-size: 10px;
+  color: #ff4444;
+  white-space: nowrap;
 }
 
 .layerDragHandle {

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.tsx
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.tsx
@@ -75,6 +75,7 @@ export function AnsiGraphicsEditor({ filePath, onDirtyChange, isActive }: AnsiGr
     addLayer,
     removeLayer,
     renameLayer,
+    changeLayerId,
     setActiveLayer,
     reorderLayer,
     toggleVisibility,
@@ -244,6 +245,7 @@ export function AnsiGraphicsEditor({ filePath, onDirtyChange, isActive }: AnsiGr
           onToggleVisibility={toggleVisibility}
           onSetLayerVisibility={setLayerVisibility}
           onRename={renameLayer}
+          onChangeLayerId={changeLayerId}
           onReorder={reorderLayer}
           onAdd={addLayer}
           onRemove={removeLayer}

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/layerUtils.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/layerUtils.ts
@@ -68,23 +68,6 @@ export function isAncestorOf(layerId: string, candidateAncestorId: string, layer
   return getAncestorGroupIds(layer, layers).includes(candidateAncestorId)
 }
 
-let nextLayerId = 1
-let nextGroupId = 1
-
-export function syncLayerIds(layers: Layer[]): void {
-  for (const layer of layers) {
-    const layerMatch = layer.id.match(/^layer-(\d+)$/)
-    if (layerMatch) {
-      const num = parseInt(layerMatch[1], 10)
-      if (num >= nextLayerId) nextLayerId = num + 1
-    }
-    const groupMatch = layer.id.match(/^group-(\d+)$/)
-    if (groupMatch) {
-      const num = parseInt(groupMatch[1], 10)
-      if (num >= nextGroupId) nextGroupId = num + 1
-    }
-  }
-}
 
 export function rgbEqual(a: RGBColor, b: RGBColor): boolean {
   return a[0] === b[0] && a[1] === b[1] && a[2] === b[2]
@@ -100,7 +83,7 @@ export function createLayer(name: string, id?: string): DrawnLayer {
   )
   return {
     type: 'drawn',
-    id: id ?? `layer-${nextLayerId++}`,
+    id: id ?? crypto.randomUUID(),
     name,
     visible: true,
     grid,
@@ -113,7 +96,7 @@ export function createLayer(name: string, id?: string): DrawnLayer {
 export function createGroup(name: string, id?: string): GroupLayer {
   return {
     type: 'group',
-    id: id ?? `group-${nextGroupId++}`,
+    id: id ?? crypto.randomUUID(),
     name,
     visible: true,
     collapsed: false,
@@ -396,7 +379,7 @@ export function duplicateLayerBlock(layers: Layer[], layerId: string): Layer[] {
 
   if (!isGroupLayer(target)) {
     const cloned = cloneLayer(target)
-    const newId = `layer-${nextLayerId++}`
+    const newId = crypto.randomUUID()
     return [{ ...cloned, id: newId, name: `${target.name} (Copy)` }]
   }
 
@@ -404,10 +387,7 @@ export function duplicateLayerBlock(layers: Layer[], layerId: string): Layer[] {
   const idMap = new Map<string, string>()
 
   for (const layer of block) {
-    const newId = isGroupLayer(layer)
-      ? `group-${nextGroupId++}`
-      : `layer-${nextLayerId++}`
-    idMap.set(layer.id, newId)
+    idMap.set(layer.id, crypto.randomUUID())
   }
 
   return block.map(layer => {

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/types.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/types.ts
@@ -188,6 +188,7 @@ export interface UseAnsiEditorReturn {
   addLayer: () => void
   removeLayer: (id: string) => void
   renameLayer: (id: string, name: string) => void
+  changeLayerId: (oldId: string, newId: string) => { success: boolean; error?: string }
   setActiveLayer: (id: string) => void
   reorderLayer: (id: string, newIndex: number, targetGroupId?: string | null) => void
   toggleVisibility: (id: string) => void

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/useAnsiEditor.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/useAnsiEditor.ts
@@ -814,7 +814,7 @@ export function useAnsiEditor(options?: UseAnsiEditorOptions): UseAnsiEditorRetu
     isSaveDialogOpen, openSaveDialog, closeSaveDialog, undo, redo, canUndo, canRedo,
     layers: layerState.layers, activeLayerId: layerState.activeLayerId,
     addLayer: addLayerWithUndo, removeLayer: removeLayerWithUndo,
-    renameLayer: layerState.renameLayer, setActiveLayer: setActiveLayerWithBounds,
+    renameLayer: layerState.renameLayer, changeLayerId: layerState.changeLayerId, setActiveLayer: setActiveLayerWithBounds,
     reorderLayer: reorderLayerWithUndo,
     toggleVisibility: toggleVisibilityWithUndo, setLayerVisibility: setLayerVisibilityWithUndo,
     mergeDown: mergeDownWithUndo,


### PR DESCRIPTION
## Summary

- Replace counter-based layer IDs (`layer-1`, `group-1`) with `crypto.randomUUID()` for unique, collision-free IDs
- Add `changeLayerId()` operation with uniqueness and empty-string validation
- Display layer ID as a monospace subtitle in each layer row (UUIDs truncated to 8 chars, custom IDs shown in full)
- Allow inline editing of layer IDs via double-click (same Enter/Escape/blur pattern as name rename)
- Add "Copy Layer ID" to layer context menu
- Remove obsolete `syncLayerIds()` function and all call sites

Closes #650

## Test plan

- [x] `layerUtils.test.ts` — UUID generation for `createLayer`, `createGroup`, `duplicateLayerBlock` (153 tests)
- [x] `useLayerState.test.ts` — `changeLayerId` validation: uniqueness, empty, not-found, parentId updates (108 tests)
- [x] `LayersPanel.test.tsx` — ID display, truncation, inline editing, error display, Copy Layer ID context menu (89 tests)
- [x] Full test suite: 3731 tests passing across 176 files
- [x] TypeScript type-check: zero errors
- [x] Lint: zero errors
- [x] Build: succeeds
- [x] Mutation tests: passing above threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)