### PR TITLE
feat: drag-and-drop frame reordering in ANSI editor

### DIFF
--- a/docs/ansi/editor.md
+++ b/docs/ansi/editor.md
@@ -235,7 +235,10 @@ When a drawn layer is active, the Frames panel appears below the canvas:
 - Click **Dup** to duplicate the current frame
 - Click **- Del** to remove the current frame
 - Click a frame thumbnail to switch to it
+- **Drag a frame thumbnail** onto the gap before, between, or after other frames to reorder it. Drop zones highlight while dragging.
 - Set the frame duration per layer (16–10,000 ms)
+
+Reordering is captured by undo/redo. Drag-and-drop is disabled during playback.
 
 ### Playback
 

--- a/lua-learning-website/public/docs/ansi/editor.md
+++ b/lua-learning-website/public/docs/ansi/editor.md
@@ -239,7 +239,10 @@ When a drawn layer is active, the Frames panel appears below the canvas:
 - Click **Dup** to duplicate the current frame
 - Click **- Del** to remove the current frame
 - Click a frame thumbnail to switch to it
+- **Drag a frame thumbnail** onto the gap before, between, or after other frames to reorder it. Drop zones highlight while dragging.
 - Set the frame duration per layer (16–10,000 ms)
+
+Reordering is captured by undo/redo. Drag-and-drop is disabled during playback.
 
 ### Playback
 

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.module.css
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.module.css
@@ -1211,9 +1211,10 @@
 
 .framesStrip {
   display: flex;
-  gap: 4px;
+  gap: 0;
   overflow-x: auto;
   padding: 2px 0;
+  align-items: stretch;
 }
 
 .frameCell {
@@ -1223,13 +1224,18 @@
   align-items: center;
   justify-content: center;
   padding: 0 6px;
+  margin: 0 2px;
   font-size: 11px;
-  cursor: pointer;
+  cursor: grab;
   background: var(--theme-bg-tertiary, #2d2d2d);
   border: 1px solid var(--theme-border, #444);
   border-radius: 3px;
   color: var(--theme-text-primary, #ccc);
   flex-shrink: 0;
+}
+
+.frameCell:active {
+  cursor: grabbing;
 }
 
 .frameCell:hover {
@@ -1240,6 +1246,23 @@
   background: var(--theme-accent-primary, #0078d4);
   border-color: var(--theme-accent-primary, #0078d4);
   color: #fff;
+}
+
+.frameCellDragging {
+  opacity: 0.4;
+}
+
+.frameDropZone {
+  width: 4px;
+  min-height: 24px;
+  flex-shrink: 0;
+  background-color: transparent;
+  border-radius: 2px;
+}
+
+.frameDropZoneActive {
+  width: 10px;
+  background-color: var(--theme-accent-primary, #0078d4);
 }
 
 /* File Options Modal */

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.tsx
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.tsx
@@ -123,6 +123,7 @@ export function AnsiGraphicsEditor({ filePath, onDirtyChange, isActive }: AnsiGr
     addFrame,
     duplicateFrame,
     removeFrame,
+    reorderFrame,
     setCurrentFrame,
     setFrameDuration,
     isPlaying,
@@ -348,6 +349,7 @@ export function AnsiGraphicsEditor({ filePath, onDirtyChange, isActive }: AnsiGr
               onAddFrame={addFrame}
               onDuplicateFrame={duplicateFrame}
               onRemoveFrame={removeFrame}
+              onReorderFrame={reorderFrame}
               onSetDuration={setFrameDuration}
               onTogglePlayback={togglePlayback}
             />

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/FramesPanel.test.tsx
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/FramesPanel.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 import { FramesPanel } from './FramesPanel'
 import type { FramesPanelProps } from './FramesPanel'
 
@@ -15,6 +15,7 @@ function defaultProps(overrides: Partial<FramesPanelProps> = {}): FramesPanelPro
     onRemoveFrame: vi.fn(),
     onSetDuration: vi.fn(),
     onTogglePlayback: vi.fn(),
+    onReorderFrame: vi.fn(),
     ...overrides,
   }
 }
@@ -27,7 +28,7 @@ describe('FramesPanel', () => {
 
   it('renders the correct number of frame cells', () => {
     render(<FramesPanel {...defaultProps({ frameCount: 5 })} />)
-    expect(screen.getByTestId('frames-strip').children).toHaveLength(5)
+    expect(screen.getAllByTestId(/^frame-cell-\d+$/)).toHaveLength(5)
   })
 
   it('highlights the active frame cell', () => {
@@ -115,5 +116,133 @@ describe('FramesPanel', () => {
     fireEvent.change(input, { target: { value: '300' } })
     fireEvent.keyDown(input, { key: 'Enter' })
     expect(onSetDuration).toHaveBeenCalledWith(300)
+  })
+})
+
+describe('FramesPanel drag-and-drop frame reordering', () => {
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(() => { vi.useRealTimers() })
+
+  /** Fire dragStart and flush the deferred requestAnimationFrame. */
+  function startDrag(cell: HTMLElement): void {
+    fireEvent.dragStart(cell, { dataTransfer: { setData: vi.fn(), effectAllowed: '' } })
+    act(() => { vi.runAllTimers() })
+  }
+
+  it('renders frameCount + 1 drop zones', () => {
+    render(<FramesPanel {...defaultProps({ frameCount: 4 })} />)
+    expect(screen.getAllByTestId(/^frame-drop-zone-\d+$/)).toHaveLength(5)
+  })
+
+  it('renders drop zones at the correct positions', () => {
+    render(<FramesPanel {...defaultProps({ frameCount: 3 })} />)
+    expect(screen.getByTestId('frame-drop-zone-0')).toBeTruthy()
+    expect(screen.getByTestId('frame-drop-zone-1')).toBeTruthy()
+    expect(screen.getByTestId('frame-drop-zone-2')).toBeTruthy()
+    expect(screen.getByTestId('frame-drop-zone-3')).toBeTruthy()
+  })
+
+  it('frame cells are draggable when not playing', () => {
+    render(<FramesPanel {...defaultProps({ frameCount: 3 })} />)
+    expect(screen.getByTestId('frame-cell-0').getAttribute('draggable')).toBe('true')
+  })
+
+  it('frame cells are not draggable while playing', () => {
+    render(<FramesPanel {...defaultProps({ frameCount: 3, isPlaying: true })} />)
+    expect(screen.getByTestId('frame-cell-0').getAttribute('draggable')).toBe('false')
+  })
+
+  it('dropping frame 0 on zone 2 calls onReorderFrame(0, 1)', () => {
+    // zone 2 is between frames 1 and 2. from=0, zone=2, zone>from+1 → to=zone-1=1
+    const onReorderFrame = vi.fn()
+    render(<FramesPanel {...defaultProps({ frameCount: 3, onReorderFrame })} />)
+    startDrag(screen.getByTestId('frame-cell-0'))
+    const zone = screen.getByTestId('frame-drop-zone-2')
+    fireEvent.dragOver(zone, { dataTransfer: { dropEffect: '' }, preventDefault: vi.fn() })
+    fireEvent.drop(zone, { dataTransfer: { getData: () => '0' }, preventDefault: vi.fn() })
+    expect(onReorderFrame).toHaveBeenCalledWith(0, 1)
+  })
+
+  it('dropping frame 0 on the last zone calls onReorderFrame(0, frameCount-1)', () => {
+    // from=0, zone=3 (after last frame when frameCount=3), zone>from+1 → to=zone-1=2
+    const onReorderFrame = vi.fn()
+    render(<FramesPanel {...defaultProps({ frameCount: 3, onReorderFrame })} />)
+    startDrag(screen.getByTestId('frame-cell-0'))
+    const zone = screen.getByTestId('frame-drop-zone-3')
+    fireEvent.dragOver(zone, { dataTransfer: { dropEffect: '' }, preventDefault: vi.fn() })
+    fireEvent.drop(zone, { dataTransfer: { getData: () => '0' }, preventDefault: vi.fn() })
+    expect(onReorderFrame).toHaveBeenCalledWith(0, 2)
+  })
+
+  it('dropping frame 2 on zone 0 calls onReorderFrame(2, 0)', () => {
+    // zone 0 is before frame 0. from=2, zone=0, zone<from → to=zone=0
+    const onReorderFrame = vi.fn()
+    render(<FramesPanel {...defaultProps({ frameCount: 3, onReorderFrame })} />)
+    startDrag(screen.getByTestId('frame-cell-2'))
+    const zone = screen.getByTestId('frame-drop-zone-0')
+    fireEvent.dragOver(zone, { dataTransfer: { dropEffect: '' }, preventDefault: vi.fn() })
+    fireEvent.drop(zone, { dataTransfer: { getData: () => '2' }, preventDefault: vi.fn() })
+    expect(onReorderFrame).toHaveBeenCalledWith(2, 0)
+  })
+
+  it('dropping frame on its left flanking zone is a no-op', () => {
+    // from=1, zone=1 (left of frame 1) → no-op
+    const onReorderFrame = vi.fn()
+    render(<FramesPanel {...defaultProps({ frameCount: 3, onReorderFrame })} />)
+    startDrag(screen.getByTestId('frame-cell-1'))
+    const zone = screen.getByTestId('frame-drop-zone-1')
+    fireEvent.dragOver(zone, { dataTransfer: { dropEffect: '' }, preventDefault: vi.fn() })
+    fireEvent.drop(zone, { dataTransfer: { getData: () => '1' }, preventDefault: vi.fn() })
+    expect(onReorderFrame).not.toHaveBeenCalled()
+  })
+
+  it('dropping frame on its right flanking zone is a no-op', () => {
+    // from=1, zone=2 (right of frame 1) → no-op
+    const onReorderFrame = vi.fn()
+    render(<FramesPanel {...defaultProps({ frameCount: 3, onReorderFrame })} />)
+    startDrag(screen.getByTestId('frame-cell-1'))
+    const zone = screen.getByTestId('frame-drop-zone-2')
+    fireEvent.dragOver(zone, { dataTransfer: { dropEffect: '' }, preventDefault: vi.fn() })
+    fireEvent.drop(zone, { dataTransfer: { getData: () => '1' }, preventDefault: vi.fn() })
+    expect(onReorderFrame).not.toHaveBeenCalled()
+  })
+
+  it('active drop zone gets the active class while dragging', () => {
+    render(<FramesPanel {...defaultProps({ frameCount: 3 })} />)
+    startDrag(screen.getByTestId('frame-cell-0'))
+    const zone = screen.getByTestId('frame-drop-zone-2')
+    fireEvent.dragOver(zone, { dataTransfer: { dropEffect: '' }, preventDefault: vi.fn() })
+    expect(zone.className).toContain('frameDropZoneActive')
+  })
+
+  it('drop zones do not trigger onReorderFrame while playing', () => {
+    const onReorderFrame = vi.fn()
+    render(<FramesPanel {...defaultProps({ frameCount: 3, isPlaying: true, onReorderFrame })} />)
+    const zone = screen.getByTestId('frame-drop-zone-2')
+    fireEvent.drop(zone, { dataTransfer: { getData: () => '0' }, preventDefault: vi.fn() })
+    expect(onReorderFrame).not.toHaveBeenCalled()
+  })
+
+  it('dragging cell applies dragging class', () => {
+    render(<FramesPanel {...defaultProps({ frameCount: 3 })} />)
+    const cell = screen.getByTestId('frame-cell-0')
+    startDrag(cell)
+    expect(cell.className).toContain('frameCellDragging')
+  })
+
+  it('dragEnd clears dragging state', () => {
+    render(<FramesPanel {...defaultProps({ frameCount: 3 })} />)
+    const cell = screen.getByTestId('frame-cell-0')
+    startDrag(cell)
+    fireEvent.dragEnd(cell)
+    expect(cell.className).not.toContain('frameCellDragging')
+  })
+
+  it('invalid dataTransfer payload does not call onReorderFrame', () => {
+    const onReorderFrame = vi.fn()
+    render(<FramesPanel {...defaultProps({ frameCount: 3, onReorderFrame })} />)
+    const zone = screen.getByTestId('frame-drop-zone-2')
+    fireEvent.drop(zone, { dataTransfer: { getData: () => 'not-a-number' }, preventDefault: vi.fn() })
+    expect(onReorderFrame).not.toHaveBeenCalled()
   })
 })

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/FramesPanel.test.tsx
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/FramesPanel.test.tsx
@@ -126,7 +126,7 @@ describe('FramesPanel drag-and-drop frame reordering', () => {
   /** Fire dragStart and flush the deferred requestAnimationFrame. */
   function startDrag(cell: HTMLElement): void {
     fireEvent.dragStart(cell, { dataTransfer: { setData: vi.fn(), effectAllowed: '' } })
-    act(() => { vi.runAllTimers() })
+    act(() => { vi.advanceTimersToNextFrame() })
   }
 
   it('renders frameCount + 1 drop zones', () => {

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/FramesPanel.tsx
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/FramesPanel.tsx
@@ -1,5 +1,6 @@
-import { useRef } from 'react'
+import { useRef, Fragment } from 'react'
 import styles from './AnsiGraphicsEditor.module.css'
+import { useFrameDragDrop } from './useFrameDragDrop'
 
 export interface FramesPanelProps {
   frameCount: number
@@ -12,13 +13,19 @@ export interface FramesPanelProps {
   onRemoveFrame: () => void
   onSetDuration: (ms: number) => void
   onTogglePlayback: () => void
+  onReorderFrame: (from: number, to: number) => void
 }
 
 export function FramesPanel({
   frameCount, currentFrame, frameDuration, isPlaying,
   onSelectFrame, onAddFrame, onDuplicateFrame, onRemoveFrame, onSetDuration, onTogglePlayback,
+  onReorderFrame,
 }: FramesPanelProps) {
   const inputRef = useRef<HTMLInputElement>(null)
+  const {
+    draggedIndex, dropZoneIndex,
+    handleDragStart, handleDragEnd, handleDragOverZone, handleDropOnZone,
+  } = useFrameDragDrop(frameCount, onReorderFrame)
 
   const commitDuration = () => {
     const val = inputRef.current?.value ?? ''
@@ -27,6 +34,16 @@ export function FramesPanel({
       onSetDuration(parsed)
     }
   }
+
+  const renderDropZone = (zone: number) => (
+    <div
+      key={`zone-${zone}`}
+      data-testid={`frame-drop-zone-${zone}`}
+      className={`${styles.frameDropZone} ${dropZoneIndex === zone ? styles.frameDropZoneActive : ''}`}
+      onDragOver={isPlaying ? undefined : e => handleDragOverZone(e, zone)}
+      onDrop={isPlaying ? undefined : e => handleDropOnZone(e, zone)}
+    />
+  )
 
   return (
     <div className={styles.framesPanel} data-testid="frames-panel">
@@ -76,17 +93,27 @@ export function FramesPanel({
         </button>
       </div>
       <div className={styles.framesStrip} data-testid="frames-strip">
+        {renderDropZone(0)}
         {Array.from({ length: frameCount }, (_, i) => (
-          <button
-            key={i}
-            type="button"
-            className={`${styles.frameCell} ${i === currentFrame ? styles.frameCellActive : ''}`}
-            onClick={() => onSelectFrame(i)}
-            disabled={isPlaying}
-            data-testid={`frame-cell-${i}`}
-          >
-            {i + 1}
-          </button>
+          <Fragment key={i}>
+            <button
+              type="button"
+              className={[
+                styles.frameCell,
+                i === currentFrame ? styles.frameCellActive : '',
+                draggedIndex === i ? styles.frameCellDragging : '',
+              ].filter(Boolean).join(' ')}
+              onClick={() => onSelectFrame(i)}
+              disabled={isPlaying}
+              draggable={!isPlaying}
+              onDragStart={e => handleDragStart(e, i)}
+              onDragEnd={handleDragEnd}
+              data-testid={`frame-cell-${i}`}
+            >
+              {i + 1}
+            </button>
+            {renderDropZone(i + 1)}
+          </Fragment>
         ))}
       </div>
     </div>

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/useFrameDragDrop.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/useFrameDragDrop.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 
 export interface UseFrameDragDropReturn {
   draggedIndex: number | null
@@ -15,6 +15,11 @@ export function useFrameDragDrop(
 ): UseFrameDragDropReturn {
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null)
   const [dropZoneIndex, setDropZoneIndex] = useState<number | null>(null)
+  const rafRef = useRef<number | null>(null)
+
+  useEffect(() => () => {
+    if (rafRef.current !== null) cancelAnimationFrame(rafRef.current)
+  }, [])
 
   const clearDragState = useCallback(() => {
     setDraggedIndex(null)
@@ -24,9 +29,11 @@ export function useFrameDragDrop(
   const handleDragStart = useCallback((e: React.DragEvent, from: number) => {
     e.dataTransfer.setData('text/plain', String(from))
     e.dataTransfer.effectAllowed = 'move'
-    // Defer so the browser captures the drag image before React re-renders
-    // and restyles the dragged cell (mirrors useLayerDragDrop).
-    requestAnimationFrame(() => setDraggedIndex(from))
+    // RAF defer so the browser captures the drag image before React restyles the source cell.
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null
+      setDraggedIndex(from)
+    })
   }, [])
 
   const handleDragEnd = useCallback(clearDragState, [clearDragState])
@@ -39,17 +46,14 @@ export function useFrameDragDrop(
 
   const handleDropOnZone = useCallback((e: React.DragEvent, zone: number) => {
     e.preventDefault()
-    const raw = e.dataTransfer.getData('text/plain')
-    const from = parseInt(raw, 10)
-    if (!Number.isFinite(from) || from < 0 || from >= frameCount) {
+    const from = parseInt(e.dataTransfer.getData('text/plain'), 10)
+    if (!Number.isInteger(from) || from < 0 || from >= frameCount) {
       clearDragState()
       return
     }
-    // Zone index z ∈ [0, frameCount] represents the gap before frame z
-    // (so zone frameCount is the gap after the last frame). Zones flanking
-    // the dragged frame (z === from, z === from + 1) are no-ops.
-    // Otherwise map to the final `to` passed to reorderFrame, compensating
-    // for the splice-then-insert semantics.
+    // Zone z ∈ [0, frameCount] is the gap before frame z; zones flanking the source
+    // (z === from, z === from + 1) are no-ops. Otherwise compensate for the
+    // splice-then-insert semantics of reorderFrame(from, to).
     if (zone !== from && zone !== from + 1) {
       const to = zone > from ? zone - 1 : zone
       onReorder(from, to)

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/useFrameDragDrop.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/useFrameDragDrop.ts
@@ -1,0 +1,68 @@
+import { useState, useCallback } from 'react'
+
+export interface UseFrameDragDropReturn {
+  draggedIndex: number | null
+  dropZoneIndex: number | null
+  handleDragStart: (e: React.DragEvent, from: number) => void
+  handleDragEnd: () => void
+  handleDragOverZone: (e: React.DragEvent, zone: number) => void
+  handleDropOnZone: (e: React.DragEvent, zone: number) => void
+}
+
+export function useFrameDragDrop(
+  frameCount: number,
+  onReorder: (from: number, to: number) => void,
+): UseFrameDragDropReturn {
+  const [draggedIndex, setDraggedIndex] = useState<number | null>(null)
+  const [dropZoneIndex, setDropZoneIndex] = useState<number | null>(null)
+
+  const clearDragState = useCallback(() => {
+    setDraggedIndex(null)
+    setDropZoneIndex(null)
+  }, [])
+
+  const handleDragStart = useCallback((e: React.DragEvent, from: number) => {
+    e.dataTransfer.setData('text/plain', String(from))
+    e.dataTransfer.effectAllowed = 'move'
+    // Defer so the browser captures the drag image before React re-renders
+    // and restyles the dragged cell (mirrors useLayerDragDrop).
+    requestAnimationFrame(() => setDraggedIndex(from))
+  }, [])
+
+  const handleDragEnd = useCallback(clearDragState, [clearDragState])
+
+  const handleDragOverZone = useCallback((e: React.DragEvent, zone: number) => {
+    e.preventDefault()
+    e.dataTransfer.dropEffect = 'move'
+    setDropZoneIndex(zone)
+  }, [])
+
+  const handleDropOnZone = useCallback((e: React.DragEvent, zone: number) => {
+    e.preventDefault()
+    const raw = e.dataTransfer.getData('text/plain')
+    const from = parseInt(raw, 10)
+    if (!Number.isFinite(from) || from < 0 || from >= frameCount) {
+      clearDragState()
+      return
+    }
+    // Zone index z ∈ [0, frameCount] represents the gap before frame z
+    // (so zone frameCount is the gap after the last frame). Zones flanking
+    // the dragged frame (z === from, z === from + 1) are no-ops.
+    // Otherwise map to the final `to` passed to reorderFrame, compensating
+    // for the splice-then-insert semantics.
+    if (zone !== from && zone !== from + 1) {
+      const to = zone > from ? zone - 1 : zone
+      onReorder(from, to)
+    }
+    clearDragState()
+  }, [frameCount, onReorder, clearDragState])
+
+  return {
+    draggedIndex,
+    dropZoneIndex,
+    handleDragStart,
+    handleDragEnd,
+    handleDragOverZone,
+    handleDropOnZone,
+  }
+}


### PR DESCRIPTION
## Summary

- Adds N+1 interleaved drop zones to `FramesPanel` (before the first frame, between every pair, after the last)
- Frame cells become draggable when not playing; dragging one onto a non-flanking drop zone reorders frames in place
- Undo/redo works automatically — the consumed `reorderFrame` is already the `reorderFrameWithUndo` wrapper in `useAnsiEditor`

## Implementation

- New hook `useFrameDragDrop` encapsulates native HTML5 drag state (dragged index, active drop zone) and maps zone indices to the `from → to` signature of the existing `reorderFrame(from, to)` in `useLayerState.ts`
- Mirrors the convention already used by `useLayerDragDrop` + `LayersPanel` for layer reordering (same deferred-RAF pattern, same `dataTransfer` payload shape)
- DnD is disabled while `isPlaying` to match the existing frame-edit button behavior

## Test plan

- [x] `FramesPanel` unit tests (28 passing, including 14 new DnD cases: zone-to-`to` mapping, flanking-zone no-ops, playback disables drag, invalid payload ignored)
- [x] `useLayerState` tests still pass (reorderFrame data layer unchanged)
- [x] Type check clean (no new errors)
- [x] Lint clean (0 errors; warning count reduced 304 → 303)
- [x] Pre-push CI (all 4327 unit tests pass)
- [ ] Manual browser smoke test: drag frame left/right, undo/redo round-trip, verify drag is inert during playback

🤖 Generated with [Claude Code](https://claude.com/claude-code)