### PR TITLE
feat: add file download and folder download-as-ZIP from context menu

### DIFF
--- a/lua-learning-website/src/components/FileExplorer/FileExplorer.tsx
+++ b/lua-learning-website/src/components/FileExplorer/FileExplorer.tsx
@@ -43,6 +43,8 @@ export function FileExplorer({
   onUploadFiles,
   onUploadFolder,
   onCloneProject,
+  onDownloadFile,
+  onDownloadAsZip,
   className,
   workspaceProps,
 }: FileExplorerProps) {
@@ -194,6 +196,8 @@ export function FileExplorer({
     triggerUpload,
     triggerFolderUpload,
     openCloneDialog,
+    onDownloadFile,
+    onDownloadAsZip,
     workspaceProps,
   })
 

--- a/lua-learning-website/src/components/FileExplorer/contextMenuHelper.ts
+++ b/lua-learning-website/src/components/FileExplorer/contextMenuHelper.ts
@@ -6,6 +6,7 @@ import {
   readOnlyMarkdownFileContextMenuItems,
   htmlFileContextMenuItems,
   readOnlyHtmlFileContextMenuItems,
+  readOnlyFileContextMenuItems,
   folderContextMenuItems,
   workspaceContextMenuItems,
   libraryWorkspaceContextMenuItems,
@@ -61,8 +62,8 @@ export function getContextMenuItems(params: GetContextMenuItemsParams): ContextM
       if (isMarkdownFile(targetPath)) {
         return readOnlyMarkdownFileContextMenuItems
       }
-      // No context menu for other files in read-only workspaces
-      return []
+      // Generic files in read-only workspaces still get Download
+      return readOnlyFileContextMenuItems
     }
     // Check if it's an HTML file
     if (targetPath && isHtmlFile(targetPath)) {

--- a/lua-learning-website/src/components/FileExplorer/contextMenuItems.test.ts
+++ b/lua-learning-website/src/components/FileExplorer/contextMenuItems.test.ts
@@ -1,7 +1,19 @@
 import { describe, it, expect } from 'vitest'
 import {
+  fileContextMenuItems,
+  markdownFileContextMenuItems,
+  readOnlyMarkdownFileContextMenuItems,
+  htmlFileContextMenuItems,
+  readOnlyHtmlFileContextMenuItems,
+  readOnlyFileContextMenuItems,
   folderContextMenuItems,
   workspaceContextMenuItems,
+  libraryWorkspaceContextMenuItems,
+  docsWorkspaceContextMenuItems,
+  bookWorkspaceContextMenuItems,
+  examplesWorkspaceContextMenuItems,
+  projectsWorkspaceContextMenuItems,
+  projectSubfolderContextMenuItems,
   buildConnectedWorkspaceMenuItems,
 } from './contextMenuItems'
 
@@ -24,6 +36,101 @@ describe('contextMenuItems', () => {
       const uploadItem = items.find((item) => item.id === 'upload-files')
       expect(uploadItem).toBeDefined()
       expect(uploadItem?.label).toBe('Upload Files...')
+    })
+  })
+
+  describe('download menu items', () => {
+    it('fileContextMenuItems includes download', () => {
+      const item = fileContextMenuItems.find((i) => i.id === 'download')
+      expect(item).toBeDefined()
+      expect(item?.label).toBe('Download')
+    })
+
+    it('markdownFileContextMenuItems includes download', () => {
+      const item = markdownFileContextMenuItems.find((i) => i.id === 'download')
+      expect(item).toBeDefined()
+      expect(item?.label).toBe('Download')
+    })
+
+    it('readOnlyMarkdownFileContextMenuItems includes download', () => {
+      const item = readOnlyMarkdownFileContextMenuItems.find((i) => i.id === 'download')
+      expect(item).toBeDefined()
+      expect(item?.label).toBe('Download')
+    })
+
+    it('htmlFileContextMenuItems includes download', () => {
+      const item = htmlFileContextMenuItems.find((i) => i.id === 'download')
+      expect(item).toBeDefined()
+      expect(item?.label).toBe('Download')
+    })
+
+    it('readOnlyHtmlFileContextMenuItems includes download', () => {
+      const item = readOnlyHtmlFileContextMenuItems.find((i) => i.id === 'download')
+      expect(item).toBeDefined()
+      expect(item?.label).toBe('Download')
+    })
+
+    it('readOnlyFileContextMenuItems includes download', () => {
+      const item = readOnlyFileContextMenuItems.find((i) => i.id === 'download')
+      expect(item).toBeDefined()
+      expect(item?.label).toBe('Download')
+    })
+  })
+
+  describe('download-zip menu items', () => {
+    it('folderContextMenuItems includes download-zip', () => {
+      const item = folderContextMenuItems.find((i) => i.id === 'download-zip')
+      expect(item).toBeDefined()
+      expect(item?.label).toBe('Download as ZIP')
+    })
+
+    it('workspaceContextMenuItems includes download-zip', () => {
+      const item = workspaceContextMenuItems.find((i) => i.id === 'download-zip')
+      expect(item).toBeDefined()
+      expect(item?.label).toBe('Download as ZIP')
+    })
+
+    it('buildConnectedWorkspaceMenuItems includes download-zip', () => {
+      const items = buildConnectedWorkspaceMenuItems()
+      const item = items.find((i) => i.id === 'download-zip')
+      expect(item).toBeDefined()
+      expect(item?.label).toBe('Download as ZIP')
+    })
+
+    it('libraryWorkspaceContextMenuItems includes download-zip', () => {
+      const item = libraryWorkspaceContextMenuItems.find((i) => i.id === 'download-zip')
+      expect(item).toBeDefined()
+      expect(item?.label).toBe('Download as ZIP')
+    })
+
+    it('docsWorkspaceContextMenuItems includes download-zip', () => {
+      const item = docsWorkspaceContextMenuItems.find((i) => i.id === 'download-zip')
+      expect(item).toBeDefined()
+      expect(item?.label).toBe('Download as ZIP')
+    })
+
+    it('bookWorkspaceContextMenuItems includes download-zip', () => {
+      const item = bookWorkspaceContextMenuItems.find((i) => i.id === 'download-zip')
+      expect(item).toBeDefined()
+      expect(item?.label).toBe('Download as ZIP')
+    })
+
+    it('examplesWorkspaceContextMenuItems includes download-zip', () => {
+      const item = examplesWorkspaceContextMenuItems.find((i) => i.id === 'download-zip')
+      expect(item).toBeDefined()
+      expect(item?.label).toBe('Download as ZIP')
+    })
+
+    it('projectsWorkspaceContextMenuItems includes download-zip', () => {
+      const item = projectsWorkspaceContextMenuItems.find((i) => i.id === 'download-zip')
+      expect(item).toBeDefined()
+      expect(item?.label).toBe('Download as ZIP')
+    })
+
+    it('projectSubfolderContextMenuItems includes download-zip', () => {
+      const item = projectSubfolderContextMenuItems.find((i) => i.id === 'download-zip')
+      expect(item).toBeDefined()
+      expect(item?.label).toBe('Download as ZIP')
     })
   })
 })

