### PR TITLE
fix: support rendering multiple HTML tabs independently

### DIFF
--- a/lua-learning-website/src/components/IDELayout/HtmlTabContent.test.tsx
+++ b/lua-learning-website/src/components/IDELayout/HtmlTabContent.test.tsx
@@ -1,30 +1,164 @@
 import { render, screen } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { HtmlTabContent } from './HtmlTabContent'
+import type { IFileSystem } from '@lua-learning/shell-core'
+
+function createMockFileSystem(files: Record<string, string>): IFileSystem {
+  return {
+    exists: vi.fn((path: string) => path in files),
+    readFile: vi.fn((path: string) => files[path] ?? ''),
+    writeFile: vi.fn(),
+    deleteFile: vi.fn(),
+    deleteDirectory: vi.fn(),
+    createDirectory: vi.fn(),
+    listFiles: vi.fn(() => []),
+    getTree: vi.fn(() => []),
+    moveFile: vi.fn(),
+    copyFile: vi.fn(),
+    readBinaryFile: vi.fn(() => new Uint8Array()),
+    writeBinaryFile: vi.fn(),
+  } as unknown as IFileSystem
+}
 
 describe('HtmlTabContent', () => {
   it('should render the HtmlViewer with provided content', () => {
-    render(<HtmlTabContent content="<h1>Hello</h1>" />)
-    const iframe = screen.getByTestId('html-viewer')
-    expect(iframe).toHaveAttribute('srcdoc', '<h1>Hello</h1>')
-  })
-
-  it('should render TabBar when tabBarProps are provided', () => {
+    const fileSystem = createMockFileSystem({ '/test.html': '<h1>Hello</h1>' })
     const tabBarProps = {
       tabs: [{ path: '/test.html', name: 'test.html', isDirty: false, type: 'html' as const, isPreview: false, isPinned: false }],
       activeTab: '/test.html',
       onSelect: () => {},
       onClose: () => {},
     }
-    render(<HtmlTabContent content="<p>test</p>" tabBarProps={tabBarProps} />)
+    render(<HtmlTabContent tabBarProps={tabBarProps} fileSystem={fileSystem} activeTab="/test.html" />)
+    const iframe = screen.getByTestId('html-viewer')
+    expect(iframe).toHaveAttribute('srcdoc', '<h1>Hello</h1>')
+  })
+
+  it('should render TabBar when tabBarProps are provided', () => {
+    const fileSystem = createMockFileSystem({ '/test.html': '<p>test</p>' })
+    const tabBarProps = {
+      tabs: [{ path: '/test.html', name: 'test.html', isDirty: false, type: 'html' as const, isPreview: false, isPinned: false }],
+      activeTab: '/test.html',
+      onSelect: () => {},
+      onClose: () => {},
+    }
+    render(<HtmlTabContent tabBarProps={tabBarProps} fileSystem={fileSystem} activeTab="/test.html" />)
     expect(screen.getByText('test.html')).toBeInTheDocument()
   })
 
-  it('should render without TabBar when tabBarProps is undefined', () => {
-    const { container } = render(<HtmlTabContent content="<p>test</p>" />)
-    // Should still render the iframe
-    expect(screen.getByTestId('html-viewer')).toBeInTheDocument()
-    // TabBar should not be present
-    expect(container.querySelector('[data-testid="tab-bar"]')).toBeNull()
+  it('should render no viewers when tabBarProps is undefined (no tabs)', () => {
+    const fileSystem = createMockFileSystem({ '/test.html': '<p>test</p>' })
+    render(<HtmlTabContent fileSystem={fileSystem} activeTab="/test.html" />)
+    // No HTML tabs means no viewers rendered
+    expect(screen.queryByTestId('html-viewer')).not.toBeInTheDocument()
+  })
+
+  describe('multi-tab rendering', () => {
+    it('should render one HtmlViewer per HTML tab', () => {
+      const fileSystem = createMockFileSystem({
+        '/page1.html': '<h1>Page 1</h1>',
+        '/page2.html': '<h2>Page 2</h2>',
+      })
+      const tabBarProps = {
+        tabs: [
+          { path: '/page1.html', name: 'page1.html', isDirty: false, type: 'html' as const, isPreview: false, isPinned: false },
+          { path: '/page2.html', name: 'page2.html', isDirty: false, type: 'html' as const, isPreview: false, isPinned: false },
+        ],
+        activeTab: '/page1.html',
+        onSelect: () => {},
+        onClose: () => {},
+      }
+      render(<HtmlTabContent tabBarProps={tabBarProps} fileSystem={fileSystem} activeTab="/page1.html" />)
+
+      const viewers = screen.getAllByTestId('html-viewer')
+      expect(viewers).toHaveLength(2)
+    })
+
+    it('should render correct content for each HTML tab', () => {
+      const fileSystem = createMockFileSystem({
+        '/page1.html': '<h1>Page 1</h1>',
+        '/page2.html': '<h2>Page 2</h2>',
+      })
+      const tabBarProps = {
+        tabs: [
+          { path: '/page1.html', name: 'page1.html', isDirty: false, type: 'html' as const, isPreview: false, isPinned: false },
+          { path: '/page2.html', name: 'page2.html', isDirty: false, type: 'html' as const, isPreview: false, isPinned: false },
+        ],
+        activeTab: '/page1.html',
+        onSelect: () => {},
+        onClose: () => {},
+      }
+      render(<HtmlTabContent tabBarProps={tabBarProps} fileSystem={fileSystem} activeTab="/page1.html" />)
+
+      const viewers = screen.getAllByTestId('html-viewer')
+      const srcdocs = viewers.map(v => v.getAttribute('srcdoc'))
+      expect(srcdocs).toContain('<h1>Page 1</h1>')
+      expect(srcdocs).toContain('<h2>Page 2</h2>')
+    })
+
+    it('should only render HTML tabs, not other tab types', () => {
+      const fileSystem = createMockFileSystem({
+        '/page.html': '<p>HTML content</p>',
+      })
+      const tabBarProps = {
+        tabs: [
+          { path: '/page.html', name: 'page.html', isDirty: false, type: 'html' as const, isPreview: false, isPinned: false },
+          { path: '/code.lua', name: 'code.lua', isDirty: false, type: 'file' as const, isPreview: false, isPinned: false },
+        ],
+        activeTab: '/page.html',
+        onSelect: () => {},
+        onClose: () => {},
+      }
+      render(<HtmlTabContent tabBarProps={tabBarProps} fileSystem={fileSystem} activeTab="/page.html" />)
+
+      const viewers = screen.getAllByTestId('html-viewer')
+      expect(viewers).toHaveLength(1)
+    })
+
+    it('should show active HTML tab with display contents and hide others off-screen', () => {
+      const fileSystem = createMockFileSystem({
+        '/page1.html': '<h1>Page 1</h1>',
+        '/page2.html': '<h2>Page 2</h2>',
+      })
+      const tabBarProps = {
+        tabs: [
+          { path: '/page1.html', name: 'page1.html', isDirty: false, type: 'html' as const, isPreview: false, isPinned: false },
+          { path: '/page2.html', name: 'page2.html', isDirty: false, type: 'html' as const, isPreview: false, isPinned: false },
+        ],
+        activeTab: '/page1.html',
+        onSelect: () => {},
+        onClose: () => {},
+      }
+      const { container } = render(<HtmlTabContent tabBarProps={tabBarProps} fileSystem={fileSystem} activeTab="/page1.html" />)
+
+      // The active tab wrapper should use display: contents
+      const wrappers = container.querySelectorAll('[data-html-tab-path]')
+      expect(wrappers).toHaveLength(2)
+
+      const activeWrapper = container.querySelector('[data-html-tab-path="/page1.html"]') as HTMLElement
+      const inactiveWrapper = container.querySelector('[data-html-tab-path="/page2.html"]') as HTMLElement
+
+      expect(activeWrapper.style.display).toBe('contents')
+      // Inactive wrapper should be positioned off-screen for iframe preservation
+      expect(inactiveWrapper.style.position).toBe('absolute')
+      expect(inactiveWrapper.style.width).toBe('0px')
+      expect(inactiveWrapper.style.height).toBe('0px')
+    })
+
+    it('should render empty content when file does not exist', () => {
+      const fileSystem = createMockFileSystem({})
+      const tabBarProps = {
+        tabs: [
+          { path: '/missing.html', name: 'missing.html', isDirty: false, type: 'html' as const, isPreview: false, isPinned: false },
+        ],
+        activeTab: '/missing.html',
+        onSelect: () => {},
+        onClose: () => {},
+      }
+      render(<HtmlTabContent tabBarProps={tabBarProps} fileSystem={fileSystem} activeTab="/missing.html" />)
+
+      const viewer = screen.getByTestId('html-viewer')
+      expect(viewer).toHaveAttribute('srcdoc', '')
+    })
   })
 })

--- a/lua-learning-website/src/components/IDELayout/HtmlTabContent.tsx
+++ b/lua-learning-website/src/components/IDELayout/HtmlTabContent.tsx
@@ -1,24 +1,62 @@
+import { useMemo } from 'react'
 import { HtmlViewer } from '../HtmlViewer'
 import { TabBar } from '../TabBar'
 import type { TabBarProps } from '../TabBar'
+import type { IFileSystem } from '@lua-learning/shell-core'
 import styles from './IDELayout.module.css'
 
 interface HtmlTabContentProps {
-  content: string
   tabBarProps?: TabBarProps
+  fileSystem: IFileSystem
+  activeTab: string | null
 }
 
 /**
- * Content displayed when an HTML preview tab is active.
- * Shows the TabBar and a sandboxed iframe with the HTML content.
+ * Off-screen style used to preserve iframe browsing context when an HTML tab is
+ * not actively visible. Using position:absolute with zero dimensions is preferred
+ * over display:none because display:none would destroy the iframe's browsing
+ * context, losing any navigation state the user had.
  */
-export function HtmlTabContent({ content, tabBarProps }: HtmlTabContentProps) {
+const offScreenStyle: React.CSSProperties = {
+  position: 'absolute',
+  width: 0,
+  height: 0,
+  overflow: 'hidden',
+  opacity: 0,
+  pointerEvents: 'none',
+}
+
+/**
+ * Content displayed when HTML preview tabs exist.
+ * Renders one HtmlViewer per HTML tab, applying the off-screen preservation
+ * pattern to inactive tabs so switching between them maintains iframe state.
+ */
+export function HtmlTabContent({ tabBarProps, fileSystem, activeTab }: HtmlTabContentProps) {
+  const htmlTabs = useMemo(
+    () => tabBarProps?.tabs.filter(t => t.type === 'html') ?? [],
+    [tabBarProps?.tabs],
+  )
+
   return (
     <div className={styles.previewContainer}>
       <div className={styles.toolbar}>
         {tabBarProps && <TabBar {...tabBarProps} />}
       </div>
-      <HtmlViewer content={content} className={styles.previewContent} />
+      {htmlTabs.map(tab => {
+        const isActive = tab.path === activeTab
+        const content = fileSystem.exists(tab.path)
+          ? fileSystem.readFile(tab.path)
+          : ''
+        return (
+          <div
+            key={tab.path}
+            data-html-tab-path={tab.path}
+            style={isActive ? { display: 'contents' } : offScreenStyle}
+          >
+            <HtmlViewer content={content} className={styles.previewContent} />
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/lua-learning-website/src/components/IDELayout/IDELayout.tsx
+++ b/lua-learning-website/src/components/IDELayout/IDELayout.tsx
@@ -168,7 +168,7 @@ function IDELayoutInner({
   // ANSI tab management
   const hasAnsiTabs = tabs.some(t => t.type === 'ansi')
   const hasAnsiEditorTabs = tabs.some(t => t.type === 'ansi-editor')
-  const htmlTabPath = tabs.find(t => t.type === 'html')?.path ?? null
+  const hasHtmlTabs = tabs.some(t => t.type === 'html')
 
   // ANSI tab request management (ansiId -> resolver for terminal handle)
   const pendingAnsiRequestsRef = useRef<Map<string, (handle: AnsiTerminalHandle) => void>>(new Map())
@@ -904,19 +904,16 @@ function IDELayoutInner({
                           onOpenMarkdown={openMarkdownPreview}
                         />
                       )}
-                      {/* HTML preview - positioned off-screen when hidden to preserve iframe browsing context */}
-                      {htmlTabPath && (
+                      {/* HTML preview - always mounted when html tabs exist to preserve iframe browsing context */}
+                      {hasHtmlTabs && (
                         <div style={activeTabType === 'html'
                           ? { display: 'contents' }
                           : { position: 'absolute', width: 0, height: 0, overflow: 'hidden', opacity: 0, pointerEvents: 'none' as const }
                         }>
                           <HtmlTabContent
-                            content={
-                              compositeFileSystem.exists(htmlTabPath)
-                                ? compositeFileSystem.readFile(htmlTabPath)
-                                : ''
-                            }
                             tabBarProps={tabBarProps}
+                            fileSystem={compositeFileSystem}
+                            activeTab={activeTab}
                           />
                         </div>
                       )}


### PR DESCRIPTION
## Summary
- Replace `tabs.find(t => t.type === 'html')` with `tabs.some(t => t.type === 'html')` in IDELayout to detect all HTML tabs
- Refactor `HtmlTabContent` to accept `fileSystem` + `activeTab` props and render one `HtmlViewer` per HTML tab
- Apply off-screen preservation pattern (`position: absolute; width: 0; height: 0`) to inactive HTML tabs to preserve iframe browsing context
- Add 5 new tests for multi-tab rendering behavior

## Test plan
- [x] All 52 IDELayout directory tests pass (8 HtmlTabContent tests: 3 updated + 5 new)
- [x] TypeScript type-check passes
- [ ] Manual test: open multiple HTML files, verify each renders independently
- [ ] CI passes

Resolves #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)