### PR TITLE
fix: skip instruction counting during load_screen

### DIFF
--- a/packages/lua-runtime/src/ansiLuaCode/core.ts
+++ b/packages/lua-runtime/src/ansiLuaCode/core.ts
@@ -184,7 +184,22 @@ export const ansiLuaCoreCode = `
       if not fn then
         error("Failed to parse ANSI file '" .. path .. "': " .. tostring(err))
       end
+
+      -- Suspend instruction counting during file execution
+      local has_exec_control = type(__loading_depth) == 'number'
+      if has_exec_control then
+        __loading_depth = __loading_depth + 1
+      end
+
       local ok, data = pcall(fn)
+
+      if has_exec_control and __loading_depth > 0 then
+        __loading_depth = __loading_depth - 1
+        if __loading_depth == 0 then
+          __reset_instruction_count()
+        end
+      end
+
       if not ok then
         error("Failed to execute ANSI file '" .. path .. "': " .. tostring(data))
       end

--- a/packages/lua-runtime/src/lua/executionControl.ts
+++ b/packages/lua-runtime/src/lua/executionControl.ts
@@ -15,6 +15,7 @@ __line_count = 0
 __instruction_limit = ${lineLimit}
 __check_interval = ${checkInterval}
 __lines_since_check = 0
+__loading_depth = 0
 
 function __request_stop()
     __stop_requested = true
@@ -32,6 +33,20 @@ end
 
 -- Hook function that counts lines and checks for stop conditions
 function __execution_hook()
+    -- During file loading, skip instruction counting but still check stop requests
+    if __loading_depth > 0 then
+        __lines_since_check = __lines_since_check + 1
+        if __lines_since_check >= __check_interval then
+            __lines_since_check = 0
+            if __stop_requested then
+                __stop_requested = false
+                __loading_depth = 0
+                error("Execution stopped by user", 0)
+            end
+        end
+        return
+    end
+
     __line_count = __line_count + 1
     __lines_since_check = __lines_since_check + 1
 


### PR DESCRIPTION
## Summary
- Add `__loading_depth` counter to execution control infrastructure that suspends instruction counting during `ansi.load_screen()` file execution
- Large ANSI art files with thousands of grid cells no longer trigger the false-positive "Script has been running for a while" dialog
- User stop requests are still honored during file loading via periodic `__stop_requested` checks

## Test plan
- [x] Unit test: `load_screen` with low instruction limit does not trigger limit callback
- [x] Unit test: instruction count resets after `load_screen` completes
- [x] Unit test: stop requests still halt execution during `load_screen`
- [x] Unit test: `__loading_depth` does not leak on `load_screen` error
- [x] All 1360 lua-runtime tests pass
- [x] All 15 existing `loadScreen` tests pass (bare engine without execution control)
- [x] Build succeeds, type-check passes

Closes #654

🤖 Generated with [Claude Code](https://claude.com/claude-code)