--- a/lua-learning-website/src/components/FileExplorer/contextMenuItems.ts
+++ b/lua-learning-website/src/components/FileExplorer/contextMenuItems.ts
@@ -2,6 +2,8 @@ import type { ContextMenuItem } from '../ContextMenu'
 
 // Stryker disable all: Menu item IDs are internal identifiers tested via behavior
 export const fileContextMenuItems: ContextMenuItem[] = [
+  { id: 'download', label: 'Download' },
+  { id: 'divider-download', type: 'divider' },
   { id: 'rename', label: 'Rename' },
   { id: 'delete', label: 'Delete' },
 ]
@@ -10,6 +12,8 @@ export const markdownFileContextMenuItems: ContextMenuItem[] = [
   { id: 'preview-markdown', label: 'Preview Markdown' },
   { id: 'edit-markdown', label: 'Edit Markdown' },
   { id: 'divider-markdown', type: 'divider' },
+  { id: 'download', label: 'Download' },
+  { id: 'divider-download', type: 'divider' },
   { id: 'rename', label: 'Rename' },
   { id: 'delete', label: 'Delete' },
 ]
@@ -18,6 +22,8 @@ export const markdownFileContextMenuItems: ContextMenuItem[] = [
 export const readOnlyMarkdownFileContextMenuItems: ContextMenuItem[] = [
   { id: 'preview-markdown', label: 'Preview Markdown' },
   { id: 'edit-markdown', label: 'Edit Markdown' },
+  { id: 'divider-download', type: 'divider' },
+  { id: 'download', label: 'Download' },
 ]
 
 export const htmlFileContextMenuItems: ContextMenuItem[] = [
@@ -25,6 +31,8 @@ export const htmlFileContextMenuItems: ContextMenuItem[] = [
   { id: 'open-in-browser', label: 'Open in Browser Tab' },
   { id: 'edit-html', label: 'Edit HTML' },
   { id: 'divider-html', type: 'divider' },
+  { id: 'download', label: 'Download' },
+  { id: 'divider-download', type: 'divider' },
   { id: 'rename', label: 'Rename' },
   { id: 'delete', label: 'Delete' },
 ]
@@ -34,6 +42,13 @@ export const readOnlyHtmlFileContextMenuItems: ContextMenuItem[] = [
   { id: 'preview-html', label: 'Preview HTML' },
   { id: 'open-in-browser', label: 'Open in Browser Tab' },
   { id: 'edit-html', label: 'Edit HTML' },
+  { id: 'divider-download', type: 'divider' },
+  { id: 'download', label: 'Download' },
+]
+
+// Generic read-only files get a Download option
+export const readOnlyFileContextMenuItems: ContextMenuItem[] = [
+  { id: 'download', label: 'Download' },
 ]
 
 export const folderContextMenuItems: ContextMenuItem[] = [
@@ -43,6 +58,7 @@ export const folderContextMenuItems: ContextMenuItem[] = [
   { id: 'upload-folder', label: 'Upload Folder...' },
   { id: 'divider', type: 'divider' },
   { id: 'open-in-terminal', label: 'Open in Shell' },
+  { id: 'download-zip', label: 'Download as ZIP' },
   { id: 'divider-terminal', type: 'divider' },
   { id: 'rename', label: 'Rename' },
   { id: 'delete', label: 'Delete' },
@@ -55,29 +71,42 @@ export const workspaceContextMenuItems: ContextMenuItem[] = [
   { id: 'upload-folder', label: 'Upload Folder...' },
   { id: 'divider', type: 'divider' },
   { id: 'open-in-terminal', label: 'Open in Shell' },
+  { id: 'download-zip', label: 'Download as ZIP' },
   { id: 'divider-terminal', type: 'divider' },
   { id: 'rename-workspace', label: 'Rename Workspace' },
   { id: 'remove-workspace', label: 'Remove Workspace' },
 ]
 
-// Library workspaces are read-only and cannot be modified
-export const libraryWorkspaceContextMenuItems: ContextMenuItem[] = []
+// Library workspaces are read-only — download only
+export const libraryWorkspaceContextMenuItems: ContextMenuItem[] = [
+  { id: 'download-zip', label: 'Download as ZIP' },
+]
 
-// Docs workspaces are read-only and cannot be modified
-export const docsWorkspaceContextMenuItems: ContextMenuItem[] = []
+// Docs workspaces are read-only — download only
+export const docsWorkspaceContextMenuItems: ContextMenuItem[] = [
+  { id: 'download-zip', label: 'Download as ZIP' },
+]
 
-// Book workspaces are read-only and cannot be modified
-export const bookWorkspaceContextMenuItems: ContextMenuItem[] = []
+// Book workspaces are read-only — download only
+export const bookWorkspaceContextMenuItems: ContextMenuItem[] = [
+  { id: 'download-zip', label: 'Download as ZIP' },
+]
 
-// Examples workspaces are read-only and cannot be modified
-export const examplesWorkspaceContextMenuItems: ContextMenuItem[] = []
+// Examples workspaces are read-only — download only
+export const examplesWorkspaceContextMenuItems: ContextMenuItem[] = [
+  { id: 'download-zip', label: 'Download as ZIP' },
+]
 
-// Projects workspace root is read-only and cannot be modified
-export const projectsWorkspaceContextMenuItems: ContextMenuItem[] = []
+// Projects workspace root is read-only — download only
+export const projectsWorkspaceContextMenuItems: ContextMenuItem[] = [
+  { id: 'download-zip', label: 'Download as ZIP' },
+]
 
-// Project subfolder (e.g., space_shooter) can be cloned
+// Project subfolder (e.g., space_shooter) can be cloned or downloaded
 export const projectSubfolderContextMenuItems: ContextMenuItem[] = [
   { id: 'clone-project', label: 'Clone Project' },
+  { id: 'divider-download', type: 'divider' },
+  { id: 'download-zip', label: 'Download as ZIP' },
 ]
 // Stryker restore all
 

--- a/lua-learning-website/src/components/FileExplorer/types.ts
+++ b/lua-learning-website/src/components/FileExplorer/types.ts
@@ -69,6 +69,10 @@ export interface FileExplorerProps {
   onUploadFolder?: (files: FileList, targetFolderPath: string) => void
   /** Clone a project from the projects workspace into a new editable workspace */
   onCloneProject?: (projectPath: string, workspaceName: string, type: 'virtual' | 'local', handle?: FileSystemDirectoryHandle) => void
+  /** Download a single file */
+  onDownloadFile?: (path: string) => void
+  /** Download a folder as a ZIP archive */
+  onDownloadAsZip?: (path: string) => void
   className?: string
   /** Optional workspace management props. When provided, workspace tabs are shown. */
   workspaceProps?: WorkspaceProps

--- a/lua-learning-website/src/components/FileExplorer/useContextMenuActions.test.ts
+++ b/lua-learning-website/src/components/FileExplorer/useContextMenuActions.test.ts
@@ -32,6 +32,8 @@ describe('useContextMenuActions', () => {
     triggerUpload: vi.fn(),
     triggerFolderUpload: vi.fn(),
     openCloneDialog: vi.fn(),
+    onDownloadFile: vi.fn(),
+    onDownloadAsZip: vi.fn(),
     workspaceProps: {
       workspaces: [],
       pendingWorkspaces: new Set<string>(),
@@ -229,6 +231,24 @@ describe('useContextMenuActions', () => {
         act(() => { result.current.handleContextMenuSelect('clone-project') })
 
         expect(defaultParams.openCloneDialog).toHaveBeenCalledWith('/workspace/file.lua')
+      })
+    })
+
+    describe('download actions', () => {
+      it('dispatches download action', () => {
+        const { result } = renderHook(() => useContextMenuActions(defaultParams))
+
+        act(() => { result.current.handleContextMenuSelect('download') })
+
+        expect(defaultParams.onDownloadFile).toHaveBeenCalledWith('/workspace/file.lua')
+      })
+
+      it('dispatches download-zip action', () => {
+        const { result } = renderHook(() => useContextMenuActions(defaultParams))
+
+        act(() => { result.current.handleContextMenuSelect('download-zip') })
+
+        expect(defaultParams.onDownloadAsZip).toHaveBeenCalledWith('/workspace/file.lua')
       })
     })
 

--- a/lua-learning-website/src/components/FileExplorer/useContextMenuActions.ts
+++ b/lua-learning-website/src/components/FileExplorer/useContextMenuActions.ts
@@ -22,6 +22,8 @@ interface UseContextMenuActionsParams {
   triggerUpload: (targetPath: string) => void
   triggerFolderUpload?: (targetPath: string) => void
   openCloneDialog: (projectPath: string) => void
+  onDownloadFile?: (path: string) => void
+  onDownloadAsZip?: (path: string) => void
   workspaceProps?: WorkspaceProps
 }
 
@@ -50,6 +52,8 @@ export function useContextMenuActions({
   triggerUpload,
   triggerFolderUpload,
   openCloneDialog,
+  onDownloadFile,
+  onDownloadAsZip,
   workspaceProps,
 }: UseContextMenuActionsParams) {
   const handleContextMenuSelect = useCallback((action: string) => {
@@ -122,6 +126,12 @@ export function useContextMenuActions({
       case 'clone-project':
         openCloneDialog(targetPath)
         break
+      case 'download':
+        onDownloadFile?.(targetPath)
+        break
+      case 'download-zip':
+        onDownloadAsZip?.(targetPath)
+        break
       case 'delete': {
         const name = findNodeName(targetPath)
         const isFolder = targetType === 'folder'
@@ -166,6 +176,8 @@ export function useContextMenuActions({
     triggerUpload,
     triggerFolderUpload,
     openCloneDialog,
+    onDownloadFile,
+    onDownloadAsZip,
     workspaceProps,
   ])
 

--- a/lua-learning-website/src/components/IDELayout/IDELayout.tsx
+++ b/lua-learning-website/src/components/IDELayout/IDELayout.tsx
@@ -29,6 +29,7 @@ import { useEditorExtensions } from '../../hooks/useEditorExtensions'
 import { useCloneProject } from '../../hooks/useCloneProject'
 import { createFileSystemAdapter } from '../../hooks/compositeFileSystemAdapter'
 import { initFormatter, formatLuaCode } from '../../utils/luaFormatter'
+import { downloadSingleFile, downloadDirectoryAsZip } from '../../utils/downloadHelper'
 import type { Workspace } from '../../hooks/workspaceTypes'
 import type { IFileSystem, ScreenMode } from '@lua-learning/shell-core'
 import styles from './IDELayout.module.css'
@@ -748,6 +749,24 @@ function IDELayoutInner({
     showError,
   })
 
+  // Download handlers for context menu
+  const handleDownloadFile = useCallback(async (path: string) => {
+    try {
+      await downloadSingleFile(compositeFileSystem, path)
+    } catch (err) {
+      showError(`Download failed: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }, [compositeFileSystem, showError])
+
+  const handleDownloadAsZip = useCallback(async (path: string) => {
+    try {
+      const zipName = path.split('/').filter(Boolean).pop() || 'download'
+      await downloadDirectoryAsZip(compositeFileSystem, path, zipName)
+    } catch (err) {
+      showError(`Download failed: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }, [compositeFileSystem, showError])
+
   // Explorer props for FileExplorer
   const explorerProps = createExplorerProps({
     fileTree, activeTab, pendingNewFilePath, pendingNewFolderPath,
@@ -760,6 +779,8 @@ function IDELayoutInner({
     refreshFileTree, supportsRefresh, handleReconnectWorkspace, handleDisconnectWorkspace,
     handleRenameWorkspace, isFolderAlreadyMounted, getUniqueWorkspaceName,
     handleCloneProject,
+    onDownloadFile: handleDownloadFile,
+    onDownloadAsZip: handleDownloadAsZip,
   })
 
   // Tab bar props for EditorPanel (only when tabs exist)

--- a/lua-learning-website/src/components/IDELayout/explorerPropsHelper.ts
+++ b/lua-learning-website/src/components/IDELayout/explorerPropsHelper.ts
@@ -58,6 +58,9 @@ export interface ExplorerPropsParams {
   getUniqueWorkspaceName: (baseName: string) => string
   // Clone project handler
   handleCloneProject?: (projectPath: string, workspaceName: string, type: 'virtual' | 'local', handle?: FileSystemDirectoryHandle) => void
+  // Download handlers
+  onDownloadFile?: (path: string) => void
+  onDownloadAsZip?: (path: string) => void
 }
 
 /**
@@ -136,6 +139,8 @@ export function createExplorerProps(params: ExplorerPropsParams) {
     onUploadFiles: params.uploadFiles,
     onUploadFolder: params.uploadFolder,
     onCloneProject: params.handleCloneProject,
+    onDownloadFile: params.onDownloadFile,
+    onDownloadAsZip: params.onDownloadAsZip,
     workspaceProps: {
       workspaces: params.workspaces,
       pendingWorkspaces: params.pendingWorkspaces,

--- a/lua-learning-website/src/utils/downloadHelper.test.ts
+++ b/lua-learning-website/src/utils/downloadHelper.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { IFileSystem, FileEntry } from '@lua-learning/shell-core'
+
+// Mock triggerDownload
+vi.mock('./dataExporter/dataExporter', () => ({
+  triggerDownload: vi.fn(),
+}))
+
+// Mock JSZip - use vi.hoisted to define mock fns before vi.mock hoisting
+const { mockFile, mockGenerateAsync } = vi.hoisted(() => ({
+  mockFile: vi.fn(),
+  mockGenerateAsync: vi.fn(),
+}))
+
+vi.mock('jszip', () => {
+  class MockJSZip {
+    file = mockFile
+    generateAsync = mockGenerateAsync
+  }
+  return { default: MockJSZip }
+})
+
+import { downloadSingleFile, downloadDirectoryAsZip } from './downloadHelper'
+import { triggerDownload } from './dataExporter/dataExporter'
+
+function createMockFileSystem(overrides: Partial<IFileSystem> = {}): IFileSystem {
+  return {
+    getCurrentDirectory: vi.fn().mockReturnValue('/'),
+    setCurrentDirectory: vi.fn(),
+    exists: vi.fn().mockReturnValue(true),
+    isDirectory: vi.fn().mockReturnValue(false),
+    isFile: vi.fn().mockReturnValue(true),
+    listDirectory: vi.fn().mockReturnValue([]),
+    readFile: vi.fn().mockReturnValue(''),
+    writeFile: vi.fn(),
+    createDirectory: vi.fn(),
+    delete: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('downloadHelper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGenerateAsync.mockResolvedValue(new ArrayBuffer(8))
+  })
+
+  describe('downloadSingleFile', () => {
+    it('downloads a text file with correct filename and content', async () => {
+      const fs = createMockFileSystem({
+        readFile: vi.fn().mockReturnValue('hello world'),
+      })
+
+      await downloadSingleFile(fs, '/workspace/hello.lua')
+
+      expect(fs.readFile).toHaveBeenCalledWith('/workspace/hello.lua')
+      const blob = vi.mocked(triggerDownload).mock.calls[0][1]
+      expect(blob.type).toBe('text/plain')
+      expect(blob.size).toBe(11) // 'hello world'.length
+      expect(triggerDownload).toHaveBeenCalledWith('hello.lua', blob)
+    })
+
+    it('downloads a binary file using readBinaryFile with octet-stream type', async () => {
+      const binaryData = new Uint8Array([0x89, 0x50, 0x4e, 0x47])
+      const fs = createMockFileSystem({
+        isBinaryFile: vi.fn().mockReturnValue(true),
+        readBinaryFile: vi.fn().mockReturnValue(binaryData),
+      })
+
+      await downloadSingleFile(fs, '/workspace/image.png')
+
+      expect(fs.readBinaryFile).toHaveBeenCalledWith('/workspace/image.png')
+      const blob = vi.mocked(triggerDownload).mock.calls[0][1]
+      expect(blob.type).toBe('application/octet-stream')
+      expect(blob.size).toBeGreaterThan(0)
+      expect(triggerDownload).toHaveBeenCalledWith('image.png', blob)
+    })
+
+    it('falls back to readFile when isBinaryFile returns true but readBinaryFile is not available', async () => {
+      const fs = createMockFileSystem({
+        isBinaryFile: vi.fn().mockReturnValue(true),
+        readFile: vi.fn().mockReturnValue('binary-as-text'),
+      })
+      // No readBinaryFile method
+
+      await downloadSingleFile(fs, '/workspace/data.bin')
+
+      expect(fs.readFile).toHaveBeenCalledWith('/workspace/data.bin')
+      expect(triggerDownload).toHaveBeenCalledWith(
+        'data.bin',
+        expect.any(Blob)
+      )
+    })
+
+    it('treats file as text when isBinaryFile is not available', async () => {
+      const fs = createMockFileSystem({
+        readFile: vi.fn().mockReturnValue('text content'),
+      })
+      // No isBinaryFile method — should default to text, not binary
+
+      await downloadSingleFile(fs, '/workspace/file.txt')
+
+      expect(fs.readFile).toHaveBeenCalledWith('/workspace/file.txt')
+      const blob = vi.mocked(triggerDownload).mock.calls[0][1]
+      expect(blob.type).toBe('text/plain')
+      expect(blob.size).toBe(12) // 'text content'.length
+    })
+
+    it('extracts filename from nested path', async () => {
+      const fs = createMockFileSystem({
+        readFile: vi.fn().mockReturnValue('content'),
+      })
+
+      await downloadSingleFile(fs, '/workspace/src/deep/nested/file.lua')
+
+      expect(triggerDownload).toHaveBeenCalledWith(
+        'file.lua',
+        expect.any(Blob)
+      )
+    })
+  })
+
+  describe('downloadDirectoryAsZip', () => {
+    it('creates a ZIP with flat files', async () => {
+      const files: FileEntry[] = [
+        { name: 'main.lua', type: 'file', path: '/workspace/main.lua' },
+        { name: 'util.lua', type: 'file', path: '/workspace/util.lua' },
+      ]
+      const fs = createMockFileSystem({
+        listDirectory: vi.fn().mockReturnValue(files),
+        readFile: vi.fn().mockReturnValue('content'),
+        isDirectory: vi.fn().mockReturnValue(false),
+      })
+
+      await downloadDirectoryAsZip(fs, '/workspace', 'workspace')
+
+      expect(mockFile).toHaveBeenCalledWith('main.lua', 'content')
+      expect(mockFile).toHaveBeenCalledWith('util.lua', 'content')
+      expect(mockGenerateAsync).toHaveBeenCalledWith({ type: 'arraybuffer' })
+      expect(triggerDownload).toHaveBeenCalledWith(
+        'workspace.zip',
+        expect.any(Blob)
+      )
+    })
+
+    it('handles nested subdirectories with correct relative paths', async () => {
+      const rootFiles: FileEntry[] = [
+        { name: 'src', type: 'directory', path: '/workspace/src' },
+      ]
+      const srcFiles: FileEntry[] = [
+        { name: 'main.lua', type: 'file', path: '/workspace/src/main.lua' },
+      ]
+      const fs = createMockFileSystem({
+        listDirectory: vi.fn()
+          .mockReturnValueOnce(rootFiles)
+          .mockReturnValueOnce(srcFiles),
+        readFile: vi.fn().mockReturnValue('code'),
+        isDirectory: vi.fn()
+          .mockImplementation((path: string) => path === '/workspace/src'),
+      })
+
+      await downloadDirectoryAsZip(fs, '/workspace', 'workspace')
+
+      expect(mockFile).toHaveBeenCalledWith('src/main.lua', 'code')
+    })
+
+    it('creates a valid ZIP for an empty directory', async () => {
+      const fs = createMockFileSystem({
+        listDirectory: vi.fn().mockReturnValue([]),
+      })
+
+      await downloadDirectoryAsZip(fs, '/empty', 'empty')
+
+      expect(mockFile).not.toHaveBeenCalled()
+      expect(mockGenerateAsync).toHaveBeenCalled()
+      const blob = vi.mocked(triggerDownload).mock.calls[0][1]
+      expect(blob.type).toBe('application/zip')
+      expect(blob.size).toBeGreaterThan(0)
+      expect(triggerDownload).toHaveBeenCalledWith('empty.zip', blob)
+    })
+
+    it('handles binary files in ZIP using readBinaryFile', async () => {
+      const binaryData = new Uint8Array([0x89, 0x50, 0x4e, 0x47])
+      const files: FileEntry[] = [
+        { name: 'image.png', type: 'file', path: '/dir/image.png' },
+      ]
+      const fs = createMockFileSystem({
+        listDirectory: vi.fn().mockReturnValue(files),
+        isDirectory: vi.fn().mockReturnValue(false),
+        isBinaryFile: vi.fn().mockReturnValue(true),
+        readBinaryFile: vi.fn().mockReturnValue(binaryData),
+      })
+
+      await downloadDirectoryAsZip(fs, '/dir', 'dir')
+
+      expect(mockFile).toHaveBeenCalledWith('image.png', binaryData, { binary: true })
+    })
+
+    it('handles mixed text and binary files', async () => {
+      const binaryData = new Uint8Array([0x00, 0x01])
+      const files: FileEntry[] = [
+        { name: 'script.lua', type: 'file', path: '/mix/script.lua' },
+        { name: 'data.bin', type: 'file', path: '/mix/data.bin' },
+      ]
+      const fs = createMockFileSystem({
+        listDirectory: vi.fn().mockReturnValue(files),
+        isDirectory: vi.fn().mockReturnValue(false),
+        isBinaryFile: vi.fn().mockImplementation((p: string) => p.endsWith('.bin')),
+        readBinaryFile: vi.fn().mockReturnValue(binaryData),
+        readFile: vi.fn().mockReturnValue('lua code'),
+      })
+
+      await downloadDirectoryAsZip(fs, '/mix', 'mix')
+
+      expect(mockFile).toHaveBeenCalledWith('script.lua', 'lua code')
+      expect(mockFile).toHaveBeenCalledWith('data.bin', binaryData, { binary: true })
+    })
+
+    it('uses the provided zip name for the download filename', async () => {
+      const fs = createMockFileSystem({
+        listDirectory: vi.fn().mockReturnValue([]),
+      })
+
+      await downloadDirectoryAsZip(fs, '/project', 'my-project')
+
+      expect(triggerDownload).toHaveBeenCalledWith(
+        'my-project.zip',
+        expect.any(Blob)
+      )
+    })
+  })
+})

--- a/lua-learning-website/src/utils/downloadHelper.ts
+++ b/lua-learning-website/src/utils/downloadHelper.ts
@@ -1,0 +1,89 @@
+import JSZip from 'jszip'
+import type { IFileSystem } from '@lua-learning/shell-core'
+import { triggerDownload } from './dataExporter/dataExporter'
+
+/**
+ * Extract the filename from a full path.
+ */
+function extractFilename(path: string): string {
+  return path.split('/').pop() || path
+}
+
+/**
+ * Read a single file from the filesystem, handling binary vs text.
+ * Returns { data, isBinary } where data is either a Uint8Array or string.
+ */
+function readFileContent(
+  fs: IFileSystem,
+  path: string
+): { data: Uint8Array | string; isBinary: boolean } {
+  const isBinary = fs.isBinaryFile?.(path) ?? false
+
+  if (isBinary && fs.readBinaryFile) {
+    return { data: fs.readBinaryFile(path), isBinary: true }
+  }
+
+  return { data: fs.readFile(path), isBinary: false }
+}
+
+/**
+ * Download a single file from the virtual filesystem.
+ */
+export async function downloadSingleFile(
+  fs: IFileSystem,
+  path: string
+): Promise<void> {
+  const { data, isBinary } = readFileContent(fs, path)
+  const blob = isBinary
+    ? new Blob([data as BlobPart], { type: 'application/octet-stream' })
+    : new Blob([data as string], { type: 'text/plain' })
+
+  triggerDownload(extractFilename(path), blob)
+}
+
+/**
+ * Recursively collect all files in a directory and add them to a JSZip instance.
+ */
+function addDirectoryToZip(
+  fs: IFileSystem,
+  zip: JSZip,
+  dirPath: string,
+  relativePath: string
+): void {
+  const entries = fs.listDirectory(dirPath)
+
+  for (const entry of entries) {
+    const entryRelative = relativePath
+      ? `${relativePath}/${entry.name}`
+      : entry.name
+
+    if (fs.isDirectory(entry.path)) {
+      addDirectoryToZip(fs, zip, entry.path, entryRelative)
+    } else {
+      const { data, isBinary } = readFileContent(fs, entry.path)
+      if (isBinary) {
+        zip.file(entryRelative, data as Uint8Array, { binary: true })
+      } else {
+        zip.file(entryRelative, data as string)
+      }
+    }
+  }
+}
+
+/**
+ * Download a directory as a ZIP archive.
+ */
+export async function downloadDirectoryAsZip(
+  fs: IFileSystem,
+  dirPath: string,
+  zipName: string
+): Promise<void> {
+  const zip = new JSZip()
+
+  addDirectoryToZip(fs, zip, dirPath, '')
+
+  const arrayBuffer = await zip.generateAsync({ type: 'arraybuffer' })
+  const blob = new Blob([arrayBuffer], { type: 'application/zip' })
+
+  triggerDownload(`${zipName}.zip`, blob)
+}


### PR DESCRIPTION
## Summary
- Add **"Download"** context menu item for all file types (regular, markdown, HTML, read-only)
- Add **"Download as ZIP"** context menu item for all folders and workspace roots (including read-only library/docs/book/examples/projects)
- New `downloadHelper.ts` utility with `downloadSingleFile()` and `downloadDirectoryAsZip()` — handles binary/text files, recursive directory traversal, reuses existing `triggerDownload()` + `JSZip`
- Callbacks threaded through the full component tree: `contextMenuItems` → `useContextMenuActions` → `FileExplorer` → `explorerPropsHelper` → `IDELayout`

## Test plan
- [x] 11 unit tests for `downloadHelper.ts` (96.88% mutation score)
- [x] 18 tests for context menu items (verify download/download-zip in all menus)
- [x] 30 tests for `useContextMenuActions` (verify download/download-zip dispatch)
- [x] Full test suite: 3914/3914 pass
- [x] TypeScript type-check: clean
- [x] Lint: clean
- [ ] Manual: right-click file → Download triggers browser download
- [ ] Manual: right-click folder → Download as ZIP creates ZIP with correct structure
- [ ] Manual: right-click read-only workspace → Download as ZIP works

🤖 Generated with [Claude Code](https://claude.com/claude-code)