### PR TITLE
refactor: extract shared helpers to deduplicate deserialization

### DIFF
--- a/lua-learning-website/src/components/AnsiGraphicsEditor/serialization.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/serialization.ts
@@ -129,6 +129,76 @@ interface RawLayer {
   tags?: string[]
 }
 
+/* ------------------------------------------------------------------ */
+/*  Private helpers shared by v3-v6 and v7 deserialization blocks      */
+/* ------------------------------------------------------------------ */
+
+const VALID_LAYER_TYPES = new Set(['drawn', 'text', 'group'])
+
+/** Validate that a raw layer has the required base fields and a known type. */
+function validateRawLayer(l: RawLayer, i: number): void {
+  if (!l.id || !l.name || l.visible === undefined) {
+    throw new Error(`Invalid layer at index ${i}: missing required fields (id, name, visible)`)
+  }
+  if (l.type !== undefined && !VALID_LAYER_TYPES.has(l.type)) {
+    throw new Error(`Invalid layer at index ${i}: unknown layer type "${l.type}"`)
+  }
+}
+
+/** Build a GroupLayer from a validated raw layer. */
+function buildGroupLayer(l: RawLayer, tags: string[] | undefined): GroupLayer {
+  return {
+    type: 'group',
+    id: l.id,
+    name: l.name,
+    visible: l.visible,
+    collapsed: l.collapsed ?? false,
+    parentId: l.parentId,
+    tags,
+  }
+}
+
+/** Build a TextLayer from a validated raw layer (includes text-field validation). */
+function buildTextLayer(l: RawLayer, tags: string[] | undefined): TextLayer {
+  if (!l.text || !l.bounds || !l.textFg) {
+    throw new Error(`Invalid text layer "${l.name}": missing text, bounds, or textFg`)
+  }
+  const textFgColors = l.textFgColors && l.textFgColors.length > 0 ? l.textFgColors : undefined
+  const textAlign = l.textAlign as TextAlign | undefined
+  return {
+    type: 'text',
+    id: l.id,
+    name: l.name,
+    visible: l.visible,
+    text: l.text,
+    bounds: l.bounds,
+    textFg: l.textFg,
+    textFgColors,
+    textAlign,
+    grid: renderTextLayerGrid(l.text, l.bounds, l.textFg, textFgColors, textAlign),
+    parentId: l.parentId,
+    tags,
+  }
+}
+
+/** Build a DrawnLayer from a validated raw layer and pre-loaded frames. */
+function buildDrawnLayer(l: RawLayer, frames: AnsiGrid[], tags: string[] | undefined): Layer {
+  const currentFrameIndex = l.currentFrameIndex ?? 0
+  const grid = frames[currentFrameIndex]
+  return {
+    type: 'drawn' as const,
+    id: l.id,
+    name: l.name,
+    visible: l.visible,
+    grid,
+    frames,
+    currentFrameIndex,
+    frameDurationMs: l.frameDurationMs ?? DEFAULT_FRAME_DURATION_MS,
+    parentId: l.parentId,
+    tags,
+  }
+}
+
 export function deserializeLayers(lua: string): LayerState {
   const stripped = lua.replace(/^return\s+/, '')
   const data = parse(stripped) as Record<string, unknown>
@@ -169,69 +239,19 @@ export function deserializeLayers(lua: string): LayerState {
   }
 
   if (version === 3 || version === 4 || version === 5 || version === 6) {
-    const VALID_LAYER_TYPES = new Set(['drawn', 'text', 'group'])
     const rawLayers = data.layers as RawLayer[]
     const rawAvailableTags = data.availableTags as string[] | undefined
     const layers: Layer[] = rawLayers.map((l, i) => {
-      if (!l.id || !l.name || l.visible === undefined) {
-        throw new Error(`Invalid layer at index ${i}: missing required fields (id, name, visible)`)
-      }
-      if (l.type !== undefined && !VALID_LAYER_TYPES.has(l.type)) {
-        throw new Error(`Invalid layer at index ${i}: unknown layer type "${l.type}"`)
-      }
+      validateRawLayer(l, i)
       const tags = l.tags && l.tags.length > 0 ? l.tags : undefined
-      if (l.type === 'group') {
-        const groupLayer: GroupLayer = {
-          type: 'group',
-          id: l.id,
-          name: l.name,
-          visible: l.visible,
-          collapsed: l.collapsed ?? false,
-          parentId: l.parentId,
-          tags,
-        }
-        return groupLayer
-      }
-      if (l.type === 'text') {
-        if (!l.text || !l.bounds || !l.textFg) {
-          throw new Error(`Invalid text layer "${l.name}": missing text, bounds, or textFg`)
-        }
-        const textFgColors = l.textFgColors && l.textFgColors.length > 0 ? l.textFgColors : undefined
-        const textAlign = l.textAlign as TextAlign | undefined
-        const textLayer: TextLayer = {
-          type: 'text',
-          id: l.id,
-          name: l.name,
-          visible: l.visible,
-          text: l.text,
-          bounds: l.bounds,
-          textFg: l.textFg,
-          textFgColors,
-          textAlign,
-          grid: renderTextLayerGrid(l.text, l.bounds, l.textFg, textFgColors, textAlign),
-          parentId: l.parentId,
-          tags,
-        }
-        return textLayer
-      }
+      if (l.type === 'group') return buildGroupLayer(l, tags)
+      if (l.type === 'text') return buildTextLayer(l, tags)
+      // Drawn layer — raw grids (v3-v6)
       if (!l.grid && (!l.frames || l.frames.length === 0)) {
         throw new Error(`Invalid drawn layer "${l.name}": missing grid`)
       }
       const frames = l.frames && l.frames.length > 0 ? l.frames : [l.grid!]
-      const currentFrameIndex = l.currentFrameIndex ?? 0
-      const grid = frames[currentFrameIndex]
-      return {
-        type: 'drawn' as const,
-        id: l.id,
-        name: l.name,
-        visible: l.visible,
-        grid,
-        frames,
-        currentFrameIndex,
-        frameDurationMs: l.frameDurationMs ?? DEFAULT_FRAME_DURATION_MS,
-        parentId: l.parentId,
-        tags,
-      }
+      return buildDrawnLayer(l, frames, tags)
     })
     const result: LayerState = {
       layers,
@@ -247,49 +267,13 @@ export function deserializeLayers(lua: string): LayerState {
     const rawPalette = data.palette as RGBColor[]
     const defaultFgIndex = data.defaultFg as number
     const defaultBgIndex = data.defaultBg as number
-    const VALID_LAYER_TYPES = new Set(['drawn', 'text', 'group'])
     const rawLayers = data.layers as RawLayer[]
     const rawAvailableTags = data.availableTags as string[] | undefined
     const layers: Layer[] = rawLayers.map((l, i) => {
-      if (!l.id || !l.name || l.visible === undefined) {
-        throw new Error(`Invalid layer at index ${i}: missing required fields (id, name, visible)`)
-      }
-      if (l.type !== undefined && !VALID_LAYER_TYPES.has(l.type)) {
-        throw new Error(`Invalid layer at index ${i}: unknown layer type "${l.type}"`)
-      }
+      validateRawLayer(l, i)
       const tags = l.tags && l.tags.length > 0 ? l.tags : undefined
-      if (l.type === 'group') {
-        return {
-          type: 'group' as const,
-          id: l.id,
-          name: l.name,
-          visible: l.visible,
-          collapsed: l.collapsed ?? false,
-          parentId: l.parentId,
-          tags,
-        }
-      }
-      if (l.type === 'text') {
-        if (!l.text || !l.bounds || !l.textFg) {
-          throw new Error(`Invalid text layer "${l.name}": missing text, bounds, or textFg`)
-        }
-        const textFgColors = l.textFgColors && l.textFgColors.length > 0 ? l.textFgColors : undefined
-        const textAlign = l.textAlign as TextAlign | undefined
-        return {
-          type: 'text' as const,
-          id: l.id,
-          name: l.name,
-          visible: l.visible,
-          text: l.text,
-          bounds: l.bounds,
-          textFg: l.textFg,
-          textFgColors,
-          textAlign,
-          grid: renderTextLayerGrid(l.text, l.bounds, l.textFg, textFgColors, textAlign),
-          parentId: l.parentId,
-          tags,
-        }
-      }
+      if (l.type === 'group') return buildGroupLayer(l, tags)
+      if (l.type === 'text') return buildTextLayer(l, tags)
       // Drawn layer — decode v7 sparse grids
       let frames: AnsiGrid[]
       const frameCells = Array.isArray(l.frameCells) ? l.frameCells : null
@@ -303,20 +287,7 @@ export function deserializeLayers(lua: string): LayerState {
       } else {
         throw new Error(`Invalid drawn layer "${l.name}": missing cells or frameCells`)
       }
-      const currentFrameIndex = l.currentFrameIndex ?? 0
-      const grid = frames[currentFrameIndex]
-      return {
-        type: 'drawn' as const,
-        id: l.id,
-        name: l.name,
-        visible: l.visible,
-        grid,
-        frames,
-        currentFrameIndex,
-        frameDurationMs: l.frameDurationMs ?? DEFAULT_FRAME_DURATION_MS,
-        parentId: l.parentId,
-        tags,
-      }
+      return buildDrawnLayer(l, frames, tags)
     })
     const result: LayerState = {
       layers,


### PR DESCRIPTION
## Summary
- Extract 4 shared helpers from duplicated v3-v6 and v7 blocks in `deserializeLayers()`: `validateRawLayer()`, `buildGroupLayer()`, `buildTextLayer()`, `buildDrawnLayer()`
- Both version blocks now follow: validate → check type → dispatch to helper, with only grid-loading logic remaining version-specific
- Net change: +79/-108 lines (29 lines removed)

## Test plan
- [x] All 40 `serialization.test.ts` tests pass unchanged
- [x] All 18 `serialization.frames-tags.test.ts` tests pass unchanged
- [x] TypeScript type-check passes
- [x] Full build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>