### PR TITLE
fix(ansi-editor): PNG import, ANS export, and move tool at project dims

### DIFF
--- a/lua-learning-website/src/components/AnsiGraphicsEditor/ansExport.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/ansExport.ts
@@ -156,7 +156,7 @@ export function gridToAnsBytes(grid: AnsiGrid): Uint8Array {
   return new Uint8Array(bytes)
 }
 
-export function buildSauceRecord(title: string, fileSize: number): Uint8Array {
+export function buildSauceRecord(title: string, fileSize: number, cols = 80, rows = 25): Uint8Array {
   const record = new Uint8Array(128)
   const view = new DataView(record.buffer)
 
@@ -189,10 +189,10 @@ export function buildSauceRecord(title: string, fileSize: number): Uint8Array {
   record[94] = 1
   // FileType = 1 (ANSi)
   record[95] = 1
-  // TInfo1 = 80 (width, LE 16-bit)
-  view.setUint16(96, 80, true)
-  // TInfo2 = 25 (height, LE 16-bit)
-  view.setUint16(98, 25, true)
+  // TInfo1 = width (LE 16-bit)
+  view.setUint16(96, cols, true)
+  // TInfo2 = height (LE 16-bit)
+  view.setUint16(98, rows, true)
   // TInfo3/4 = 0 (already zero)
   // Comments = 0 (already zero at offset 104)
   // TFlags = 0x01 (iCE colors)
@@ -206,7 +206,9 @@ export function buildSauceRecord(title: string, fileSize: number): Uint8Array {
 export function exportAnsFile(grid: AnsiGrid, title?: string): Uint8Array {
   const ansData = gridToAnsBytes(grid)
   const sauceTitle = title ?? 'untitled'
-  const sauce = buildSauceRecord(sauceTitle, ansData.byteLength)
+  const cols = grid[0]?.length ?? 80
+  const rows = grid.length ?? 25
+  const sauce = buildSauceRecord(sauceTitle, ansData.byteLength, cols, rows)
 
   const result = new Uint8Array(ansData.byteLength + 1 + 128)
   result.set(ansData, 0)

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/pngImport.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/pngImport.ts
@@ -1,10 +1,6 @@
 import type { AnsiGrid, RGBColor } from './types'
-import { ANSI_COLS, ANSI_ROWS, HALF_BLOCK, DEFAULT_CELL, TRANSPARENT_HALF } from './types'
+import { DEFAULT_ANSI_COLS, DEFAULT_ANSI_ROWS, HALF_BLOCK, DEFAULT_CELL, TRANSPARENT_HALF } from './types'
 import { rgbEqual } from './layerUtils'
-
-/** Maximum pixel dimensions of the canvas (80 wide x 50 tall). */
-const MAX_PX_W = ANSI_COLS
-const MAX_PX_H = ANSI_ROWS * 2
 
 export interface ScaledSize {
   width: number
@@ -32,17 +28,25 @@ export function computeScaledSize(
  * Each cell encodes two vertical pixels: fg = top pixel, bg = bottom pixel.
  * Pixels with alpha < 128 are treated as transparent (TRANSPARENT_HALF).
  * Cells where both halves are transparent become DEFAULT_CELL (transparent in layer system).
+ *
+ * `cols`/`rows` control the output grid size and pixel bounds. Defaults to 80×25.
  */
-export function rgbaToAnsiGrid(rgba: Uint8ClampedArray, width: number, height: number): AnsiGrid {
-  const grid: AnsiGrid = Array.from({ length: ANSI_ROWS }, () =>
-    Array.from({ length: ANSI_COLS }, () => ({ ...DEFAULT_CELL }))
+export function rgbaToAnsiGrid(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  cols: number = DEFAULT_ANSI_COLS,
+  rows: number = DEFAULT_ANSI_ROWS,
+): AnsiGrid {
+  const grid: AnsiGrid = Array.from({ length: rows }, () =>
+    Array.from({ length: cols }, () => ({ ...DEFAULT_CELL }))
   )
 
   for (let py = 0; py < height; py += 2) {
     const row = py >> 1
-    if (row >= ANSI_ROWS) break
+    if (row >= rows) break
     for (let px = 0; px < width; px++) {
-      if (px >= ANSI_COLS) break
+      if (px >= cols) break
 
       const topIdx = (py * width + px) * 4
       const topAlpha = rgba[topIdx + 3]
@@ -77,10 +81,15 @@ export interface PngPixels {
 }
 
 /**
- * Load a PNG file, decode it, scale to fit 80x50 pixel bounds, and return the RGBA buffer.
+ * Load a PNG file, decode it, scale to fit the given pixel bounds, and return the RGBA buffer.
+ * `cols`/`rows` control the max dimensions (rows are doubled for half-block encoding).
  * Uses createImageBitmap + OffscreenCanvas for browser-native decoding.
  */
-export async function loadPngPixels(file: File): Promise<PngPixels> {
+export async function loadPngPixels(
+  file: File,
+  cols: number = DEFAULT_ANSI_COLS,
+  rows: number = DEFAULT_ANSI_ROWS,
+): Promise<PngPixels> {
   let bitmap: ImageBitmap
   try {
     bitmap = await createImageBitmap(file)
@@ -88,7 +97,7 @@ export async function loadPngPixels(file: File): Promise<PngPixels> {
     throw new Error(`Failed to decode image "${file.name}". The file may be corrupted or not a supported image format.`)
   }
 
-  const { width, height } = computeScaledSize(bitmap.width, bitmap.height, MAX_PX_W, MAX_PX_H)
+  const { width, height } = computeScaledSize(bitmap.width, bitmap.height, cols, rows * 2)
 
   if (width === 0 || height === 0) {
     bitmap.close()

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/useAnsiEditor.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/useAnsiEditor.ts
@@ -313,9 +313,11 @@ export function useAnsiEditor(options?: UseAnsiEditorOptions): UseAnsiEditorRetu
 
   const importPngAsLayer = useCallback(async (file: File) => {
     try {
-      const px = await loadPngPixels(file)
+      const c = projectColsRef.current
+      const r = projectRowsRef.current
+      const px = await loadPngPixels(file, c, r)
       const name = file.name.replace(/\.\w+$/, '')
-      withLayerUndo(() => rawAddLayerWithGrid(name, rgbaToAnsiGrid(px.rgba, px.width, px.height)))
+      withLayerUndo(() => rawAddLayerWithGrid(name, rgbaToAnsiGrid(px.rgba, px.width, px.height, c, r)))
     } catch {
       showToastRef.current?.('Failed to import image')
     }

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/useAnsiEditorLoadDims.test.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/useAnsiEditorLoadDims.test.ts
@@ -138,4 +138,36 @@ describe('useAnsiEditor — loading a project with non-default dimensions', () =
     expect(active.frames[1].length).toBe(40)
     expect(active.frames[1][0].length).toBe(120)
   })
+
+  it('move tool shifts cells within the full 120×40 canvas, not just 80×25', () => {
+    // Place a mark at (100, 35) on the loaded 120×40 project.
+    const state = wideProject(120, 40)
+    const drawnLayer = state.layers[0] as DrawnLayer
+    drawnLayer.grid[35][100] = { char: 'M', fg: [255, 0, 0], bg: [0, 0, 0] }
+    drawnLayer.frames[0] = drawnLayer.grid
+
+    const { result } = renderHook(() => useAnsiEditor({ initialLayerState: state }))
+    const container = createMockContainer(120 * 10, 40 * 20)
+    const handle = { write: vi.fn(), container, dispose: vi.fn(), setCrt: vi.fn() }
+    act(() => result.current.onTerminalReady(handle))
+    act(() => result.current.setTool('move'))
+
+    // Drag from (100, 35) to (110, 38) — both well outside the old 80×25 region.
+    // mousedown on container starts capture; mouseup on document commits the shift.
+    const cellW = 10, cellH = 20
+    act(() => { container.dispatchEvent(new MouseEvent('mousedown', {
+      clientX: 100 * cellW + cellW / 2, clientY: 35 * cellH + cellH / 2, bubbles: true,
+    })) })
+    act(() => { document.dispatchEvent(new MouseEvent('mouseup', {
+      clientX: 110 * cellW + cellW / 2, clientY: 38 * cellH + cellH / 2, bubbles: true,
+    })) })
+
+    // After move, 'M' should have shifted from (100,35) to (110,38).
+    const movedLayer = result.current.layers[0] as DrawnLayer
+    expect(movedLayer.grid.length).toBe(40)
+    expect(movedLayer.grid[0].length).toBe(120)
+    expect(movedLayer.grid[38][110].char).toBe('M')
+    // Original position should be cleared.
+    expect(movedLayer.grid[35][100].char).toBe(' ')
+  })
 })


### PR DESCRIPTION
## Summary

Follow-up to #755 — fixes the remaining 80×25 hardcodings that shipped with the arbitrary canvas dimensions feature.

- **PNG import** clipped to 80×25 regardless of project size. `rgbaToAnsiGrid` and `loadPngPixels` now accept `(cols, rows)` and `importPngAsLayer` threads the project dims through.
- **ANS export** SAUCE record wrote `TInfo1=80, TInfo2=25` for every file. Now derives from actual grid dimensions.
- **Move tool** regression test confirms a cell at (100, 35) on a 120×40 project can be moved to (110, 38) end-to-end.

## Test plan
- [x] 4328 unit tests pass
- [x] Type check clean
- [x] Lint: 0 errors
- [x] Pre-push CI gate passed
- [ ] E2E (\`/e2e-verified\`)
- [ ] Manual: open a 120×40 project, import a PNG → should fill the full canvas

🤖 Generated with [Claude Code](https://claude.com/claude-code)