### PR TITLE
fix: restore focus in exported ANSI and canvas projects

### DIFF
--- a/packages/export/src/AnsiHtmlGenerator.ts
+++ b/packages/export/src/AnsiHtmlGenerator.ts
@@ -181,6 +181,9 @@ export function generateAnsiHtml(
 
     async function startApp() {
       overlay.remove(); wrapper.style.display = 'block'; wrapper.focus();
+      // Restore focus when user clicks back into the page or alt-tabs back
+      wrapper.addEventListener('mousedown', () => wrapper.focus());
+      document.addEventListener('visibilitychange', () => { if (!document.hidden) wrapper.focus(); });
       // Create AudioContext synchronously in gesture handler (Issue #617)
       let preUnlockedAudioContext = null;
       try {

--- a/packages/export/src/HtmlGenerator.ts
+++ b/packages/export/src/HtmlGenerator.ts
@@ -496,6 +496,9 @@ export class HtmlGenerator {
 
       await initLua();
       gameCanvas.focus();
+      // Restore focus when user clicks back into the page or alt-tabs back
+      gameCanvas.addEventListener('mousedown', () => gameCanvas.focus());
+      document.addEventListener('visibilitychange', () => { if (!document.hidden) gameCanvas.focus(); });
     }
 
     // Wait for user interaction before starting


### PR DESCRIPTION
## Summary
- Exported ANSI and canvas projects lost keyboard/mouse input after alt-tab or click-outside because focus was only set once at startup
- Adds `mousedown` and `visibilitychange` event listeners to re-focus the terminal wrapper (ANSI) and game canvas (canvas) elements
- Mirrors the IDE's `AnsiTerminalPanel` focus restoration pattern

## Test plan
- [x] Export package tests pass (202/202)
- [x] Lint passes (0 errors)
- [x] E2E tests pass
- [ ] Manual: export an ANSI project, alt-tab away and back — keyboard input restored
- [ ] Manual: export a canvas project, click outside and back — mouse/keyboard input restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)