### PR TITLE
fix: spacebar stops working after ANSI Terminal/Editor closes

### DIFF
--- a/lua-learning-website/src/components/AnsiGraphicsEditor/useAnsiEditor.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/useAnsiEditor.ts
@@ -701,6 +701,13 @@ export function useAnsiEditor(options?: UseAnsiEditorOptions): UseAnsiEditorRetu
     cleanupRef.current = attachMouseListeners(handle as HTMLElement)
   }, [attachMouseListeners])
 
+  // Ensure document-level listeners (keydown, mouseup) are removed on unmount.
+  // cleanupRef may be set by the effect above OR by onTerminalReady.
+  useEffect(() => () => {
+    cleanupRef.current?.()
+    cleanupRef.current = null
+  }, [])
+
   const setActiveLayerWithBounds = useCallback((id: string) => {
     commitPendingTextRef.current?.()
     const prevLayer = layersRef.current.find(l => l.id === activeLayerIdRef.current)

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/useAnsiEditorLifecycle.test.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/useAnsiEditorLifecycle.test.ts
@@ -21,6 +21,56 @@ describe('useAnsiEditor lifecycle', () => {
     })
   })
 
+  describe('document keydown listener cleanup on unmount', () => {
+    it('should remove the document keydown listener when unmounted after onTerminalReady', () => {
+      const removeEventListenerSpy = vi.spyOn(document, 'removeEventListener')
+      const { result, unmount } = renderHook(() => useAnsiEditor())
+
+      // Simulate terminal becoming ready with a mock container
+      const mockContainer = document.createElement('div')
+      act(() => {
+        result.current.onTerminalReady({
+          write: vi.fn(),
+          container: mockContainer,
+          dispose: vi.fn(),
+        })
+      })
+
+      removeEventListenerSpy.mockClear()
+      unmount()
+
+      const keydownRemovals = removeEventListenerSpy.mock.calls
+        .filter(([event]) => event === 'keydown')
+      expect(keydownRemovals.length).toBeGreaterThanOrEqual(1)
+
+      removeEventListenerSpy.mockRestore()
+    })
+
+    it('should not call preventDefault on spacebar after unmount', () => {
+      const { result, unmount } = renderHook(() => useAnsiEditor())
+
+      const mockContainer = document.createElement('div')
+      act(() => {
+        result.current.onTerminalReady({
+          write: vi.fn(),
+          container: mockContainer,
+          dispose: vi.fn(),
+        })
+      })
+
+      unmount()
+
+      const spaceEvent = new KeyboardEvent('keydown', {
+        key: ' ',
+        bubbles: true,
+        cancelable: true,
+      })
+      document.dispatchEvent(spaceEvent)
+
+      expect(spaceEvent.defaultPrevented).toBe(false)
+    })
+  })
+
   describe('importPngAsLayer error handling', () => {
     it('should show toast when PNG import fails', async () => {
       const { loadPngPixels } = await import('./pngImport')

--- a/lua-learning-website/src/components/AnsiTerminalPanel/AnsiTerminalPanel.test.tsx
+++ b/lua-learning-website/src/components/AnsiTerminalPanel/AnsiTerminalPanel.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, act } from '@testing-library/react'
+import { AnsiTerminalPanel } from './AnsiTerminalPanel'
+
+// Mock xterm modules — Terminal must be a class so `new Terminal()` works
+vi.mock('@xterm/xterm', () => {
+  class MockTerminal {
+    options = { fontSize: 16 }
+    open = vi.fn()
+    loadAddon = vi.fn()
+    attachCustomKeyEventHandler = vi.fn()
+    write = vi.fn()
+    dispose = vi.fn()
+  }
+  return { Terminal: MockTerminal }
+})
+
+vi.mock('@xterm/addon-canvas', () => {
+  class MockCanvasAddon {}
+  return { CanvasAddon: MockCanvasAddon }
+})
+
+// Mock CSS module
+vi.mock('./AnsiTerminalPanel.module.css', () => ({
+  default: { container: 'container', terminalWrapper: 'terminalWrapper' },
+}))
+
+beforeEach(() => {
+  // Provide FontFaceSet.load mock since jsdom lacks it
+  Object.defineProperty(document, 'fonts', {
+    value: { load: vi.fn().mockResolvedValue([]) },
+    configurable: true,
+  })
+})
+
+describe('AnsiTerminalPanel', () => {
+  it('should call onTerminalReady(null) on unmount', async () => {
+    const onTerminalReady = vi.fn()
+
+    const { unmount } = render(
+      <AnsiTerminalPanel onTerminalReady={onTerminalReady} />
+    )
+
+    // Wait for the async init() to complete (font load + terminal setup)
+    await act(async () => {
+      // Flush microtask queue
+    })
+
+    // Should have been called with a handle on mount
+    expect(onTerminalReady).toHaveBeenCalledWith(
+      expect.objectContaining({ write: expect.any(Function) })
+    )
+
+    onTerminalReady.mockClear()
+
+    unmount()
+
+    expect(onTerminalReady).toHaveBeenCalledWith(null)
+  })
+})

--- a/lua-learning-website/src/components/AnsiTerminalPanel/AnsiTerminalPanel.tsx
+++ b/lua-learning-website/src/components/AnsiTerminalPanel/AnsiTerminalPanel.tsx
@@ -135,6 +135,7 @@ export function AnsiTerminalPanel({ isActive, scaleMode = 'fit', onTerminalReady
     return () => {
       disposed = true
       resizeObserver?.disconnect()
+      onTerminalReadyRef.current?.(null)
       if (terminalRef.current) {
         terminalRef.current.dispose()
         terminalRef.current = null


### PR DESCRIPTION
## Summary

- Fixed spacebar becoming unresponsive after the ANSI Editor/Terminal closes by ensuring the global `document` keydown listener is properly cleaned up on unmount
- Added `onTerminalReady(null)` call to `AnsiTerminalPanel` cleanup so the parent's imperative cleanup path is triggered on unmount
- Added a standalone `useEffect` unmount cleanup in `useAnsiEditor` that calls `cleanupRef` regardless of which code path (useEffect or onTerminalReady) originally attached the listeners

## Root Cause

Two cleanup gaps allowed the ANSI editor's global `document.addEventListener('keydown', ...)` to persist after unmount:

1. **`useAnsiEditor.ts`**: The useEffect re-attaching mouse/keyboard listeners had no cleanup return, and `onTerminalReady` set `cleanupRef` without any unmount guard
2. **`AnsiTerminalPanel.tsx`**: The cleanup function never called `onTerminalReady(null)`, so the parent never ran its imperative cleanup

## Test plan

- [x] New test: document keydown listener is removed on unmount after `onTerminalReady`
- [x] New test: spacebar `preventDefault()` is NOT called after unmount
- [x] New test: `AnsiTerminalPanel` calls `onTerminalReady(null)` on unmount
- [x] All 3985 existing tests pass
- [x] Type-check clean, lint clean (no new warnings)
- [x] Full build succeeds

Closes #698

🤖 Generated with [Claude Code](https://claude.com/claude-code)