### PR TITLE
fix: harden v7 codec with palette bounds checking

### DIFF
--- a/lua-learning-website/src/components/AnsiGraphicsEditor/serialization.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/serialization.ts
@@ -81,12 +81,12 @@ export function serializeLayers(state: LayerState, availableTags?: string[]): st
     }
     if (layer.frames.length > 1) {
       serialized.frameCells = layer.frames.map(frame =>
-        encodeGrid(frame, colorToIndex, defaultFgIndex, defaultBgIndex)
+        encodeGrid(frame, colorToIndex)
       )
       serialized.currentFrameIndex = layer.currentFrameIndex
       serialized.frameDurationMs = layer.frameDurationMs
     } else {
-      serialized.cells = encodeGrid(layer.grid, colorToIndex, defaultFgIndex, defaultBgIndex)
+      serialized.cells = encodeGrid(layer.grid, colorToIndex)
     }
     addOptionalFields(serialized, layer)
     return serialized

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/v7Codec.test.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/v7Codec.test.ts
@@ -84,8 +84,8 @@ describe('buildPalette', () => {
 
 describe('encodeGrid', () => {
   function encode(grid: AnsiGrid): Run[] {
-    const { colorToIndex, defaultFgIndex, defaultBgIndex } = buildPalette([grid])
-    return encodeGrid(grid, colorToIndex, defaultFgIndex, defaultBgIndex)
+    const { colorToIndex } = buildPalette([grid])
+    return encodeGrid(grid, colorToIndex)
   }
 
   it('empty default grid produces empty runs', () => {
@@ -268,12 +268,84 @@ describe('decodeGrid', () => {
     expect(grid[4][1].char).toBe('*')
     expect(grid[4][2].char).toBe('*')
   })
+
+  it('throws on out-of-range defaultFgIndex (0)', () => {
+    expect(() => decodeGrid([], palette, 0, 2)).toThrow('defaultFgIndex')
+  })
+
+  it('throws on out-of-range defaultFgIndex (exceeds palette length)', () => {
+    expect(() => decodeGrid([], palette, palette.length + 1, 2)).toThrow('defaultFgIndex')
+  })
+
+  it('throws on out-of-range defaultBgIndex (0)', () => {
+    expect(() => decodeGrid([], palette, 1, 0)).toThrow('defaultBgIndex')
+  })
+
+  it('throws on out-of-range defaultBgIndex (exceeds palette length)', () => {
+    expect(() => decodeGrid([], palette, 1, palette.length + 1)).toThrow('defaultBgIndex')
+  })
+
+  it('throws on negative defaultFgIndex', () => {
+    expect(() => decodeGrid([], palette, -1, 2)).toThrow('defaultFgIndex')
+  })
+
+  it('throws on negative defaultBgIndex', () => {
+    expect(() => decodeGrid([], palette, 1, -1)).toThrow('defaultBgIndex')
+  })
+
+  it('skips runs with out-of-range fgIdx in single cell run', () => {
+    // fgIdx 99 is way beyond palette length
+    const runs: Run[] = [[1, 1, '#', 99, 2]]
+    const grid = decodeGrid(runs, palette, 1, 2)
+    // Cell should remain default because the run was skipped
+    expect(grid[0][0]).toEqual({ char: ' ', fg: [...DEFAULT_FG], bg: [...DEFAULT_BG] })
+  })
+
+  it('skips runs with out-of-range bgIdx in single cell run', () => {
+    const runs: Run[] = [[1, 1, '#', 3, 99]]
+    const grid = decodeGrid(runs, palette, 1, 2)
+    expect(grid[0][0]).toEqual({ char: ' ', fg: [...DEFAULT_FG], bg: [...DEFAULT_BG] })
+  })
+
+  it('skips runs with out-of-range fgIdx in repeat run', () => {
+    const runs: Run[] = [[1, 1, 3, '#', 99, 2]]
+    const grid = decodeGrid(runs, palette, 1, 2)
+    // All cells should remain default
+    expect(grid[0][0]).toEqual({ char: ' ', fg: [...DEFAULT_FG], bg: [...DEFAULT_BG] })
+    expect(grid[0][1]).toEqual({ char: ' ', fg: [...DEFAULT_FG], bg: [...DEFAULT_BG] })
+    expect(grid[0][2]).toEqual({ char: ' ', fg: [...DEFAULT_FG], bg: [...DEFAULT_BG] })
+  })
+
+  it('skips runs with out-of-range bgIdx in repeat run', () => {
+    const runs: Run[] = [[1, 1, 3, '#', 3, 99]]
+    const grid = decodeGrid(runs, palette, 1, 2)
+    expect(grid[0][0]).toEqual({ char: ' ', fg: [...DEFAULT_FG], bg: [...DEFAULT_BG] })
+  })
+
+  it('skips runs with out-of-range fgIdx in text run', () => {
+    const runs: Run[] = [[1, 1, 'Hi', 99, 2]]
+    const grid = decodeGrid(runs, palette, 1, 2)
+    expect(grid[0][0]).toEqual({ char: ' ', fg: [...DEFAULT_FG], bg: [...DEFAULT_BG] })
+    expect(grid[0][1]).toEqual({ char: ' ', fg: [...DEFAULT_FG], bg: [...DEFAULT_BG] })
+  })
+
+  it('skips runs with zero fgIdx', () => {
+    const runs: Run[] = [[1, 1, '#', 0, 2]]
+    const grid = decodeGrid(runs, palette, 1, 2)
+    expect(grid[0][0]).toEqual({ char: ' ', fg: [...DEFAULT_FG], bg: [...DEFAULT_BG] })
+  })
+
+  it('skips runs with zero bgIdx', () => {
+    const runs: Run[] = [[1, 1, '#', 3, 0]]
+    const grid = decodeGrid(runs, palette, 1, 2)
+    expect(grid[0][0]).toEqual({ char: ' ', fg: [...DEFAULT_FG], bg: [...DEFAULT_BG] })
+  })
 })
 
 describe('round-trip encode/decode', () => {
   function roundTrip(grid: AnsiGrid): AnsiGrid {
     const { palette, colorToIndex, defaultFgIndex, defaultBgIndex } = buildPalette([grid])
-    const runs = encodeGrid(grid, colorToIndex, defaultFgIndex, defaultBgIndex)
+    const runs = encodeGrid(grid, colorToIndex)
     return decodeGrid(runs, palette, defaultFgIndex, defaultBgIndex)
   }
 

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/v7Codec.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/v7Codec.ts
@@ -80,13 +80,7 @@ export type Run = Run5 | Run6
 export function encodeGrid(
   grid: AnsiGrid,
   colorToIndex: Map<string, number>,
-  defaultFgIndex: number,
-  defaultBgIndex: number,
 ): Run[] {
-  // defaultFgIndex/defaultBgIndex reserved for potential future optimizations
-  void defaultFgIndex
-  void defaultBgIndex
-
   const runs: Run[] = []
 
   for (let r = 0; r < grid.length; r++) {
@@ -150,6 +144,11 @@ export function encodeGrid(
   return runs
 }
 
+/** Check that a 1-based palette index is within bounds. */
+function isValidPaletteIndex(idx: number, palette: RGBColor[]): boolean {
+  return idx >= 1 && idx <= palette.length
+}
+
 /**
  * Decode sparse run-encoded tuples back into a full ANSI_ROWS x ANSI_COLS grid.
  * Empty runs array = fully default grid.
@@ -160,6 +159,13 @@ export function decodeGrid(
   defaultFgIndex: number,
   defaultBgIndex: number,
 ): AnsiGrid {
+  if (!isValidPaletteIndex(defaultFgIndex, palette)) {
+    throw new RangeError(`defaultFgIndex ${defaultFgIndex} out of palette bounds [1..${palette.length}]`)
+  }
+  if (!isValidPaletteIndex(defaultBgIndex, palette)) {
+    throw new RangeError(`defaultBgIndex ${defaultBgIndex} out of palette bounds [1..${palette.length}]`)
+  }
+
   const defaultFg = palette[defaultFgIndex - 1]
   const defaultBg = palette[defaultBgIndex - 1]
 
@@ -178,6 +184,7 @@ export function decodeGrid(
     if (run.length === 6) {
       // Repeat run: [row, col, count, char, fgIdx, bgIdx]
       const [row, col, count, char, fgIdx, bgIdx] = run
+      if (!isValidPaletteIndex(fgIdx, palette) || !isValidPaletteIndex(bgIdx, palette)) continue
       const fg = palette[fgIdx - 1]
       const bg = palette[bgIdx - 1]
       for (let i = 0; i < count; i++) {
@@ -189,6 +196,7 @@ export function decodeGrid(
     } else {
       // Single cell or text run: [row, col, charOrText, fgIdx, bgIdx]
       const [row, col, charOrText, fgIdx, bgIdx] = run
+      if (!isValidPaletteIndex(fgIdx, palette) || !isValidPaletteIndex(bgIdx, palette)) continue
       const fg = palette[fgIdx - 1]
       const bg = palette[bgIdx - 1]
 

--- a/packages/lua-runtime/src/v7Decode.ts
+++ b/packages/lua-runtime/src/v7Decode.ts
@@ -28,11 +28,16 @@ function makeDefaultGrid(fg: RGBColor, bg: RGBColor): AnsiGrid {
   )
 }
 
+/** Check that a 1-based palette index is within bounds. */
+function isValidPaletteIndex(idx: number, palette: RGBColor[]): boolean {
+  return idx >= 1 && idx <= palette.length
+}
+
 /** Write a cell into the grid if within bounds (1-based row/col). */
 function setCell(grid: AnsiGrid, row1: number, col1: number, char: string, fg: RGBColor, bg: RGBColor): void {
   const r = row1 - 1
   const c = col1 - 1
-  if (r < ANSI_ROWS && c >= 0 && c < ANSI_COLS) {
+  if (r >= 0 && r < ANSI_ROWS && c >= 0 && c < ANSI_COLS) {
     grid[r][c] = { char, fg: [...fg] as RGBColor, bg: [...bg] as RGBColor }
   }
 }
@@ -51,6 +56,13 @@ export function decodeV7Grid(
   defaultFgIndex: number,
   defaultBgIndex: number,
 ): AnsiGrid {
+  if (!isValidPaletteIndex(defaultFgIndex, palette)) {
+    throw new RangeError(`defaultFgIndex ${defaultFgIndex} out of palette bounds [1..${palette.length}]`)
+  }
+  if (!isValidPaletteIndex(defaultBgIndex, palette)) {
+    throw new RangeError(`defaultBgIndex ${defaultBgIndex} out of palette bounds [1..${palette.length}]`)
+  }
+
   const grid = makeDefaultGrid(palette[defaultFgIndex - 1], palette[defaultBgIndex - 1])
 
   const runs = luaArrayToJsArray<unknown>(rawRuns)
@@ -63,18 +75,24 @@ export function decodeV7Grid(
 
     if (el.length === 6) {
       // Repeat run: [row, col, count, char, fgIdx, bgIdx]
+      const fgIdx = Number(el[4])
+      const bgIdx = Number(el[5])
+      if (!isValidPaletteIndex(fgIdx, palette) || !isValidPaletteIndex(bgIdx, palette)) continue
       const count = Number(el[2])
       const char = String(el[3])
-      const fg = palette[Number(el[4]) - 1]
-      const bg = palette[Number(el[5]) - 1]
+      const fg = palette[fgIdx - 1]
+      const bg = palette[bgIdx - 1]
       for (let i = 0; i < count; i++) {
         setCell(grid, row, col + i, char, fg, bg)
       }
     } else if (el.length === 5) {
       // Single cell or text run
+      const fgIdx = Number(el[3])
+      const bgIdx = Number(el[4])
+      if (!isValidPaletteIndex(fgIdx, palette) || !isValidPaletteIndex(bgIdx, palette)) continue
       const charOrText = String(el[2])
-      const fg = palette[Number(el[3]) - 1]
-      const bg = palette[Number(el[4]) - 1]
+      const fg = palette[fgIdx - 1]
+      const bg = palette[bgIdx - 1]
 
       if (charOrText.length > 1) {
         for (let i = 0; i < charOrText.length; i++) {

--- a/packages/lua-runtime/tests/v7Decode.test.ts
+++ b/packages/lua-runtime/tests/v7Decode.test.ts
@@ -88,4 +88,81 @@ describe('decodeV7Grid', () => {
     expect(grid.length).toBe(ANSI_ROWS)
     expect(grid[0][0]).toEqual({ char: ' ', fg: [...DEFAULT_FG], bg: [...DEFAULT_BG] })
   })
+
+  it('throws on out-of-range defaultFgIndex (0)', () => {
+    expect(() => decodeV7Grid({}, palette, 0, 2)).toThrow('defaultFgIndex')
+  })
+
+  it('throws on out-of-range defaultFgIndex (exceeds palette length)', () => {
+    expect(() => decodeV7Grid({}, palette, palette.length + 1, 2)).toThrow('defaultFgIndex')
+  })
+
+  it('throws on out-of-range defaultBgIndex (0)', () => {
+    expect(() => decodeV7Grid({}, palette, 1, 0)).toThrow('defaultBgIndex')
+  })
+
+  it('throws on out-of-range defaultBgIndex (exceeds palette length)', () => {
+    expect(() => decodeV7Grid({}, palette, 1, palette.length + 1)).toThrow('defaultBgIndex')
+  })
+
+  it('throws on negative defaultFgIndex', () => {
+    expect(() => decodeV7Grid({}, palette, -1, 2)).toThrow('defaultFgIndex')
+  })
+
+  it('throws on negative defaultBgIndex', () => {
+    expect(() => decodeV7Grid({}, palette, 1, -1)).toThrow('defaultBgIndex')
+  })
+
+  it('skips runs with out-of-range fgIdx in single cell run', () => {
+    const rawRuns = { 1: { 1: 1, 2: 1, 3: '#', 4: 99, 5: 2 } }
+    const grid = decodeV7Grid(rawRuns, palette, 1, 2)
+    expect(grid[0][0]).toEqual({ char: ' ', fg: [...DEFAULT_FG], bg: [...DEFAULT_BG] })
+  })
+
+  it('skips runs with out-of-range bgIdx in single cell run', () => {
+    const rawRuns = { 1: { 1: 1, 2: 1, 3: '#', 4: 3, 5: 99 } }
+    const grid = decodeV7Grid(rawRuns, palette, 1, 2)
+    expect(grid[0][0]).toEqual({ char: ' ', fg: [...DEFAULT_FG], bg: [...DEFAULT_BG] })
+  })
+
+  it('skips runs with out-of-range fgIdx in repeat run', () => {
+    const rawRuns = { 1: { 1: 1, 2: 1, 3: 3, 4: '#', 5: 99, 6: 2 } }
+    const grid = decodeV7Grid(rawRuns, palette, 1, 2)
+    expect(grid[0][0]).toEqual({ char: ' ', fg: [...DEFAULT_FG], bg: [...DEFAULT_BG] })
+    expect(grid[0][1]).toEqual({ char: ' ', fg: [...DEFAULT_FG], bg: [...DEFAULT_BG] })
+    expect(grid[0][2]).toEqual({ char: ' ', fg: [...DEFAULT_FG], bg: [...DEFAULT_BG] })
+  })
+
+  it('skips runs with out-of-range bgIdx in repeat run', () => {
+    const rawRuns = { 1: { 1: 1, 2: 1, 3: 3, 4: '#', 5: 3, 6: 99 } }
+    const grid = decodeV7Grid(rawRuns, palette, 1, 2)
+    expect(grid[0][0]).toEqual({ char: ' ', fg: [...DEFAULT_FG], bg: [...DEFAULT_BG] })
+  })
+
+  it('skips runs with out-of-range fgIdx in text run', () => {
+    const rawRuns = { 1: { 1: 1, 2: 1, 3: 'Hi', 4: 99, 5: 2 } }
+    const grid = decodeV7Grid(rawRuns, palette, 1, 2)
+    expect(grid[0][0]).toEqual({ char: ' ', fg: [...DEFAULT_FG], bg: [...DEFAULT_BG] })
+    expect(grid[0][1]).toEqual({ char: ' ', fg: [...DEFAULT_FG], bg: [...DEFAULT_BG] })
+  })
+
+  it('skips runs with zero fgIdx', () => {
+    const rawRuns = { 1: { 1: 1, 2: 1, 3: '#', 4: 0, 5: 2 } }
+    const grid = decodeV7Grid(rawRuns, palette, 1, 2)
+    expect(grid[0][0]).toEqual({ char: ' ', fg: [...DEFAULT_FG], bg: [...DEFAULT_BG] })
+  })
+
+  it('skips runs with zero bgIdx', () => {
+    const rawRuns = { 1: { 1: 1, 2: 1, 3: '#', 4: 3, 5: 0 } }
+    const grid = decodeV7Grid(rawRuns, palette, 1, 2)
+    expect(grid[0][0]).toEqual({ char: ' ', fg: [...DEFAULT_FG], bg: [...DEFAULT_BG] })
+  })
+
+  it('setCell rejects row=0 (1-based row below minimum)', () => {
+    // row=0 means row1-1 = -1, which should be out of bounds
+    const rawRuns = { 1: { 1: 0, 2: 1, 3: '#', 4: 3, 5: 4 } }
+    const grid = decodeV7Grid(rawRuns, palette, 1, 2)
+    // All cells should remain default — no crash, no out-of-bounds write
+    expect(grid[0][0]).toEqual({ char: ' ', fg: [...DEFAULT_FG], bg: [...DEFAULT_BG] })
+  })
 })


### PR DESCRIPTION
## Summary
- Remove unused `defaultFgIndex`/`defaultBgIndex` params from `encodeGrid()` and update call sites
- Add palette bounds checking in `decodeGrid()` and `decodeV7Grid()` (throw `RangeError` for bad defaults, skip invalid per-run indices)
- Fix `setCell()` bounds check: add missing `r >= 0` guard (row=0 produced `grid[-1]` access)
- 27 new tests covering all bounds-check paths

## Test plan
- [x] 13 new tests in `v7Codec.test.ts` (43 total, all pass)
- [x] 14 new tests in `v7Decode.test.ts` (24 total, all pass)
- [x] All existing serialization tests pass (58 tests)
- [x] TypeScript type-check passes
- [x] Full build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>