### PR TITLE
fix(audio): drive AudioAssetManager from canvas lifecycle

### DIFF
--- a/packages/export/src/runtime/canvas-inline.generated.ts
+++ b/packages/export/src/runtime/canvas-inline.generated.ts
@@ -8,7 +8,7 @@
  */
 export const CANVAS_INLINE_JS = `"use strict";
 var CanvasInline = (() => {
-  // ../lua-runtime/src/canvasLuaCode/core.ts
+  // .claude/worktrees/fix-canvas-audio-lifecycle/packages/lua-runtime/src/canvasLuaCode/core.ts
   var canvasLuaCoreCode = \`
     local _canvas = {}
 
@@ -17,6 +17,9 @@ var CanvasInline = (() => {
       if __canvas_is_active() then
         error("Canvas is already running. Call canvas.stop() first.")
       end
+      -- Drive the ail_audio asset manager before canvas so assets loaded via
+      -- canvas.assets.load_sound/load_music are decoded before the game loop.
+      if __audio_assets_start then __audio_assets_start():await() end
       __canvas_start():await()
     end
 
@@ -216,6 +219,8 @@ var CanvasInline = (() => {
     -- Must be called BEFORE canvas.start()
     function _canvas.assets.add_path(path)
       __canvas_assets_addPath(path)
+      -- Mirror to ail_audio so load_sound/load_music can resolve from the path.
+      if __audio_assets_addPath then __audio_assets_addPath(path) end
     end
 
     -- Create a named reference to a discovered image file
@@ -463,7 +468,7 @@ var CanvasInline = (() => {
     end
 \`;
 
-  // ../lua-runtime/src/canvasLuaCode/path.ts
+  // .claude/worktrees/fix-canvas-audio-lifecycle/packages/lua-runtime/src/canvasLuaCode/path.ts
   var canvasLuaPathCode = \`
     -- Path API
     function _canvas.begin_path()
@@ -740,7 +745,7 @@ var CanvasInline = (() => {
     end
 \`;
 
-  // ../lua-runtime/src/canvasLuaCode/styling.ts
+  // .claude/worktrees/fix-canvas-audio-lifecycle/packages/lua-runtime/src/canvasLuaCode/styling.ts
   var canvasLuaStylingCode = \`
     -- Line Style API
     function _canvas.set_line_cap(cap)
@@ -877,7 +882,7 @@ var CanvasInline = (() => {
     end
 \`;
 
-  // ../lua-runtime/src/canvasLuaCode/text.ts
+  // .claude/worktrees/fix-canvas-audio-lifecycle/packages/lua-runtime/src/canvasLuaCode/text.ts
   var canvasLuaTextCode = \`
     -- Text Alignment
     function _canvas.set_text_align(align)
@@ -1081,7 +1086,7 @@ var CanvasInline = (() => {
     end
 \`;
 
-  // ../lua-runtime/src/canvasLuaCode/input.ts
+  // .claude/worktrees/fix-canvas-audio-lifecycle/packages/lua-runtime/src/canvasLuaCode/input.ts
   var canvasLuaInputCode = \`
     -- Helper to normalize key names
     local function normalize_key(key)
@@ -1307,7 +1312,7 @@ var CanvasInline = (() => {
     end
 \`;
 
-  // ../lua-runtime/src/canvasLuaCode/audio.ts
+  // .claude/worktrees/fix-canvas-audio-lifecycle/packages/lua-runtime/src/canvasLuaCode/audio.ts
   var canvasLuaAudioCode = \`
     -- ========================================================================
     -- Audio API (delegates to ail_audio module)
@@ -1333,7 +1338,7 @@ var CanvasInline = (() => {
     end
 \`;
 
-  // ../lua-runtime/src/lua/hc.generated.ts
+  // .claude/worktrees/fix-canvas-audio-lifecycle/packages/lua-runtime/src/lua/hc.generated.ts
   var LUA_HC_CODE = \`---@meta hc
 --- hc.lua - HC Collision Detection Library
 --- Load with: local HC = require('hc')
@@ -2922,7 +2927,7 @@ return setmetatable({
 }, {__call = function(_, ...) return common_local.instance(HC, ...) end})
 \`;
 
-  // ../lua-runtime/src/lua/localstorage.generated.ts
+  // .claude/worktrees/fix-canvas-audio-lifecycle/packages/lua-runtime/src/lua/localstorage.generated.ts
   var LUA_LOCALSTORAGE_CODE = \`---@meta localstorage
 --- localstorage.lua - Persistent key-value storage library
 --- Load with: local localstorage = require('localstorage')
@@ -3024,7 +3029,7 @@ end
 return localstorage
 \`;
 
-  // ../lua-runtime/src/audioLuaCode/audio.ts
+  // .claude/worktrees/fix-canvas-audio-lifecycle/packages/lua-runtime/src/audioLuaCode/audio.ts
   var audioLuaCode = \`
     -- ========================================================================
     -- Audio Module (standalone)
@@ -3204,7 +3209,7 @@ return localstorage
     end
 \`;
 
-  // ../lua-runtime/src/chipLuaCode/chip.ts
+  // .claude/worktrees/fix-canvas-audio-lifecycle/packages/lua-runtime/src/chipLuaCode/chip.ts
   var chipLuaCode = \`
     -- ========================================================================
     -- Chip Module (OPL3 FM Synthesis)
@@ -3468,7 +3473,7 @@ return localstorage
     end
 \`;
 
-  // src/runtime/canvas-bridge-utils.ts
+  // .claude/worktrees/fix-canvas-audio-lifecycle/packages/export/src/runtime/canvas-bridge-utils.ts
   function toNumberArray(segments) {
     if (Array.isArray(segments)) {
       return [...segments];
@@ -3483,7 +3488,7 @@ return localstorage
     return result;
   }
 
-  // src/runtime/canvas-standalone.ts
+  // .claude/worktrees/fix-canvas-audio-lifecycle/packages/export/src/runtime/canvas-standalone.ts
   function createEmptyGamepadState() {
     return {
       connected: false,
@@ -4575,7 +4580,7 @@ return localstorage
   }
   var localStorageLuaCode = LUA_LOCALSTORAGE_CODE;
 
-  // src/runtime/canvas-inline-entry.ts
+  // .claude/worktrees/fix-canvas-audio-lifecycle/packages/export/src/runtime/canvas-inline-entry.ts
   globalThis.CanvasStandalone = {
     setupCanvasBridge,
     createCanvasRuntimeState,

--- a/packages/lua-runtime/src/canvasLuaCode/core.ts
+++ b/packages/lua-runtime/src/canvasLuaCode/core.ts
@@ -10,6 +10,9 @@ export const canvasLuaCoreCode = `
       if __canvas_is_active() then
         error("Canvas is already running. Call canvas.stop() first.")
       end
