### PR TITLE
refactor: deduplicate group/text layer parsing in parseV3to6

### DIFF
--- a/packages/lua-runtime/src/screenParser.ts
+++ b/packages/lua-runtime/src/screenParser.ts
@@ -139,41 +139,8 @@ function parseV2(data: Record<string, unknown>): LayerData[] {
 function parseV3to6(data: Record<string, unknown>): LayerData[] {
   const rawLayers = luaArrayToJsArray<RawLayer>(data.layers)
   return rawLayers.map((l): LayerData => {
-    if (l.type === 'group') {
-      const group: GroupLayerData = {
-        type: 'group',
-        id: l.id,
-        name: l.name,
-        visible: l.visible,
-        collapsed: l.collapsed ?? false,
-        parentId: l.parentId,
-        tags: parseTags(l.tags),
-      }
-      return group
-    }
-
-    if (l.type === 'text') {
-      const bounds = normalizeRect(l.bounds)
-      const textFg = normalizeRgb(l.textFg)
-      const textFgColors = normalizeRgbArray(l.textFgColors)
-      const textAlign = l.textAlign as TextAlign | undefined
-      const grid = renderTextLayerGrid(l.text ?? '', bounds, textFg, textFgColors, textAlign)
-      const textLayer: TextLayerData = {
-        type: 'text',
-        id: l.id,
-        name: l.name,
-        visible: l.visible,
-        text: l.text ?? '',
-        bounds,
-        textFg,
-        textFgColors,
-        textAlign,
-        grid,
-        parentId: l.parentId,
-        tags: parseTags(l.tags),
-      }
-      return textLayer
-    }
+    if (l.type === 'group') return parseGroupLayerData(l)
+    if (l.type === 'text') return parseTextLayerData(l)
 
     // Drawn layer (default for v3 where type may be unset)
     const rawFrames = l.frames ? luaArrayToJsArray<unknown>(l.frames) : null


### PR DESCRIPTION
## Summary
- Replace 35 lines of inline group/text layer construction in `parseV3to6()` with 2 calls to existing `parseGroupLayerData()` and `parseTextLayerData()` helpers
- These helpers were already used by `parseV7()` — the inline code was character-for-character identical
- Net change: +2/-35 lines

## Test plan
- [x] All 27 existing `screenParser.test.ts` tests pass unchanged
- [x] TypeScript type-check passes
- [x] Package builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>