### PR TITLE
docs: enforce worktree-only development in Project Rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
 # Project Rules
 
 - NEVER use `cd` in Bash commands. Always use absolute paths or `--prefix`. The working directory must remain at the repo root to keep hook paths working.
+- NEVER edit code or make changes directly in the root repository (main worktree). ALL implementation work MUST happen in an isolated worktree. Use `/issue <n> begin` (which auto-creates a worktree after plan approval) or `/worktree create <n>` to create one. If you find yourself on the `main` branch and about to edit files, STOP and create a worktree first. The only exceptions are editing CLAUDE.md, docs/, and .claude/ configuration files.
 
 ## Project Overview
 


### PR DESCRIPTION
## Summary
- Adds a hard enforcement rule to the `# Project Rules` section of CLAUDE.md requiring all implementation work to happen in isolated worktrees
- Prevents agents from editing code directly in the root repository (main worktree)
- Carves out exceptions for CLAUDE.md, docs/, and .claude/ configuration files

## Test plan
- [ ] Verify the rule appears at the top of CLAUDE.md in `# Project Rules`
- [ ] Verify new agent sessions see and follow the worktree requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)