### PR TITLE
feat(ansi-editor): configurable eyedropper modifier + tabbed File Options

### DIFF
--- a/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiEditorToolbar.tsx
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiEditorToolbar.tsx
@@ -1,8 +1,8 @@
 import { useRef, useState } from 'react'
-import type { BrushMode, DrawTool, BrushSettings, BorderStyle, TextAlign, ScaleMode } from './types'
-import { BORDER_PRESETS, DEFAULT_BLEND_RATIO, borderStyleEqual } from './types'
+import { BORDER_PRESETS, DEFAULT_BLEND_RATIO, borderStyleEqual, type BrushMode, type DrawTool, type BrushSettings, type BorderStyle, type TextAlign, type ScaleMode } from './types'
 import { CharPaletteModal } from './CharPaletteModal'
 import { FileOptionsModal } from './FileOptionsModal'
+import { DEFAULT_EYEDROPPER_MODIFIER, type EyedropperModifier } from './eyedropperModifierPersistence'
 import { toolTooltip, tooltipWithShortcut, MODE_SHORTCUTS, ACTION_SHORTCUTS } from './keyboardShortcuts'
 import styles from './AnsiGraphicsEditor.module.css'
 
@@ -56,6 +56,8 @@ export interface AnsiEditorToolbarProps {
   dprCompensate?: boolean
   /** Toggle crisp-pixel mode. */
   onSetDprCompensate?: (enabled: boolean) => void
+  eyedropperModifier?: EyedropperModifier
+  onSetEyedropperModifier?: (modifier: EyedropperModifier) => void
   activeLayerIsGroup?: boolean
   isPlaying?: boolean
   fileMenuOpen?: boolean
@@ -65,7 +67,7 @@ export interface AnsiEditorToolbarProps {
 export function AnsiEditorToolbar({
   brush, onSetChar, onSetMode, onSetTool, onClear, onSave, onSaveAs,
   onImportPng, onImportLayers, onExportAns, onExportDosAns, onExportSh, onExportBat, onExportLayers, onUndo, onRedo, canUndo, canRedo, textAlign, onSetTextAlign,
-  onFlipHorizontal, onFlipVertical, onFlipLayerHorizontal, onFlipLayerVertical, flipOrigin, onSetBorderStyle, onSetBlendRatio, cgaPreview, onToggleCgaPreview, scaleMode, onSetScaleMode, cols, rows, onResizeCanvas, font, onSetFont, useFontBlocks, onSetUseFontBlocks, dprCompensate, onSetDprCompensate, activeLayerIsGroup, isPlaying,
+  onFlipHorizontal, onFlipVertical, onFlipLayerHorizontal, onFlipLayerVertical, flipOrigin, onSetBorderStyle, onSetBlendRatio, cgaPreview, onToggleCgaPreview, scaleMode, onSetScaleMode, cols, rows, onResizeCanvas, font, onSetFont, useFontBlocks, onSetUseFontBlocks, dprCompensate, onSetDprCompensate, eyedropperModifier, onSetEyedropperModifier, activeLayerIsGroup, isPlaying,
   fileMenuOpen: controlledFileMenuOpen, onSetFileMenuOpen,
 }: AnsiEditorToolbarProps) {
   const toolsDisabled = activeLayerIsGroup || isPlaying
@@ -89,25 +91,18 @@ export function AnsiEditorToolbar({
       {fileOptionsOpen && (
         <FileOptionsModal
           onClose={() => setFileOptionsOpen(false)}
-          onClear={onClear}
-          onSave={onSave}
-          onSaveAs={onSaveAs}
+          onClear={onClear} onSave={onSave} onSaveAs={onSaveAs}
           onImportPng={onImportPng} onImportLayers={onImportLayers}
           onExportAns={onExportAns} onExportDosAns={onExportDosAns} onExportSh={onExportSh}
           onExportBat={onExportBat} onExportLayers={onExportLayers}
-          cgaPreview={cgaPreview ?? false}
-          onToggleCgaPreview={onToggleCgaPreview!}
-          scaleMode={scaleMode ?? 'integer-auto'}
-          onSetScaleMode={onSetScaleMode!}
-          cols={cols ?? 80}
-          rows={rows ?? 25}
-          onResizeCanvas={onResizeCanvas ?? (() => {})}
-          font={font ?? 'IBM_VGA_8x16'}
-          onSetFont={onSetFont ?? (() => {})}
-          useFontBlocks={useFontBlocks ?? true}
-          onSetUseFontBlocks={onSetUseFontBlocks ?? (() => {})}
-          dprCompensate={dprCompensate ?? false}
-          onSetDprCompensate={onSetDprCompensate ?? (() => {})}
+          cgaPreview={cgaPreview ?? false} onToggleCgaPreview={onToggleCgaPreview!}
+          scaleMode={scaleMode ?? 'integer-auto'} onSetScaleMode={onSetScaleMode!}
+          cols={cols ?? 80} rows={rows ?? 25} onResizeCanvas={onResizeCanvas ?? (() => {})}
+          font={font ?? 'IBM_VGA_8x16'} onSetFont={onSetFont ?? (() => {})}
+          useFontBlocks={useFontBlocks ?? true} onSetUseFontBlocks={onSetUseFontBlocks ?? (() => {})}
+          dprCompensate={dprCompensate ?? false} onSetDprCompensate={onSetDprCompensate ?? (() => {})}
+          eyedropperModifier={eyedropperModifier ?? DEFAULT_EYEDROPPER_MODIFIER}
+          onSetEyedropperModifier={onSetEyedropperModifier ?? (() => {})}
         />
       )}
       <div className={styles.modeGroup}>

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.module.css
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.module.css
@@ -1265,23 +1265,27 @@
   background-color: var(--theme-accent-primary, #0078d4);
 }
 
-/* File Options Modal */
+/* File Options Modal.
+ * Overlay is transparent so the canvas remains visible while toggling
+ * view settings (e.g. CGA Preview). Dialog sits at a fixed top-left
+ * position so it doesn't cover the canvas center and doesn't shift
+ * around when tabs are switched. */
 .fileOptionsOverlay {
   position: fixed;
   inset: 0;
-  background-color: rgba(0, 0, 0, 0.5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  background-color: transparent;
   z-index: 1000;
 }
 
 .fileOptionsDialog {
+  position: fixed;
+  top: 48px;
+  left: 16px;
+  width: 300px;
   background-color: var(--theme-bg-secondary);
   border: 1px solid var(--theme-border);
   border-radius: 6px;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
-  min-width: 220px;
   outline: none;
 }
 
@@ -1317,6 +1321,9 @@
   flex-direction: column;
   gap: 6px;
   padding: 8px 16px 16px;
+  /* Sized to fit the tallest tab (File) so the modal does not resize
+   * when switching between tabs. */
+  min-height: 360px;
 }
 
 .crtTabContent {

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.module.css
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.module.css
@@ -1362,6 +1362,15 @@
   width: 4em;
 }
 
+/* Muted help text shown under a control (e.g. the Input tab's eyedropper hint). */
+.fileOptionsHelp {
+  margin: 0;
+  padding: 0 2px;
+  font-size: 11px;
+  color: var(--theme-text-secondary);
+  line-height: 1.4;
+}
+
 /* ---- Toast Notifications ---- */
 
 .toastContainer {

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.tsx
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.tsx
@@ -8,6 +8,11 @@ import {
   loadStoredDprCompensate,
   saveStoredDprCompensate,
 } from './scaleModePersistence'
+import {
+  loadStoredEyedropperModifier,
+  saveStoredEyedropperModifier,
+  type EyedropperModifier,
+} from './eyedropperModifierPersistence'
 import { ConfirmDialog } from '../ConfirmDialog'
 import { useIDE } from '../IDEContext/useIDE'
 import { AnsiEditorToolbar } from './AnsiEditorToolbar'
@@ -49,6 +54,11 @@ export function AnsiGraphicsEditor({ filePath, onDirtyChange, isActive }: AnsiGr
   const setDprCompensate = useCallback((flag: boolean) => {
     setDprCompensateRaw(flag)
     saveStoredDprCompensate(flag)
+  }, [])
+  const [eyedropperModifier, setEyedropperModifierRaw] = useState<EyedropperModifier>(() => loadStoredEyedropperModifier())
+  const setEyedropperModifier = useCallback((modifier: EyedropperModifier) => {
+    setEyedropperModifierRaw(modifier)
+    saveStoredEyedropperModifier(modifier)
   }, [])
 
   const { toasts, showToast } = useToast()
@@ -169,6 +179,7 @@ export function AnsiGraphicsEditor({ filePath, onDirtyChange, isActive }: AnsiGr
     onOpenFileMenu: () => handleOpenFileMenuRef.current(),
     onShowToast: showToast,
     isActive,
+    eyedropperModifier,
   })
 
   closeSaveDialogRef.current = closeSaveDialog
@@ -348,6 +359,8 @@ export function AnsiGraphicsEditor({ filePath, onDirtyChange, isActive }: AnsiGr
         onSetUseFontBlocks={setUseFontBlocks}
         dprCompensate={dprCompensate}
         onSetDprCompensate={setDprCompensate}
+        eyedropperModifier={eyedropperModifier}
+        onSetEyedropperModifier={setEyedropperModifier}
         activeLayerIsGroup={activeLayerIsGroup}
         isPlaying={isPlaying}
         fileMenuOpen={fileMenuOpen}

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/FileOptionsModal.test.tsx
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/FileOptionsModal.test.tsx
@@ -28,8 +28,14 @@ function defaultProps(overrides?: Partial<FileOptionsModalProps>): FileOptionsMo
     onSetUseFontBlocks: vi.fn(),
     dprCompensate: false,
     onSetDprCompensate: vi.fn(),
+    eyedropperModifier: 'ctrl',
+    onSetEyedropperModifier: vi.fn(),
     ...overrides,
   }
+}
+
+function selectTab(id: 'file' | 'canvas' | 'input'): void {
+  fireEvent.click(screen.getByTestId(`file-options-tab-${id}`))
 }
 
 describe('FileOptionsModal', () => {
@@ -40,77 +46,168 @@ describe('FileOptionsModal', () => {
     expect(dialog.getAttribute('aria-modal')).toBe('true')
   })
 
-  it.each([
-    ['onSave', 'file-save'],
-    ['onSaveAs', 'file-save-as'],
-    ['onClear', 'file-clear'],
-    ['onImportPng', 'file-import-png'],
-    ['onImportLayers', 'file-import-layers'],
-    ['onExportAns', 'file-export-ans'],
-    ['onExportDosAns', 'file-export-dos-ans'],
-    ['onExportSh', 'file-export-sh'],
-    ['onExportBat', 'file-export-bat'],
-    ['onExportLayers', 'file-export-layers'],
-  ] as const)('fires %s and onClose when %s is clicked', (handlerName, testId) => {
-    const handler = vi.fn()
-    const onClose = vi.fn()
-    render(<FileOptionsModal {...defaultProps({ [handlerName]: handler, onClose })} />)
-    fireEvent.click(screen.getByTestId(testId))
-    expect(handler).toHaveBeenCalledOnce()
-    expect(onClose).toHaveBeenCalledOnce()
+  describe('tabs', () => {
+    it('renders File / Canvas / Input tabs', () => {
+      render(<FileOptionsModal {...defaultProps()} />)
+      expect(screen.getByTestId('file-options-tab-file')).toBeTruthy()
+      expect(screen.getByTestId('file-options-tab-canvas')).toBeTruthy()
+      expect(screen.getByTestId('file-options-tab-input')).toBeTruthy()
+    })
+
+    it('defaults to the File tab and shows File-tab content', () => {
+      render(<FileOptionsModal {...defaultProps()} />)
+      expect(screen.getByTestId('file-options-tab-file').getAttribute('aria-selected')).toBe('true')
+      expect(screen.getByTestId('file-save')).toBeTruthy()
+      expect(screen.queryByTestId('file-cga-preview')).toBeNull()
+      expect(screen.queryByTestId('file-eyedropper-modifier')).toBeNull()
+    })
+
+    it('switches to Canvas tab content on click', () => {
+      render(<FileOptionsModal {...defaultProps()} />)
+      selectTab('canvas')
+      expect(screen.getByTestId('file-options-tab-canvas').getAttribute('aria-selected')).toBe('true')
+      expect(screen.getByTestId('file-cga-preview')).toBeTruthy()
+      expect(screen.getByTestId('file-scale-mode')).toBeTruthy()
+      expect(screen.getByTestId('file-resize-apply')).toBeTruthy()
+      expect(screen.queryByTestId('file-save')).toBeNull()
+      expect(screen.queryByTestId('file-eyedropper-modifier')).toBeNull()
+    })
+
+    it('switches to Input tab content on click', () => {
+      render(<FileOptionsModal {...defaultProps()} />)
+      selectTab('input')
+      expect(screen.getByTestId('file-options-tab-input').getAttribute('aria-selected')).toBe('true')
+      expect(screen.getByTestId('file-eyedropper-modifier')).toBeTruthy()
+      expect(screen.queryByTestId('file-save')).toBeNull()
+      expect(screen.queryByTestId('file-cga-preview')).toBeNull()
+    })
   })
 
-  it('reflects cgaPreview state on the checkbox', () => {
-    const { rerender } = render(<FileOptionsModal {...defaultProps({ cgaPreview: false })} />)
-    const checkbox = screen.getByTestId('file-cga-preview') as HTMLInputElement
-    expect(checkbox.checked).toBe(false)
-
-    rerender(<FileOptionsModal {...defaultProps({ cgaPreview: true })} />)
-    expect(checkbox.checked).toBe(true)
+  describe('File tab actions', () => {
+    it.each([
+      ['onSave', 'file-save'],
+      ['onSaveAs', 'file-save-as'],
+      ['onImportPng', 'file-import-png'],
+      ['onImportLayers', 'file-import-layers'],
+      ['onExportAns', 'file-export-ans'],
+      ['onExportDosAns', 'file-export-dos-ans'],
+      ['onExportSh', 'file-export-sh'],
+      ['onExportBat', 'file-export-bat'],
+      ['onExportLayers', 'file-export-layers'],
+    ] as const)('fires %s and onClose when %s is clicked', (handlerName, testId) => {
+      const handler = vi.fn()
+      const onClose = vi.fn()
+      render(<FileOptionsModal {...defaultProps({ [handlerName]: handler, onClose })} />)
+      fireEvent.click(screen.getByTestId(testId))
+      expect(handler).toHaveBeenCalledOnce()
+      expect(onClose).toHaveBeenCalledOnce()
+    })
   })
 
-  it('calls onToggleCgaPreview on checkbox change but does NOT close modal', () => {
-    const onToggleCgaPreview = vi.fn()
-    const onClose = vi.fn()
-    render(<FileOptionsModal {...defaultProps({ onToggleCgaPreview, onClose })} />)
-    fireEvent.click(screen.getByTestId('file-cga-preview'))
-    expect(onToggleCgaPreview).toHaveBeenCalledOnce()
-    expect(onClose).not.toHaveBeenCalled()
+  describe('Canvas tab', () => {
+    it('fires onClear and onClose when Clear is clicked', () => {
+      const onClear = vi.fn()
+      const onClose = vi.fn()
+      render(<FileOptionsModal {...defaultProps({ onClear, onClose })} />)
+      selectTab('canvas')
+      fireEvent.click(screen.getByTestId('file-clear'))
+      expect(onClear).toHaveBeenCalledOnce()
+      expect(onClose).toHaveBeenCalledOnce()
+    })
+
+    it('reflects cgaPreview state on the checkbox', () => {
+      const { rerender } = render(<FileOptionsModal {...defaultProps({ cgaPreview: false })} />)
+      selectTab('canvas')
+      const checkbox = screen.getByTestId('file-cga-preview') as HTMLInputElement
+      expect(checkbox.checked).toBe(false)
+
+      rerender(<FileOptionsModal {...defaultProps({ cgaPreview: true })} />)
+      selectTab('canvas')
+      const checkbox2 = screen.getByTestId('file-cga-preview') as HTMLInputElement
+      expect(checkbox2.checked).toBe(true)
+    })
+
+    it('calls onToggleCgaPreview on checkbox change but does NOT close modal', () => {
+      const onToggleCgaPreview = vi.fn()
+      const onClose = vi.fn()
+      render(<FileOptionsModal {...defaultProps({ onToggleCgaPreview, onClose })} />)
+      selectTab('canvas')
+      fireEvent.click(screen.getByTestId('file-cga-preview'))
+      expect(onToggleCgaPreview).toHaveBeenCalledOnce()
+      expect(onClose).not.toHaveBeenCalled()
+    })
+
+    it('renders scale mode select with correct initial value', () => {
+      render(<FileOptionsModal {...defaultProps({ scaleMode: 'fit' })} />)
+      selectTab('canvas')
+      const select = screen.getByTestId('file-scale-mode') as HTMLSelectElement
+      expect(select.value).toBe('fit')
+    })
+
+    it('calls onSetScaleMode on change and does NOT close modal', () => {
+      const onSetScaleMode = vi.fn()
+      const onClose = vi.fn()
+      render(<FileOptionsModal {...defaultProps({ onSetScaleMode, onClose })} />)
+      selectTab('canvas')
+      fireEvent.change(screen.getByTestId('file-scale-mode'), { target: { value: 'integer-2x' } })
+      expect(onSetScaleMode).toHaveBeenCalledWith('integer-2x')
+      expect(onClose).not.toHaveBeenCalled()
+    })
   })
 
-  it('calls onClose when backdrop is clicked', () => {
-    const onClose = vi.fn()
-    render(<FileOptionsModal {...defaultProps({ onClose })} />)
-    fireEvent.click(screen.getByTestId('file-options-overlay'))
-    expect(onClose).toHaveBeenCalledOnce()
+  describe('Input tab', () => {
+    it('renders the eyedropper modifier select with the current value', () => {
+      render(<FileOptionsModal {...defaultProps({ eyedropperModifier: 'shift' })} />)
+      selectTab('input')
+      const select = screen.getByTestId('file-eyedropper-modifier') as HTMLSelectElement
+      expect(select.value).toBe('shift')
+    })
+
+    it('offers ctrl/shift/alt/meta options', () => {
+      render(<FileOptionsModal {...defaultProps()} />)
+      selectTab('input')
+      const select = screen.getByTestId('file-eyedropper-modifier') as HTMLSelectElement
+      const values = Array.from(select.options).map(o => o.value)
+      expect(values).toEqual(['ctrl', 'shift', 'alt', 'meta'])
+    })
+
+    it('calls onSetEyedropperModifier on change and does NOT close the modal', () => {
+      const onSetEyedropperModifier = vi.fn()
+      const onClose = vi.fn()
+      render(<FileOptionsModal {...defaultProps({ onSetEyedropperModifier, onClose })} />)
+      selectTab('input')
+      fireEvent.change(screen.getByTestId('file-eyedropper-modifier'), { target: { value: 'alt' } })
+      expect(onSetEyedropperModifier).toHaveBeenCalledWith('alt')
+      expect(onClose).not.toHaveBeenCalled()
+    })
+
+    it('shows helper text explaining the behavior', () => {
+      render(<FileOptionsModal {...defaultProps()} />)
+      selectTab('input')
+      expect(screen.getByTestId('file-eyedropper-modifier-help')).toBeTruthy()
+    })
   })
 
-  it('does not close when dialog body is clicked', () => {
-    const onClose = vi.fn()
-    render(<FileOptionsModal {...defaultProps({ onClose })} />)
-    fireEvent.click(screen.getByRole('dialog'))
-    expect(onClose).not.toHaveBeenCalled()
-  })
+  describe('overlay and keyboard', () => {
+    it('calls onClose when backdrop is clicked', () => {
+      const onClose = vi.fn()
+      render(<FileOptionsModal {...defaultProps({ onClose })} />)
+      fireEvent.click(screen.getByTestId('file-options-overlay'))
+      expect(onClose).toHaveBeenCalledOnce()
+    })
 
-  it('calls onClose when Escape key is pressed', () => {
-    const onClose = vi.fn()
-    render(<FileOptionsModal {...defaultProps({ onClose })} />)
-    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' })
-    expect(onClose).toHaveBeenCalledOnce()
-  })
+    it('does not close when dialog body is clicked', () => {
+      const onClose = vi.fn()
+      render(<FileOptionsModal {...defaultProps({ onClose })} />)
+      fireEvent.click(screen.getByRole('dialog'))
+      expect(onClose).not.toHaveBeenCalled()
+    })
 
-  it('renders scale mode select with correct initial value', () => {
-    render(<FileOptionsModal {...defaultProps({ scaleMode: 'fit' })} />)
-    const select = screen.getByTestId('file-scale-mode') as HTMLSelectElement
-    expect(select.value).toBe('fit')
-  })
-
-  it('calls onSetScaleMode on change and does NOT close modal', () => {
-    const onSetScaleMode = vi.fn()
-    const onClose = vi.fn()
-    render(<FileOptionsModal {...defaultProps({ onSetScaleMode, onClose })} />)
-    fireEvent.change(screen.getByTestId('file-scale-mode'), { target: { value: 'integer-2x' } })
-    expect(onSetScaleMode).toHaveBeenCalledWith('integer-2x')
-    expect(onClose).not.toHaveBeenCalled()
+    it('calls onClose when Escape key is pressed', () => {
+      const onClose = vi.fn()
+      render(<FileOptionsModal {...defaultProps({ onClose })} />)
+      fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' })
+      expect(onClose).toHaveBeenCalledOnce()
+    })
   })
 })

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/FileOptionsModal.tsx
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/FileOptionsModal.tsx
@@ -1,7 +1,8 @@
-import { useState, type KeyboardEvent } from 'react'
+import { useState, type KeyboardEvent, type ReactNode } from 'react'
 import type { ScaleMode } from './types'
 import { tooltipWithShortcut, ACTION_SHORTCUTS } from './keyboardShortcuts'
 import { BITMAP_FONT_REGISTRY } from '@lua-learning/lua-runtime'
+import type { EyedropperModifier } from './eyedropperModifierPersistence'
 import styles from './AnsiGraphicsEditor.module.css'
 
 export interface FileOptionsModalProps {
@@ -38,6 +39,10 @@ export interface FileOptionsModalProps {
   dprCompensate: boolean
   /** Toggle crisp-pixel mode. */
   onSetDprCompensate: (enabled: boolean) => void
+  /** Modifier key that enables click-to-sample-color outside the eyedropper tool. */
+  eyedropperModifier: EyedropperModifier
+  /** Update the eyedropper modifier preference. */
+  onSetEyedropperModifier: (modifier: EyedropperModifier) => void
 }
 
 interface ActionItem {
@@ -46,63 +51,30 @@ interface ActionItem {
   action: () => void
 }
 
-export function FileOptionsModal({
-  onClose,
-  onClear,
-  onSave,
-  onSaveAs,
-  onImportPng,
-  onImportLayers,
-  onExportAns,
-  onExportDosAns,
-  onExportSh,
-  onExportBat,
-  onExportLayers,
-  cgaPreview,
-  onToggleCgaPreview,
-  scaleMode,
-  onSetScaleMode,
-  cols,
-  rows,
-  onResizeCanvas,
-  font,
-  onSetFont,
-  useFontBlocks,
-  onSetUseFontBlocks,
-  dprCompensate,
-  onSetDprCompensate,
-}: FileOptionsModalProps) {
-  const [nextCols, setNextCols] = useState<string>(String(cols))
-  const [nextRows, setNextRows] = useState<string>(String(rows))
-  const parsedCols = Number.parseInt(nextCols, 10)
-  const parsedRows = Number.parseInt(nextRows, 10)
-  const dimsValid =
-    Number.isFinite(parsedCols) && parsedCols >= 1 && parsedCols <= 240 &&
-    Number.isFinite(parsedRows) && parsedRows >= 1 && parsedRows <= 100
-  const dimsChanged = parsedCols !== cols || parsedRows !== rows
+type TabId = 'file' | 'canvas' | 'input'
+
+interface Tab {
+  id: TabId
+  label: string
+  testId: string
+}
+
+const TABS: readonly Tab[] = [
+  { id: 'file', label: 'File', testId: 'file-options-tab-file' },
+  { id: 'canvas', label: 'Canvas', testId: 'file-options-tab-canvas' },
+  { id: 'input', label: 'Input', testId: 'file-options-tab-input' },
+]
+
+export function FileOptionsModal(props: FileOptionsModalProps) {
+  const { onClose } = props
+  const [activeTab, setActiveTab] = useState<TabId>('file')
+
   function handleKeyDown(event: KeyboardEvent): void {
     if (event.key === 'Escape') {
       event.preventDefault()
       onClose()
     }
   }
-
-  function handleAction(action: () => void): void {
-    action()
-    onClose()
-  }
-
-  const actions: ActionItem[] = [
-    { label: tooltipWithShortcut('Save', ACTION_SHORTCUTS.save), testId: 'file-save', action: onSave },
-    { label: tooltipWithShortcut('Save As', ACTION_SHORTCUTS.saveAs), testId: 'file-save-as', action: onSaveAs },
-    { label: 'Load PNG', testId: 'file-import-png', action: onImportPng },
-    { label: 'Import Layers', testId: 'file-import-layers', action: onImportLayers },
-    { label: 'Export Layers', testId: 'file-export-layers', action: onExportLayers },
-    { label: 'Export ANS', testId: 'file-export-ans', action: onExportAns },
-    { label: 'Export ANS (DOS)', testId: 'file-export-dos-ans', action: onExportDosAns },
-    { label: 'Export .sh', testId: 'file-export-sh', action: onExportSh },
-    { label: 'Export .bat', testId: 'file-export-bat', action: onExportBat },
-  ]
 
   return (
     <div
@@ -128,119 +100,223 @@ export function FileOptionsModal({
             ✕
           </button>
         </div>
-        <div className={styles.fileOptionsBody}>
-          {actions.map(({ label, testId, action }) => (
+        <div className={styles.charPaletteTabs} role="tablist" data-testid="file-options-tabs">
+          {TABS.map(tab => (
             <button
-              key={testId}
+              key={tab.id}
               type="button"
-              className={styles.fileOptionsAction}
-              onClick={() => handleAction(action)}
-              data-testid={testId}
+              role="tab"
+              aria-selected={activeTab === tab.id}
+              className={`${styles.paletteSelectorBtn} ${activeTab === tab.id ? styles.paletteSelectorBtnActive : ''}`}
+              onClick={() => setActiveTab(tab.id)}
+              data-testid={tab.testId}
             >
-              {label}
+              {tab.label}
             </button>
           ))}
-          <label className={styles.fileOptionsAction}>
-            <input
-              type="checkbox"
-              checked={cgaPreview}
-              onChange={onToggleCgaPreview}
-              data-testid="file-cga-preview"
-            />
-            CGA Preview
-          </label>
-          <label className={styles.fileOptionsAction}>
-            Font:
-            <select
-              value={font}
-              onChange={e => onSetFont(e.target.value)}
-              data-testid="file-font"
-              className={styles.fileOptionsSelect}
-            >
-              {BITMAP_FONT_REGISTRY.map(f => (
-                <option key={f.id} value={f.id}>
-                  {f.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className={styles.fileOptionsAction}>
-            <input
-              type="checkbox"
-              checked={useFontBlocks}
-              onChange={e => onSetUseFontBlocks(e.target.checked)}
-              data-testid="file-use-font-blocks"
-            />
-            Use pixel renderer (font blocks)
-          </label>
-          <label className={styles.fileOptionsAction}>
-            Scale:
-            <select
-              value={scaleMode}
-              onChange={e => onSetScaleMode(e.target.value as ScaleMode)}
-              data-testid="file-scale-mode"
-              className={styles.fileOptionsSelect}
-            >
-              <option value="integer-auto">Integer Auto</option>
-              <option value="integer-1x">Integer 1x</option>
-              <option value="integer-2x">Integer 2x</option>
-              <option value="integer-3x">Integer 3x</option>
-              <option value="fit">Fit</option>
-              <option value="fill">Fill</option>
-            </select>
-          </label>
-          <label className={styles.fileOptionsAction} title="Snap the scale up to a multiple where scale × DPR is integer, eliminating the 1-2-1-2 pixel pattern on fractional-DPR displays. May render larger than the selected scale.">
-            <input
-              type="checkbox"
-              checked={dprCompensate}
-              onChange={e => onSetDprCompensate(e.target.checked)}
-              data-testid="file-dpr-compensate"
-            />
-            Emulate Pixel Perfect on HiDPI
-          </label>
-          <button
-            type="button"
-            className={styles.fileOptionsAction}
-            onClick={() => handleAction(onClear)}
-            data-testid="file-clear"
-          >
-            Clear
-          </button>
-          <div className={styles.fileOptionsAction} data-testid="file-resize-canvas-group">
-            <span>Canvas size:</span>
-            <input
-              type="number"
-              min={1}
-              max={240}
-              value={nextCols}
-              onChange={e => setNextCols(e.target.value)}
-              data-testid="file-resize-cols"
-              aria-label="Canvas width in columns"
-              className={`${styles.fileOptionsSelect} ${styles.fileOptionsNumberInput}`}
-            />
-            <span>×</span>
-            <input
-              type="number"
-              min={1}
-              max={100}
-              value={nextRows}
-              onChange={e => setNextRows(e.target.value)}
-              data-testid="file-resize-rows"
-              aria-label="Canvas height in rows"
-              className={`${styles.fileOptionsSelect} ${styles.fileOptionsNumberInput}`}
-            />
-            <button
-              type="button"
-              className={styles.fileOptionsAction}
-              onClick={() => { if (dimsValid && dimsChanged) handleAction(() => onResizeCanvas(parsedCols, parsedRows)) }}
-              disabled={!dimsValid || !dimsChanged}
-              data-testid="file-resize-apply"
-            >
-              Resize
-            </button>
-          </div>
+        </div>
+        <div className={styles.fileOptionsBody}>
+          {activeTab === 'file' && <FileTab {...props} />}
+          {activeTab === 'canvas' && <CanvasTab {...props} />}
+          {activeTab === 'input' && <InputTab {...props} />}
         </div>
       </div>
     </div>
+  )
+}
+
+function FileTab(props: FileOptionsModalProps): ReactNode {
+  const { onClose, onSave, onSaveAs, onImportPng, onImportLayers, onExportLayers, onExportAns, onExportDosAns, onExportSh, onExportBat } = props
+
+  function handleAction(action: () => void): void {
+    action()
+    onClose()
+  }
+
+  const actions: ActionItem[] = [
+    { label: tooltipWithShortcut('Save', ACTION_SHORTCUTS.save), testId: 'file-save', action: onSave },
+    { label: tooltipWithShortcut('Save As', ACTION_SHORTCUTS.saveAs), testId: 'file-save-as', action: onSaveAs },
+    { label: 'Load PNG', testId: 'file-import-png', action: onImportPng },
+    { label: 'Import Layers', testId: 'file-import-layers', action: onImportLayers },
+    { label: 'Export Layers', testId: 'file-export-layers', action: onExportLayers },
+    { label: 'Export ANS', testId: 'file-export-ans', action: onExportAns },
+    { label: 'Export ANS (DOS)', testId: 'file-export-dos-ans', action: onExportDosAns },
+    { label: 'Export .sh', testId: 'file-export-sh', action: onExportSh },
+    { label: 'Export .bat', testId: 'file-export-bat', action: onExportBat },
+  ]
+
+  return (
+    <>
+      {actions.map(({ label, testId, action }) => (
+        <button
+          key={testId}
+          type="button"
+          className={styles.fileOptionsAction}
+          onClick={() => handleAction(action)}
+          data-testid={testId}
+        >
+          {label}
+        </button>
+      ))}
+    </>
+  )
+}
+
+function CanvasTab(props: FileOptionsModalProps): ReactNode {
+  const {
+    onClose, onClear,
+    cgaPreview, onToggleCgaPreview,
+    scaleMode, onSetScaleMode,
+    cols, rows, onResizeCanvas,
+    font, onSetFont,
+    useFontBlocks, onSetUseFontBlocks,
+    dprCompensate, onSetDprCompensate,
+  } = props
+
+  const [nextCols, setNextCols] = useState<string>(String(cols))
+  const [nextRows, setNextRows] = useState<string>(String(rows))
+  const parsedCols = Number.parseInt(nextCols, 10)
+  const parsedRows = Number.parseInt(nextRows, 10)
+  const dimsValid =
+    Number.isFinite(parsedCols) && parsedCols >= 1 && parsedCols <= 240 &&
+    Number.isFinite(parsedRows) && parsedRows >= 1 && parsedRows <= 100
+  const dimsChanged = parsedCols !== cols || parsedRows !== rows
+
+  function handleAction(action: () => void): void {
+    action()
+    onClose()
+  }
+
+  return (
+    <>
+      <label className={styles.fileOptionsAction}>
+        <input
+          type="checkbox"
+          checked={cgaPreview}
+          onChange={onToggleCgaPreview}
+          data-testid="file-cga-preview"
+        />
+        CGA Preview
+      </label>
+      <label className={styles.fileOptionsAction}>
+        Font:
+        <select
+          value={font}
+          onChange={e => onSetFont(e.target.value)}
+          data-testid="file-font"
+          className={styles.fileOptionsSelect}
+        >
+          {BITMAP_FONT_REGISTRY.map(f => (
+            <option key={f.id} value={f.id}>
+              {f.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className={styles.fileOptionsAction}>
+        <input
+          type="checkbox"
+          checked={useFontBlocks}
+          onChange={e => onSetUseFontBlocks(e.target.checked)}
+          data-testid="file-use-font-blocks"
+        />
+        Use pixel renderer (font blocks)
+      </label>
+      <label className={styles.fileOptionsAction}>
+        Scale:
+        <select
+          value={scaleMode}
+          onChange={e => onSetScaleMode(e.target.value as ScaleMode)}
+          data-testid="file-scale-mode"
+          className={styles.fileOptionsSelect}
+        >
+          <option value="integer-auto">Integer Auto</option>
+          <option value="integer-1x">Integer 1x</option>
+          <option value="integer-2x">Integer 2x</option>
+          <option value="integer-3x">Integer 3x</option>
+          <option value="fit">Fit</option>
+          <option value="fill">Fill</option>
+        </select>
+      </label>
+      <label className={styles.fileOptionsAction} title="Snap the scale up to a multiple where scale × DPR is integer, eliminating the 1-2-1-2 pixel pattern on fractional-DPR displays. May render larger than the selected scale.">
+        <input
+          type="checkbox"
+          checked={dprCompensate}
+          onChange={e => onSetDprCompensate(e.target.checked)}
+          data-testid="file-dpr-compensate"
+        />
+        Emulate Pixel Perfect on HiDPI
+      </label>
+      <button
+        type="button"
+        className={styles.fileOptionsAction}
+        onClick={() => handleAction(onClear)}
+        data-testid="file-clear"
+      >
+        Clear
+      </button>
+      <div className={styles.fileOptionsAction} data-testid="file-resize-canvas-group">
+        <span>Canvas size:</span>
+        <input
+          type="number"
+          min={1}
+          max={240}
+          value={nextCols}
+          onChange={e => setNextCols(e.target.value)}
+          data-testid="file-resize-cols"
+          aria-label="Canvas width in columns"
+          className={`${styles.fileOptionsSelect} ${styles.fileOptionsNumberInput}`}
+        />
+        <span>×</span>
+        <input
+          type="number"
+          min={1}
+          max={100}
+          value={nextRows}
+          onChange={e => setNextRows(e.target.value)}
+          data-testid="file-resize-rows"
+          aria-label="Canvas height in rows"
+          className={`${styles.fileOptionsSelect} ${styles.fileOptionsNumberInput}`}
+        />
+        <button
+          type="button"
+          className={styles.fileOptionsAction}
+          onClick={() => { if (dimsValid && dimsChanged) handleAction(() => onResizeCanvas(parsedCols, parsedRows)) }}
+          disabled={!dimsValid || !dimsChanged}
+          data-testid="file-resize-apply"
+        >
+          Resize
+        </button>
+      </div>
+    </>
+  )
+}
+
+function InputTab(props: FileOptionsModalProps): ReactNode {
+  const { eyedropperModifier, onSetEyedropperModifier } = props
+  return (
+    <>
+      <label
+        className={styles.fileOptionsAction}
+        title="Hold this modifier and click on the canvas to sample the foreground color; right-click samples the background color."
+      >
+        Eyedropper modifier:
+        <select
+          value={eyedropperModifier}
+          onChange={e => onSetEyedropperModifier(e.target.value as EyedropperModifier)}
+          data-testid="file-eyedropper-modifier"
+          className={styles.fileOptionsSelect}
+        >
+          <option value="ctrl">Ctrl</option>
+          <option value="shift">Shift</option>
+          <option value="alt">Alt</option>
+          <option value="meta">Meta (⌘ / Win)</option>
+        </select>
+      </label>
+      <p className={styles.fileOptionsHelp} data-testid="file-eyedropper-modifier-help">
+        Hold the selected modifier and click on the canvas to sample the foreground color.
+        Right-click samples the background color. Plain right-click (no modifier) always copies the character.
+      </p>
+    </>
   )
 }

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/eyedropperModifierPersistence.test.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/eyedropperModifierPersistence.test.ts
@@ -1,0 +1,153 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  DEFAULT_EYEDROPPER_MODIFIER,
+  loadStoredEyedropperModifier,
+  saveStoredEyedropperModifier,
+  isEyedropperModifierPressed,
+  eyedropperModifierLabel,
+  type EyedropperModifier,
+  type ModifierEvent,
+} from './eyedropperModifierPersistence'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('eyedropperModifierPersistence', () => {
+  it('DEFAULT_EYEDROPPER_MODIFIER is ctrl (preserves pre-existing behavior)', () => {
+    expect(DEFAULT_EYEDROPPER_MODIFIER).toBe('ctrl')
+  })
+
+  it('returns default when storage is empty', () => {
+    expect(loadStoredEyedropperModifier()).toBe('ctrl')
+  })
+
+  it('returns default for an unknown stored value (schema protection)', () => {
+    localStorage.setItem('ansi-editor:eyedropper-modifier', 'not-a-real-modifier')
+    expect(loadStoredEyedropperModifier()).toBe('ctrl')
+  })
+
+  it('returns default for empty-string stored value', () => {
+    localStorage.setItem('ansi-editor:eyedropper-modifier', '')
+    expect(loadStoredEyedropperModifier()).toBe('ctrl')
+  })
+
+  it('each valid modifier round-trips', () => {
+    const modifiers: readonly EyedropperModifier[] = ['ctrl', 'shift', 'alt', 'meta']
+    for (const m of modifiers) {
+      saveStoredEyedropperModifier(m)
+      expect(loadStoredEyedropperModifier()).toBe(m)
+    }
+  })
+
+  it('overwrites a previous value', () => {
+    saveStoredEyedropperModifier('shift')
+    saveStoredEyedropperModifier('alt')
+    expect(loadStoredEyedropperModifier()).toBe('alt')
+  })
+
+  it('writes under the stable storage key (ansi-editor:eyedropper-modifier)', () => {
+    saveStoredEyedropperModifier('shift')
+    expect(localStorage.getItem('ansi-editor:eyedropper-modifier')).toBe('shift')
+  })
+
+  it('reads from the stable storage key (independent of save round-trip)', () => {
+    localStorage.setItem('ansi-editor:eyedropper-modifier', 'meta')
+    expect(loadStoredEyedropperModifier()).toBe('meta')
+  })
+
+  it('returns default when localStorage.getItem throws', () => {
+    const original = Storage.prototype.getItem
+    Storage.prototype.getItem = () => {
+      throw new Error('blocked')
+    }
+    try {
+      expect(loadStoredEyedropperModifier()).toBe('ctrl')
+    } finally {
+      Storage.prototype.getItem = original
+    }
+  })
+
+  it('swallows localStorage.setItem errors silently', () => {
+    const original = Storage.prototype.setItem
+    Storage.prototype.setItem = () => {
+      throw new Error('quota')
+    }
+    try {
+      expect(() => saveStoredEyedropperModifier('shift')).not.toThrow()
+    } finally {
+      Storage.prototype.setItem = original
+    }
+  })
+})
+
+describe('isEyedropperModifierPressed', () => {
+  function evt(overrides: Partial<ModifierEvent> = {}): ModifierEvent {
+    return { ctrlKey: false, shiftKey: false, altKey: false, metaKey: false, ...overrides }
+  }
+
+  it('ctrl modifier matches only ctrlKey', () => {
+    expect(isEyedropperModifierPressed(evt({ ctrlKey: true }), 'ctrl')).toBe(true)
+    expect(isEyedropperModifierPressed(evt({ shiftKey: true }), 'ctrl')).toBe(false)
+    expect(isEyedropperModifierPressed(evt({ altKey: true }), 'ctrl')).toBe(false)
+    expect(isEyedropperModifierPressed(evt({ metaKey: true }), 'ctrl')).toBe(false)
+    expect(isEyedropperModifierPressed(evt(), 'ctrl')).toBe(false)
+  })
+
+  it('shift modifier matches only shiftKey', () => {
+    expect(isEyedropperModifierPressed(evt({ shiftKey: true }), 'shift')).toBe(true)
+    expect(isEyedropperModifierPressed(evt({ ctrlKey: true }), 'shift')).toBe(false)
+    expect(isEyedropperModifierPressed(evt({ altKey: true }), 'shift')).toBe(false)
+    expect(isEyedropperModifierPressed(evt({ metaKey: true }), 'shift')).toBe(false)
+  })
+
+  it('alt modifier matches only altKey', () => {
+    expect(isEyedropperModifierPressed(evt({ altKey: true }), 'alt')).toBe(true)
+    expect(isEyedropperModifierPressed(evt({ ctrlKey: true }), 'alt')).toBe(false)
+    expect(isEyedropperModifierPressed(evt({ shiftKey: true }), 'alt')).toBe(false)
+    expect(isEyedropperModifierPressed(evt({ metaKey: true }), 'alt')).toBe(false)
+  })
+
+  it('meta modifier matches only metaKey — does NOT fall back to ctrl', () => {
+    expect(isEyedropperModifierPressed(evt({ metaKey: true }), 'meta')).toBe(true)
+    expect(isEyedropperModifierPressed(evt({ ctrlKey: true }), 'meta')).toBe(false)
+    expect(isEyedropperModifierPressed(evt({ shiftKey: true }), 'meta')).toBe(false)
+    expect(isEyedropperModifierPressed(evt({ altKey: true }), 'meta')).toBe(false)
+  })
+
+  it('returns true when extra non-matching modifiers are also held', () => {
+    expect(isEyedropperModifierPressed(evt({ shiftKey: true, altKey: true }), 'shift')).toBe(true)
+  })
+})
+
+describe('eyedropperModifierLabel', () => {
+  it('returns distinct labels per modifier', () => {
+    const labels = new Set([
+      eyedropperModifierLabel('ctrl'),
+      eyedropperModifierLabel('shift'),
+      eyedropperModifierLabel('alt'),
+      eyedropperModifierLabel('meta'),
+    ])
+    expect(labels.size).toBe(4)
+  })
+
+  it('ctrl label contains "Ctrl"', () => {
+    expect(eyedropperModifierLabel('ctrl')).toContain('Ctrl')
+  })
+
+  it('shift label contains "Shift"', () => {
+    expect(eyedropperModifierLabel('shift')).toContain('Shift')
+  })
+
+  it('alt label contains "Alt"', () => {
+    expect(eyedropperModifierLabel('alt')).toContain('Alt')
+  })
+
+  it('meta label disambiguates mac/windows', () => {
+    expect(eyedropperModifierLabel('meta')).toMatch(/Meta/)
+    expect(eyedropperModifierLabel('meta')).toMatch(/⌘|Win/)
+  })
+})

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/eyedropperModifierPersistence.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/eyedropperModifierPersistence.ts
@@ -1,0 +1,77 @@
+/**
+ * The keyboard modifier that triggers eyedropper sampling when not in the
+ * eyedropper tool. Default is Ctrl to preserve prior behavior, but some users
+ * (macOS trackpad, virtual-right-click setups) need to choose a different
+ * modifier because Ctrl+click is already consumed by the OS as right-click.
+ */
+export type EyedropperModifier = 'ctrl' | 'shift' | 'alt' | 'meta'
+
+const STORAGE_KEY = 'ansi-editor:eyedropper-modifier'
+
+const VALID_MODIFIERS: ReadonlySet<EyedropperModifier> = new Set<EyedropperModifier>([
+  'ctrl',
+  'shift',
+  'alt',
+  'meta',
+])
+
+export const DEFAULT_EYEDROPPER_MODIFIER: EyedropperModifier = 'ctrl'
+
+export function loadStoredEyedropperModifier(): EyedropperModifier {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (raw && (VALID_MODIFIERS as ReadonlySet<string>).has(raw)) {
+      return raw as EyedropperModifier
+    }
+  } catch {
+    /* localStorage unavailable (privacy mode, disabled) — fall through */
+  }
+  return DEFAULT_EYEDROPPER_MODIFIER
+}
+
+export function saveStoredEyedropperModifier(modifier: EyedropperModifier): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, modifier)
+  } catch {
+    /* ignore quota / privacy-mode errors */
+  }
+}
+
+/**
+ * Subset of MouseEvent we actually read — keeps unit tests free of
+ * full DOM MouseEvent construction.
+ */
+export interface ModifierEvent {
+  ctrlKey: boolean
+  shiftKey: boolean
+  altKey: boolean
+  metaKey: boolean
+}
+
+/**
+ * Check whether the user's configured eyedropper modifier is held on a
+ * mouse event. Strict match — no implicit ctrl/meta aliasing, because the
+ * whole point of this preference is to let users pick a specific modifier
+ * that doesn't collide with their OS-level virtual-right-click setup.
+ */
+export function isEyedropperModifierPressed(
+  e: ModifierEvent,
+  modifier: EyedropperModifier,
+): boolean {
+  switch (modifier) {
+    case 'ctrl':  return e.ctrlKey
+    case 'shift': return e.shiftKey
+    case 'alt':   return e.altKey
+    case 'meta':  return e.metaKey
+  }
+}
+
+/** Human-readable label for UI display. Meta is annotated for cross-platform clarity. */
+export function eyedropperModifierLabel(modifier: EyedropperModifier): string {
+  switch (modifier) {
+    case 'ctrl':  return 'Ctrl'
+    case 'shift': return 'Shift'
+    case 'alt':   return 'Alt'
+    case 'meta':  return 'Meta (⌘ / Win)'
+  }
+}

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/types.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/types.ts
@@ -302,6 +302,13 @@ export interface UseAnsiEditorOptions {
   onOpenFileMenu?: () => void
   onShowToast?: (message: string) => void
   isActive?: boolean
+  /**
+   * Keyboard modifier that enables click-to-sample-color when not in the
+   * eyedropper tool. User-configurable via the File Options → Input tab so
+   * it doesn't collide with OS-level virtual-right-click conventions.
+   * See `eyedropperModifierPersistence.ts`. Defaults to 'ctrl' when omitted.
+   */
+  eyedropperModifier?: import('./eyedropperModifierPersistence').EyedropperModifier
 }
 
 export type StaticPaletteType = 'cga' | 'ega' | 'vga'

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/useAnsiEditor.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/useAnsiEditor.ts
@@ -26,6 +26,10 @@ import {
   DEFAULT_USE_FONT_BLOCKS,
   normalizeAnsiFontId,
 } from '@lua-learning/ansi-shared'
+import {
+  DEFAULT_EYEDROPPER_MODIFIER,
+  isEyedropperModifierPressed,
+} from './eyedropperModifierPersistence'
 import { CRT_DEFAULTS, type CrtConfig } from '@lua-learning/lua-runtime'
 
 export { computePixelCell, computeLineCells } from './gridUtils'
@@ -153,6 +157,8 @@ export function useAnsiEditor(options?: UseAnsiEditorOptions): UseAnsiEditorRetu
   const openFileMenuRef = useRef<(() => void) | undefined>(options?.onOpenFileMenu); openFileMenuRef.current = options?.onOpenFileMenu
   const showToastRef = useRef<((msg: string) => void) | undefined>(options?.onShowToast); showToastRef.current = options?.onShowToast
   const isActiveRef = useRef(options?.isActive ?? true); isActiveRef.current = options?.isActive ?? true
+  const eyedropperModifierRef = useRef(options?.eyedropperModifier ?? DEFAULT_EYEDROPPER_MODIFIER)
+  eyedropperModifierRef.current = options?.eyedropperModifier ?? DEFAULT_EYEDROPPER_MODIFIER
 
   const pushSnapshot = useCallback(() => {
     const stack = undoStackRef.current
@@ -536,7 +542,7 @@ export function useAnsiEditor(options?: UseAnsiEditorOptions): UseAnsiEditorRetu
         setBrush(p => isRight ? { ...p, bg: [...c] as RGBColor } : { ...p, fg: [...c] as RGBColor })
         return true
       }
-      if (e.ctrlKey) {
+      if (isEyedropperModifierPressed(e, eyedropperModifierRef.current)) {
         setBrush(p => isRight ? { ...p, bg: [...s.bg] as RGBColor } : { ...p, fg: [...s.fg] as RGBColor })
         return true
       }


### PR DESCRIPTION
## Summary

- The ANSI editor's eyedropper modifier was hardcoded to Ctrl, colliding with the macOS/trackpad virtual-right-click convention. Users can now pick the modifier (Ctrl / Shift / Alt / Meta) via a new **Input** tab in the File Options modal. Default stays Ctrl, so existing behavior is unchanged.
- The File Options modal is restructured into **File / Canvas / Input** tabs (mirroring the tab pattern already used by `CharPaletteModal`), resolving the pre-existing crowding (~20 mixed entries in one flat list) and giving future preferences a natural home.
- Preference is persisted in `localStorage` under `ansi-editor:eyedropper-modifier` using the same pattern as `scaleModePersistence.ts`.

## Files

**New**
- `eyedropperModifierPersistence.ts` — type, load/save, `isEyedropperModifierPressed`, `eyedropperModifierLabel`
- `eyedropperModifierPersistence.test.ts` — 20 tests (mutation score 94.44%)

**Modified**
- `useAnsiEditor.ts` — `sampleCell` reads the configured modifier via ref instead of hardcoded `e.ctrlKey`
- `FileOptionsModal.tsx` / `.test.tsx` — split into 3 tabs; 26 tests covering all tabs, overlay, keyboard
- `AnsiGraphicsEditor.tsx` — state + persistence wiring
- `AnsiEditorToolbar.tsx` — forwards the new props
- `types.ts` — `UseAnsiEditorOptions.eyedropperModifier`
- `AnsiGraphicsEditor.module.css` — new `.fileOptionsHelp` class

## Test plan

- [x] Full unit suite: `npm run test` → 4447 passed across 210 files
- [x] Lint: 0 errors (313 pre-existing warnings unchanged)
- [x] Type-check: `npx tsc -p lua-learning-website/tsconfig.app.json --noEmit 2>&1 | grep -v "@lua-learning/"` produces no output
- [x] Scoped mutation: `eyedropperModifierPersistence.ts` → 94.44%
- [ ] Manual smoke in dev server: open File Options → tabs render (File default); Ctrl+click samples fg, Ctrl+right-click samples bg, plain right-click copies char; switch to Shift/Alt/Meta → same behavior follows the new modifier; preference persists across reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)