+      -- Drive the ail_audio asset manager before canvas so assets loaded via
+      -- canvas.assets.load_sound/load_music are decoded before the game loop.
+      if __audio_assets_start then __audio_assets_start():await() end
       __canvas_start():await()
     end
 
@@ -209,6 +212,8 @@ export const canvasLuaCoreCode = `
     -- Must be called BEFORE canvas.start()
     function _canvas.assets.add_path(path)
       __canvas_assets_addPath(path)
+      -- Mirror to ail_audio so load_sound/load_music can resolve from the path.
+      if __audio_assets_addPath then __audio_assets_addPath(path) end
     end
 
     -- Create a named reference to a discovered image file

--- a/packages/lua-runtime/tests/canvasLuaCode.audioLifecycle.test.ts
+++ b/packages/lua-runtime/tests/canvasLuaCode.audioLifecycle.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for canvas <-> AudioAssetManager lifecycle coupling (core.ts).
+ *
+ * Regression: games built before the standalone `ail_audio` split registered
+ * their audio through `canvas.assets.*`. After the split, those calls routed
+ * to AudioAssetManager while canvas.start() only drove the canvas AssetManager,
+ * so audio was never decoded and channel_play silently no-oped.
+ *
+ * The fix wires canvas.assets.add_path and canvas.start to also notify the
+ * audio-side bridges when they exist, so the old API continues to work.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { LuaFactory, LuaEngine } from 'wasmoon'
+import { setupCanvasAPI } from '../src/setupCanvasAPI'
+import type { CanvasController } from '../src/CanvasController'
+
+function createMockController(): CanvasController {
+  return {
+    isActive: vi.fn().mockReturnValue(false),
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn(),
+    addAssetPath: vi.fn(),
+    loadImageAsset: vi.fn(),
+    loadFontAsset: vi.fn(),
+    getAssetManifest: vi.fn().mockReturnValue(new Map()),
+    loadAssets: vi.fn().mockResolvedValue(undefined),
+    getAssetWidth: vi.fn().mockReturnValue(0),
+    getAssetHeight: vi.fn().mockReturnValue(0),
+    setOnDrawCallback: vi.fn(),
+    setReloadCallback: vi.fn(),
+    getDelta: vi.fn().mockReturnValue(0),
+    getTime: vi.fn().mockReturnValue(0),
+    getWidth: vi.fn().mockReturnValue(0),
+    getHeight: vi.fn().mockReturnValue(0),
+    getKeysDown: vi.fn().mockReturnValue([]),
+    getKeysPressed: vi.fn().mockReturnValue([]),
+    isKeyDown: vi.fn().mockReturnValue(false),
+    isKeyPressed: vi.fn().mockReturnValue(false),
+    getMouseX: vi.fn().mockReturnValue(0),
+    getMouseY: vi.fn().mockReturnValue(0),
+    isMouseButtonDown: vi.fn().mockReturnValue(false),
+    isMouseButtonPressed: vi.fn().mockReturnValue(false),
+    getInputState: vi.fn().mockReturnValue({
+      keysDown: [],
+      keysPressed: [],
+      mouseX: 0,
+      mouseY: 0,
+      mouseButtonsDown: [],
+      mouseButtonsPressed: [],
+    }),
+  } as unknown as CanvasController
+}
+
+describe('canvasLuaCode <-> audio asset lifecycle', () => {
+  let engine: LuaEngine
+
+  beforeEach(async () => {
+    const factory = new LuaFactory()
+    engine = await factory.createEngine()
+  })
+
+  afterEach(() => {
+    engine.global.close()
+  })
+
+  it('canvas.assets.add_path mirrors the path to __audio_assets_addPath when registered', async () => {
+    const audioAddPath = vi.fn()
+    setupCanvasAPI(engine, () => createMockController())
+    engine.global.set('__audio_assets_addPath', audioAddPath)
+
+    await engine.doString(`
+      local canvas = require('canvas')
+      canvas.assets.add_path('assets/')
+    `)
+
+    expect(audioAddPath).toHaveBeenCalledTimes(1)
+    expect(audioAddPath).toHaveBeenCalledWith('assets/')
+  })
+
+  it('canvas.assets.add_path does not error when __audio_assets_addPath is absent', async () => {
+    setupCanvasAPI(engine, () => createMockController())
+    // Intentionally do NOT set __audio_assets_addPath
+
+    await expect(
+      engine.doString(`
+        local canvas = require('canvas')
+        canvas.assets.add_path('assets/')
+      `)
+    ).resolves.not.toThrow()
+  })
+
+  it('canvas.start awaits __audio_assets_start before __canvas_start when registered', async () => {
+    const order: string[] = []
+    const audioStart = vi.fn().mockImplementation(() => {
+      order.push('audio_start_called')
+      return Promise.resolve().then(() => {
+        order.push('audio_start_resolved')
+      })
+    })
+    const canvasStart = vi.fn().mockImplementation(() => {
+      order.push('canvas_start_called')
+      return Promise.resolve()
+    })
+
+    setupCanvasAPI(engine, () => createMockController())
+    engine.global.set('__audio_assets_start', audioStart)
+    // Override __canvas_start to track ordering
+    engine.global.set('__canvas_start', canvasStart)
+
+    await engine.doString(`
+      local canvas = require('canvas')
+      canvas.start()
+    `)
+
+    expect(audioStart).toHaveBeenCalledTimes(1)
+    expect(canvasStart).toHaveBeenCalledTimes(1)
+    expect(order).toEqual([
+      'audio_start_called',
+      'audio_start_resolved',
+      'canvas_start_called',
+    ])
+  })
+
+  it('canvas.start does not error when __audio_assets_start is absent', async () => {
+    setupCanvasAPI(engine, () => createMockController())
+    // Intentionally do NOT set __audio_assets_start
+    engine.global.set('__canvas_start', () => Promise.resolve())
+
+    await expect(
+      engine.doString(`
+        local canvas = require('canvas')
+        canvas.start()
+      `)
+    ).resolves.not.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary

- Games that register audio through `canvas.assets.add_path` / `load_sound` / `load_music` went silent after the standalone `ail_audio` split: the path registered with the canvas `AssetManager`, the audio assets went to the `AudioAssetManager`, and nothing started the latter. `canvas.start()` only drove the former, so `channel_play` had no decoded buffers and silently no-oped (`__audio_channelPlay` early-returns at `if (!audioEngine) return;`).
- `_canvas.start` now `:await()`s `__audio_assets_start()` when registered, before `__canvas_start()`, so audio buffers are decoded before the game loop begins.
- `_canvas.assets.add_path` mirrors the path to `__audio_assets_addPath` when registered, so `AudioAssetManager` has somewhere to scan.
- Both changes are guarded (`if __audio_assets_start then …`) so standalone canvas contexts without the audio module preloaded still work.
- Regenerated `packages/export/src/runtime/canvas-inline.generated.ts` so single-file HTML exports stay in sync (the new guards are harmless there — `__audio_assets_addPath` is a no-op in exports and `__audio_assets_start` waits on already-resolved promises).

### Repro

Imported `student-knightmare.zip` (a Knightmare-era platformer built against a prior Adventures in Lua). Runs without errors but produces no music and no SFX — exactly matching the lifecycle analysis above. With this fix applied, title-screen music and all SFX play correctly.

### Why not the alternatives

- **Re-route `canvas.assets.load_sound/load_music` back to the canvas `AssetManager`** — would drop the `AudioAssetManager` for canvas games, reintroducing the duplication that `9903f63` intentionally removed.
- **Give `CanvasController` a reference to `AudioAssetManager`** — cleaner separation but requires plumbing through `LuaReplProcess`, `LuaScriptProcess`, tests, and exports. Larger surface for the same runtime behavior.
- **Tell users to call `audio.start()` manually** — pre-existing games can't be modified; the fix needs to be in the runtime.

## Test plan

- [x] New `tests/canvasLuaCode.audioLifecycle.test.ts` (4 tests): path mirroring, path-guard safety, start ordering, start-guard safety — all pass.
- [x] Existing audio tests pass together: `CanvasController.audio` + `setupAudioAPI` + `AssetManager` + new lifecycle = 103/103.
- [x] Full lua-runtime + export CI (87 files, 1724 tests) passes via the pre-push hook.
- [x] Lint: 0 errors (145 pre-existing warnings unchanged). `core.ts` was at the 400-line lint budget — guards were compacted to one-liners to stay within it.
- [ ] Manual smoke: load the Knightmare project in the editor and confirm music/SFX play. (Performed locally; should be re-verified in reviewer's env.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)