### PR TITLE
feat(ansi-editor): add alpha (transparent) color selection

### DIFF
--- a/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.module.css
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.module.css
@@ -180,16 +180,6 @@
   padding: 0 8px 4px;
 }
 
-.alphaSwatchRow {
-  display: flex;
-  padding: 0 8px 4px;
-}
-
-.alphaSwatchRow .colorSwatch {
-  width: 22px;
-  height: 22px;
-}
-
 /*
  * Checkered "no color / inherit from below" swatch.
  * Used both for the alpha pick-swatch and for the FG/BG buttons when their slot
@@ -208,6 +198,17 @@
 
 .alphaSwatch[data-fg-disabled='true'] {
   cursor: not-allowed;
+}
+
+/* Full-row variant for the alpha swatch when it lives inside .colorGrid. */
+.alphaSwatchFull {
+  grid-column: 1 / -1;
+  aspect-ratio: auto;
+  height: 18px;
+}
+
+.colorGridVga .alphaSwatchFull {
+  height: 11px;
 }
 
 .simplifyBtn {

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.module.css
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.module.css
@@ -196,7 +196,7 @@
   background-position: 0 0, 0 4px, 4px -4px, -4px 0;
 }
 
-.alphaSwatch[data-fg-disabled='true'] {
+.alphaSwatch[data-disabled='true'] {
   cursor: not-allowed;
 }
 

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.module.css
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.module.css
@@ -180,6 +180,36 @@
   padding: 0 8px 4px;
 }
 
+.alphaSwatchRow {
+  display: flex;
+  padding: 0 8px 4px;
+}
+
+.alphaSwatchRow .colorSwatch {
+  width: 22px;
+  height: 22px;
+}
+
+/*
+ * Checkered "no color / inherit from below" swatch.
+ * Used both for the alpha pick-swatch and for the FG/BG buttons when their slot
+ * holds a transparency sentinel.
+ */
+.alphaSwatch {
+  background-color: #fff;
+  background-image:
+    linear-gradient(45deg, #888 25%, transparent 25%),
+    linear-gradient(-45deg, #888 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #888 75%),
+    linear-gradient(-45deg, transparent 75%, #888 75%);
+  background-size: 8px 8px;
+  background-position: 0 0, 0 4px, 4px -4px, -4px 0;
+}
+
+.alphaSwatch[data-fg-disabled='true'] {
+  cursor: not-allowed;
+}
+
 .simplifyBtn {
   width: 100%;
   padding: 3px 0;

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.tsx
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.tsx
@@ -377,6 +377,8 @@ export function AnsiGraphicsEditor({ filePath, onDirtyChange, isActive }: AnsiGr
         <ColorPanel
           selectedFg={brush.fg}
           selectedBg={brush.bg}
+          brushMode={brush.mode}
+          brushChar={brush.char}
           onSetFg={setBrushFg}
           onSetBg={setBrushBg}
           onSimplifyColors={simplifyColors}

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.tsx
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.tsx
@@ -382,6 +382,7 @@ export function AnsiGraphicsEditor({ filePath, onDirtyChange, isActive }: AnsiGr
           onSetFg={setBrushFg}
           onSetBg={setBrushBg}
           onSimplifyColors={simplifyColors}
+          onShowToast={showToast}
           layers={layers}
           activeLayerId={activeLayerId}
         />

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/ColorPanel.alpha.test.tsx
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/ColorPanel.alpha.test.tsx
@@ -46,16 +46,37 @@ describe('ColorPanel — alpha swatch', () => {
     expect(props.onSetBg).toHaveBeenCalledWith(TRANSPARENT_BG)
   })
 
-  it('left-click is a no-op in brush mode with a non-HALF_BLOCK glyph', () => {
+  it('left-click does not call onSetFg in brush mode with a non-HALF_BLOCK glyph', () => {
     render(<ColorPanel {...props} brushMode="brush" brushChar="X" />)
     fireEvent.click(screen.getByTestId('alpha-swatch'))
     expect(props.onSetFg).not.toHaveBeenCalled()
+  })
+
+  it('left-click fires onShowToast when FG alpha is disabled', () => {
+    const onShowToast = vi.fn()
+    render(<ColorPanel {...props} brushMode="brush" brushChar="X" onShowToast={onShowToast} />)
+    fireEvent.click(screen.getByTestId('alpha-swatch'))
+    expect(onShowToast).toHaveBeenCalledTimes(1)
+    expect(onShowToast.mock.calls[0][0]).toMatch(/half-block/i)
+  })
+
+  it('does not fire onShowToast when FG alpha is allowed', () => {
+    const onShowToast = vi.fn()
+    render(<ColorPanel {...props} brushMode="pixel" brushChar={HALF_BLOCK} onShowToast={onShowToast} />)
+    fireEvent.click(screen.getByTestId('alpha-swatch'))
+    expect(onShowToast).not.toHaveBeenCalled()
   })
 
   it('marks data-fg-disabled when FG alpha is not allowed', () => {
     render(<ColorPanel {...props} brushMode="brush" brushChar="X" />)
     const swatch = screen.getByTestId('alpha-swatch')
     expect(swatch.getAttribute('data-fg-disabled')).toBe('true')
+  })
+
+  it('does not mark data-disabled when only FG alpha is disabled (BG still works)', () => {
+    render(<ColorPanel {...props} brushMode="brush" brushChar="X" />)
+    const swatch = screen.getByTestId('alpha-swatch')
+    expect(swatch.getAttribute('data-disabled')).toBeNull()
   })
 
   it('shows fg-selected indicator when selectedFg is alpha', () => {

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/ColorPanel.alpha.test.tsx
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/ColorPanel.alpha.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ColorPanel, type ColorPanelProps } from './ColorPanel'
+import { DEFAULT_FG, DEFAULT_BG, HALF_BLOCK, TRANSPARENT_BG, TRANSPARENT_HALF } from './types'
+import type { RGBColor } from './types'
+import { createLayer } from './layerUtils'
+
+describe('ColorPanel — alpha swatch', () => {
+  let props: ColorPanelProps
+
+  beforeEach(() => {
+    const layer = createLayer('Layer 1', 'layer-default')
+    props = {
+      selectedFg: DEFAULT_FG,
+      selectedBg: DEFAULT_BG,
+      brushMode: 'pixel',
+      brushChar: HALF_BLOCK,
+      onSetFg: vi.fn(),
+      onSetBg: vi.fn(),
+      onSimplifyColors: vi.fn(),
+      layers: [layer],
+      activeLayerId: layer.id,
+    }
+  })
+
+  it('renders the alpha swatch', () => {
+    render(<ColorPanel {...props} />)
+    expect(screen.getByTestId('alpha-swatch')).toBeTruthy()
+  })
+
+  it('left-click sets FG to TRANSPARENT_HALF in pixel mode', () => {
+    render(<ColorPanel {...props} brushMode="pixel" brushChar={HALF_BLOCK} />)
+    fireEvent.click(screen.getByTestId('alpha-swatch'))
+    expect(props.onSetFg).toHaveBeenCalledWith(TRANSPARENT_HALF)
+  })
+
+  it('right-click sets BG to TRANSPARENT_HALF in pixel mode', () => {
+    render(<ColorPanel {...props} brushMode="pixel" brushChar={HALF_BLOCK} />)
+    fireEvent.contextMenu(screen.getByTestId('alpha-swatch'))
+    expect(props.onSetBg).toHaveBeenCalledWith(TRANSPARENT_HALF)
+  })
+
+  it('right-click sets BG to TRANSPARENT_BG in brush mode with a glyph char', () => {
+    render(<ColorPanel {...props} brushMode="brush" brushChar="X" />)
+    fireEvent.contextMenu(screen.getByTestId('alpha-swatch'))
+    expect(props.onSetBg).toHaveBeenCalledWith(TRANSPARENT_BG)
+  })
+
+  it('left-click is a no-op in brush mode with a non-HALF_BLOCK glyph', () => {
+    render(<ColorPanel {...props} brushMode="brush" brushChar="X" />)
+    fireEvent.click(screen.getByTestId('alpha-swatch'))
+    expect(props.onSetFg).not.toHaveBeenCalled()
+  })
+
+  it('marks data-fg-disabled when FG alpha is not allowed', () => {
+    render(<ColorPanel {...props} brushMode="brush" brushChar="X" />)
+    const swatch = screen.getByTestId('alpha-swatch')
+    expect(swatch.getAttribute('data-fg-disabled')).toBe('true')
+  })
+
+  it('shows fg-selected indicator when selectedFg is alpha', () => {
+    render(<ColorPanel {...props} selectedFg={[...TRANSPARENT_HALF] as RGBColor} />)
+    const swatch = screen.getByTestId('alpha-swatch')
+    expect(swatch.getAttribute('data-fg-selected')).toBe('true')
+  })
+
+  it('shows bg-selected indicator when selectedBg is alpha', () => {
+    render(<ColorPanel {...props} selectedBg={[...TRANSPARENT_BG] as RGBColor} />)
+    const swatch = screen.getByTestId('alpha-swatch')
+    expect(swatch.getAttribute('data-bg-selected')).toBe('true')
+  })
+
+  it('disables FG button click + brightness when FG slot is alpha', () => {
+    render(<ColorPanel {...props} selectedFg={[...TRANSPARENT_HALF] as RGBColor} />)
+    const fgBtn = screen.getByTestId('fg-color-btn') as HTMLButtonElement
+    const fgDarken = screen.getByTestId('fg-darken-btn') as HTMLButtonElement
+    const fgLighten = screen.getByTestId('fg-lighten-btn') as HTMLButtonElement
+    expect(fgBtn.disabled).toBe(true)
+    expect(fgDarken.disabled).toBe(true)
+    expect(fgLighten.disabled).toBe(true)
+  })
+
+  it('disables BG button click + brightness when BG slot is alpha', () => {
+    render(<ColorPanel {...props} selectedBg={[...TRANSPARENT_BG] as RGBColor} />)
+    const bgBtn = screen.getByTestId('bg-color-btn') as HTMLButtonElement
+    const bgDarken = screen.getByTestId('bg-darken-btn') as HTMLButtonElement
+    const bgLighten = screen.getByTestId('bg-lighten-btn') as HTMLButtonElement
+    expect(bgBtn.disabled).toBe(true)
+    expect(bgDarken.disabled).toBe(true)
+    expect(bgLighten.disabled).toBe(true)
+  })
+
+  it('keeps the opposite slot enabled when only one slot is alpha', () => {
+    render(<ColorPanel {...props} selectedFg={[...TRANSPARENT_HALF] as RGBColor} />)
+    const bgBtn = screen.getByTestId('bg-color-btn') as HTMLButtonElement
+    expect(bgBtn.disabled).toBe(false)
+  })
+})

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/ColorPanel.test.tsx
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/ColorPanel.test.tsx
@@ -38,7 +38,7 @@ describe('ColorPanel', () => {
   it('defaults to CGA palette with 16 swatches', () => {
     render(<ColorPanel {...props} />)
     const grid = screen.getByTestId('color-grid')
-    const swatches = grid.querySelectorAll('button')
+    const swatches = grid.querySelectorAll('button:not([data-testid="alpha-swatch"])')
     expect(swatches).toHaveLength(16)
   })
 
@@ -46,7 +46,7 @@ describe('ColorPanel', () => {
     render(<ColorPanel {...props} />)
     fireEvent.click(screen.getByTestId('palette-btn-ega'))
     const grid = screen.getByTestId('color-grid')
-    const swatches = grid.querySelectorAll('button')
+    const swatches = grid.querySelectorAll('button:not([data-testid="alpha-swatch"])')
     expect(swatches).toHaveLength(64)
   })
 
@@ -54,14 +54,14 @@ describe('ColorPanel', () => {
     render(<ColorPanel {...props} />)
     fireEvent.click(screen.getByTestId('palette-btn-vga'))
     const grid = screen.getByTestId('color-grid')
-    const swatches = grid.querySelectorAll('button')
+    const swatches = grid.querySelectorAll('button:not([data-testid="alpha-swatch"])')
     expect(swatches).toHaveLength(256)
   })
 
   it('left-click on swatch calls onSetFg', () => {
     render(<ColorPanel {...props} />)
     const grid = screen.getByTestId('color-grid')
-    const firstSwatch = grid.querySelectorAll('button')[0]
+    const firstSwatch = grid.querySelectorAll('button:not([data-testid="alpha-swatch"])')[0]
     fireEvent.click(firstSwatch)
     expect(props.onSetFg).toHaveBeenCalledWith(CGA_PALETTE[0].rgb)
   })
@@ -69,7 +69,7 @@ describe('ColorPanel', () => {
   it('right-click on swatch calls onSetBg', () => {
     render(<ColorPanel {...props} />)
     const grid = screen.getByTestId('color-grid')
-    const firstSwatch = grid.querySelectorAll('button')[0]
+    const firstSwatch = grid.querySelectorAll('button:not([data-testid="alpha-swatch"])')[0]
     fireEvent.contextMenu(firstSwatch)
     expect(props.onSetBg).toHaveBeenCalledWith(CGA_PALETTE[0].rgb)
   })
@@ -77,7 +77,7 @@ describe('ColorPanel', () => {
   it('marks FG-selected swatch with data-fg-selected', () => {
     render(<ColorPanel {...props} />)
     const grid = screen.getByTestId('color-grid')
-    const swatches = grid.querySelectorAll('button')
+    const swatches = grid.querySelectorAll('button:not([data-testid="alpha-swatch"])')
     expect(swatches[7].getAttribute('data-fg-selected')).toBe('true')
     expect(swatches[0].getAttribute('data-fg-selected')).toBeNull()
   })
@@ -85,7 +85,7 @@ describe('ColorPanel', () => {
   it('marks BG-selected swatch with data-bg-selected', () => {
     render(<ColorPanel {...props} />)
     const grid = screen.getByTestId('color-grid')
-    const swatches = grid.querySelectorAll('button')
+    const swatches = grid.querySelectorAll('button:not([data-testid="alpha-swatch"])')
     expect(swatches[0].getAttribute('data-bg-selected')).toBe('true')
     expect(swatches[1].getAttribute('data-bg-selected')).toBeNull()
   })
@@ -94,7 +94,7 @@ describe('ColorPanel', () => {
     const sameColor: RGBColor = [0, 0, 0]
     render(<ColorPanel {...props} selectedFg={sameColor} selectedBg={sameColor} />)
     const grid = screen.getByTestId('color-grid')
-    const swatches = grid.querySelectorAll('button')
+    const swatches = grid.querySelectorAll('button:not([data-testid="alpha-swatch"])')
     expect(swatches[0].getAttribute('data-fg-selected')).toBe('true')
     expect(swatches[0].getAttribute('data-bg-selected')).toBe('true')
   })
@@ -112,7 +112,7 @@ describe('ColorPanel', () => {
   it('swatch has correct title and aria-label from palette entry', () => {
     render(<ColorPanel {...props} />)
     const grid = screen.getByTestId('color-grid')
-    const firstSwatch = grid.querySelectorAll('button')[0]
+    const firstSwatch = grid.querySelectorAll('button:not([data-testid="alpha-swatch"])')[0]
     expect(firstSwatch.getAttribute('title')).toBe('Black')
     expect(firstSwatch.getAttribute('aria-label')).toBe('Black')
   })
@@ -120,7 +120,7 @@ describe('ColorPanel', () => {
   it('swatch has correct background color style', () => {
     render(<ColorPanel {...props} />)
     const grid = screen.getByTestId('color-grid')
-    const blueSwatch = grid.querySelectorAll('button')[1]
+    const blueSwatch = grid.querySelectorAll('button:not([data-testid="alpha-swatch"])')[1] as HTMLButtonElement
     expect(blueSwatch.style.backgroundColor).toBe('rgb(0, 0, 170)')
   })
 
@@ -139,7 +139,7 @@ describe('ColorPanel', () => {
   it('clicking second swatch calls onSetFg with correct color', () => {
     render(<ColorPanel {...props} />)
     const grid = screen.getByTestId('color-grid')
-    const secondSwatch = grid.querySelectorAll('button')[1]
+    const secondSwatch = grid.querySelectorAll('button:not([data-testid="alpha-swatch"])')[1]
     fireEvent.click(secondSwatch)
     expect(props.onSetFg).toHaveBeenCalledWith(CGA_PALETTE[1].rgb)
   })
@@ -147,7 +147,7 @@ describe('ColorPanel', () => {
   it('right-click second swatch calls onSetBg with correct color', () => {
     render(<ColorPanel {...props} />)
     const grid = screen.getByTestId('color-grid')
-    const secondSwatch = grid.querySelectorAll('button')[1]
+    const secondSwatch = grid.querySelectorAll('button:not([data-testid="alpha-swatch"])')[1]
     fireEvent.contextMenu(secondSwatch)
     expect(props.onSetBg).toHaveBeenCalledWith(CGA_PALETTE[1].rgb)
   })
@@ -155,7 +155,7 @@ describe('ColorPanel', () => {
   it('non-selected swatch does not have data-fg-selected or data-bg-selected', () => {
     render(<ColorPanel {...props} />)
     const grid = screen.getByTestId('color-grid')
-    const swatch = grid.querySelectorAll('button')[1]
+    const swatch = grid.querySelectorAll('button:not([data-testid="alpha-swatch"])')[1]
     expect(swatch.getAttribute('data-fg-selected')).toBeNull()
     expect(swatch.getAttribute('data-bg-selected')).toBeNull()
   })
@@ -165,7 +165,7 @@ describe('ColorPanel', () => {
     fireEvent.click(screen.getByTestId('palette-btn-ega'))
     fireEvent.click(screen.getByTestId('palette-btn-cga'))
     const grid = screen.getByTestId('color-grid')
-    expect(grid.querySelectorAll('button')).toHaveLength(16)
+    expect(grid.querySelectorAll('button:not([data-testid="alpha-swatch"])')).toHaveLength(16)
   })
 
   describe('FG/BG color buttons', () => {
@@ -389,7 +389,7 @@ describe('ColorPanel', () => {
       render(<ColorPanel {...props} layers={[l1, l2]} activeLayerId="l1" />)
       fireEvent.click(screen.getByTestId('palette-btn-current'))
       const grid = screen.getByTestId('color-grid')
-      const swatches = grid.querySelectorAll('button')
+      const swatches = grid.querySelectorAll('button:not([data-testid="alpha-swatch"])')
       expect(swatches.length).toBeGreaterThanOrEqual(2)
     })
 
@@ -400,7 +400,7 @@ describe('ColorPanel', () => {
       render(<ColorPanel {...props} layers={[layer]} activeLayerId="l1" />)
       fireEvent.click(screen.getByTestId('palette-btn-current'))
       const grid = screen.getByTestId('color-grid')
-      const swatch = grid.querySelectorAll('button')[0]
+      const swatch = grid.querySelectorAll('button:not([data-testid="alpha-swatch"])')[0]
       fireEvent.click(swatch)
       expect(props.onSetFg).toHaveBeenCalled()
     })
@@ -424,7 +424,7 @@ describe('ColorPanel', () => {
       render(<ColorPanel {...props} layers={[l1, l2]} activeLayerId="l1" />)
       fireEvent.click(screen.getByTestId('palette-btn-layer'))
       const grid = screen.getByTestId('color-grid')
-      const swatches = grid.querySelectorAll('button')
+      const swatches = grid.querySelectorAll('button:not([data-testid="alpha-swatch"])')
       // Only red should appear (not blue from l2)
       expect(swatches).toHaveLength(1)
       expect(swatches[0].getAttribute('title')).toBe('#ff0000')
@@ -437,7 +437,7 @@ describe('ColorPanel', () => {
       render(<ColorPanel {...props} layers={[layer]} activeLayerId="l1" />)
       fireEvent.click(screen.getByTestId('palette-btn-layer'))
       const grid = screen.getByTestId('color-grid')
-      const swatch = grid.querySelectorAll('button')[0]
+      const swatch = grid.querySelectorAll('button:not([data-testid="alpha-swatch"])')[0]
       fireEvent.contextMenu(swatch)
       expect(props.onSetBg).toHaveBeenCalled()
     })

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/ColorPanel.test.tsx
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/ColorPanel.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { ColorPanel, type ColorPanelProps } from './ColorPanel'
-import { CGA_PALETTE, DEFAULT_FG, DEFAULT_BG } from './types'
+import { CGA_PALETTE, DEFAULT_FG, DEFAULT_BG, HALF_BLOCK } from './types'
 import type { RGBColor, Layer } from './types'
 import { createLayer } from './layerUtils'
 
@@ -13,6 +13,8 @@ describe('ColorPanel', () => {
     props = {
       selectedFg: DEFAULT_FG,
       selectedBg: DEFAULT_BG,
+      brushMode: 'pixel',
+      brushChar: HALF_BLOCK,
       onSetFg: vi.fn(),
       onSetBg: vi.fn(),
       onSimplifyColors: vi.fn(),
@@ -557,4 +559,5 @@ describe('ColorPanel', () => {
       expect(screen.queryByTestId('simplify-modal')).toBeNull()
     })
   })
+
 })

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/ColorPanel.tsx
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/ColorPanel.tsx
@@ -1,8 +1,8 @@
 import { Fragment, useState, useMemo } from 'react'
-import type { RGBColor, PaletteType, StaticPaletteType, Layer } from './types'
+import type { RGBColor, PaletteType, StaticPaletteType, Layer, BrushMode } from './types'
 import { isDrawableLayer } from './types'
 import { rgbEqual } from './layerUtils'
-import { rgbStyle, extractGridColors, extractAllLayerColors } from './colorUtils'
+import { rgbStyle, extractGridColors, extractAllLayerColors, isAlphaColor, resolveAlphaForSlot } from './colorUtils'
 import { isDynamicPalette, resolvePalette } from './colorPanelUtils'
 import { SimplifyPaletteModal } from './SimplifyPaletteModal'
 import { useColorPicker } from './useColorPicker'
@@ -11,6 +11,8 @@ import styles from './AnsiGraphicsEditor.module.css'
 export interface ColorPanelProps {
   selectedFg: RGBColor
   selectedBg: RGBColor
+  brushMode: BrushMode
+  brushChar: string
   onSetFg: (color: RGBColor) => void
   onSetBg: (color: RGBColor) => void
   onSimplifyColors: (mapping: Map<string, RGBColor>, scope: 'current' | 'layer') => void
@@ -43,7 +45,7 @@ function resolveGridClass(type: PaletteType, paletteLength: number): string {
   return STATIC_GRID_CLASS[type]
 }
 
-export function ColorPanel({ selectedFg, selectedBg, onSetFg, onSetBg, onSimplifyColors, layers, activeLayerId }: ColorPanelProps) {
+export function ColorPanel({ selectedFg, selectedBg, brushMode, brushChar, onSetFg, onSetBg, onSimplifyColors, layers, activeLayerId }: ColorPanelProps) {
   const [paletteType, setPaletteType] = useState<PaletteType>('cga')
 
   // Dynamic palette computation
@@ -77,6 +79,14 @@ export function ColorPanel({ selectedFg, selectedBg, onSetFg, onSetBg, onSimplif
     handleHexApply,
     adjustBrightness,
   } = useColorPicker(selectedFg, selectedBg, onSetFg, onSetBg)
+
+  const fgAlpha = resolveAlphaForSlot('fg', brushMode, brushChar)
+  const bgAlpha = resolveAlphaForSlot('bg', brushMode, brushChar)
+  const fgIsAlpha = isAlphaColor(selectedFg)
+  const bgIsAlpha = isAlphaColor(selectedBg)
+  const alphaTitle = fgAlpha
+    ? 'Alpha (click = FG, right-click = BG)'
+    : 'Alpha (right-click = BG; FG disabled while painting non-block glyphs)'
 
   return (
     <div className={styles.colorPanel} data-testid="color-panel">
@@ -117,6 +127,20 @@ export function ColorPanel({ selectedFg, selectedBg, onSetFg, onSetBg, onSimplif
           onClose={() => setSimplifyOpen(false)}
         />
       )}
+      <div className={styles.alphaSwatchRow}>
+        <button
+          type="button"
+          className={`${styles.colorSwatch} ${styles.alphaSwatch} ${fgIsAlpha ? styles.swatchFgSelected : ''} ${bgIsAlpha ? styles.swatchBgSelected : ''}`}
+          title={alphaTitle}
+          aria-label="Alpha (transparent)"
+          onClick={() => { if (fgAlpha) onSetFg(fgAlpha) }}
+          onContextMenu={(e) => { e.preventDefault(); if (bgAlpha) onSetBg(bgAlpha) }}
+          data-testid="alpha-swatch"
+          data-fg-disabled={fgAlpha === null ? 'true' : undefined}
+          {...(fgIsAlpha ? { 'data-fg-selected': 'true' } : {})}
+          {...(bgIsAlpha ? { 'data-bg-selected': 'true' } : {})}
+        />
+      </div>
       <div
         className={`${styles.colorGrid} ${gridClass}`}
         data-testid="color-grid"
@@ -220,24 +244,25 @@ export function ColorPanel({ selectedFg, selectedBg, onSetFg, onSetBg, onSimplif
       )}
       <div className={styles.fgBgButtonSection} ref={fgBgSectionRef}>
         {([
-          { target: 'fg' as PickerTarget, label: 'FG', fullLabel: 'Foreground', color: selectedFg },
-          { target: 'bg' as PickerTarget, label: 'BG', fullLabel: 'Background', color: selectedBg },
-        ]).map(({ target, label, fullLabel, color }) => (
+          { target: 'fg' as PickerTarget, label: 'FG', fullLabel: 'Foreground', color: selectedFg, isAlpha: fgIsAlpha },
+          { target: 'bg' as PickerTarget, label: 'BG', fullLabel: 'Background', color: selectedBg, isAlpha: bgIsAlpha },
+        ]).map(({ target, label, fullLabel, color, isAlpha }) => (
           <Fragment key={target}>
             <button
               type="button"
-              className={styles.fgBgButton}
-              style={{ backgroundColor: rgbStyle(color) }}
-              onClick={() => openPicker(target)}
+              className={`${styles.fgBgButton} ${isAlpha ? styles.alphaSwatch : ''}`}
+              style={isAlpha ? undefined : { backgroundColor: rgbStyle(color) }}
+              onClick={() => { if (!isAlpha) openPicker(target) }}
+              disabled={isAlpha}
               data-testid={`${target}-color-btn`}
-              title={`${fullLabel} color`}
+              title={isAlpha ? `${fullLabel} is alpha — pick an opaque color first` : `${fullLabel} color`}
             >
               {label}
             </button>
             <div className={styles.brightnessRow} data-testid={`${target}-brightness-row`}>
               <span className={styles.brightnessLabel}>Brightness</span>
-              <button type="button" className={styles.brightnessBtn} onClick={() => adjustBrightness(target, -0.01)} data-testid={`${target}-darken-btn`} title={`Darken ${fullLabel.toLowerCase()}`}>−</button>
-              <button type="button" className={styles.brightnessBtn} onClick={() => adjustBrightness(target, 0.01)} data-testid={`${target}-lighten-btn`} title={`Lighten ${fullLabel.toLowerCase()}`}>+</button>
+              <button type="button" className={styles.brightnessBtn} onClick={() => adjustBrightness(target, -0.01)} data-testid={`${target}-darken-btn`} title={`Darken ${fullLabel.toLowerCase()}`} disabled={isAlpha}>−</button>
+              <button type="button" className={styles.brightnessBtn} onClick={() => adjustBrightness(target, 0.01)} data-testid={`${target}-lighten-btn`} title={`Lighten ${fullLabel.toLowerCase()}`} disabled={isAlpha}>+</button>
             </div>
           </Fragment>
         ))}

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/ColorPanel.tsx
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/ColorPanel.tsx
@@ -127,10 +127,13 @@ export function ColorPanel({ selectedFg, selectedBg, brushMode, brushChar, onSet
           onClose={() => setSimplifyOpen(false)}
         />
       )}
-      <div className={styles.alphaSwatchRow}>
+      <div
+        className={`${styles.colorGrid} ${gridClass}`}
+        data-testid="color-grid"
+      >
         <button
           type="button"
-          className={`${styles.colorSwatch} ${styles.alphaSwatch} ${fgIsAlpha ? styles.swatchFgSelected : ''} ${bgIsAlpha ? styles.swatchBgSelected : ''}`}
+          className={`${styles.colorSwatch} ${styles.alphaSwatch} ${styles.alphaSwatchFull} ${fgIsAlpha ? styles.swatchFgSelected : ''} ${bgIsAlpha ? styles.swatchBgSelected : ''}`}
           title={alphaTitle}
           aria-label="Alpha (transparent)"
           onClick={() => { if (fgAlpha) onSetFg(fgAlpha) }}
@@ -140,11 +143,6 @@ export function ColorPanel({ selectedFg, selectedBg, brushMode, brushChar, onSet
           {...(fgIsAlpha ? { 'data-fg-selected': 'true' } : {})}
           {...(bgIsAlpha ? { 'data-bg-selected': 'true' } : {})}
         />
-      </div>
-      <div
-        className={`${styles.colorGrid} ${gridClass}`}
-        data-testid="color-grid"
-      >
         {palette.length === 0 && isDynamicPalette(paletteType) ? (
           <div className={styles.emptyPalette} data-testid="empty-palette">No colors in use</div>
         ) : palette.map((entry, i) => {

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/ColorPanel.tsx
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/ColorPanel.tsx
@@ -16,9 +16,12 @@ export interface ColorPanelProps {
   onSetFg: (color: RGBColor) => void
   onSetBg: (color: RGBColor) => void
   onSimplifyColors: (mapping: Map<string, RGBColor>, scope: 'current' | 'layer') => void
+  onShowToast?: (message: string) => void
   layers: Layer[]
   activeLayerId: string
 }
+
+const ALPHA_FG_DISABLED_TOAST = 'Alpha foreground requires the half-block (▀) character. Switch to pixel mode or change the brush character.'
 
 type PickerTarget = 'fg' | 'bg'
 
@@ -45,7 +48,7 @@ function resolveGridClass(type: PaletteType, paletteLength: number): string {
   return STATIC_GRID_CLASS[type]
 }
 
-export function ColorPanel({ selectedFg, selectedBg, brushMode, brushChar, onSetFg, onSetBg, onSimplifyColors, layers, activeLayerId }: ColorPanelProps) {
+export function ColorPanel({ selectedFg, selectedBg, brushMode, brushChar, onSetFg, onSetBg, onSimplifyColors, onShowToast, layers, activeLayerId }: ColorPanelProps) {
   const [paletteType, setPaletteType] = useState<PaletteType>('cga')
 
   // Dynamic palette computation
@@ -84,6 +87,7 @@ export function ColorPanel({ selectedFg, selectedBg, brushMode, brushChar, onSet
   const bgAlpha = resolveAlphaForSlot('bg', brushMode, brushChar)
   const fgIsAlpha = isAlphaColor(selectedFg)
   const bgIsAlpha = isAlphaColor(selectedBg)
+  const alphaFullyDisabled = fgAlpha === null && bgAlpha === null
   const alphaTitle = fgAlpha
     ? 'Alpha (click = FG, right-click = BG)'
     : 'Alpha (right-click = BG; FG disabled while painting non-block glyphs)'
@@ -136,10 +140,14 @@ export function ColorPanel({ selectedFg, selectedBg, brushMode, brushChar, onSet
           className={`${styles.colorSwatch} ${styles.alphaSwatch} ${styles.alphaSwatchFull} ${fgIsAlpha ? styles.swatchFgSelected : ''} ${bgIsAlpha ? styles.swatchBgSelected : ''}`}
           title={alphaTitle}
           aria-label="Alpha (transparent)"
-          onClick={() => { if (fgAlpha) onSetFg(fgAlpha) }}
+          onClick={() => {
+            if (fgAlpha) onSetFg(fgAlpha)
+            else onShowToast?.(ALPHA_FG_DISABLED_TOAST)
+          }}
           onContextMenu={(e) => { e.preventDefault(); if (bgAlpha) onSetBg(bgAlpha) }}
           data-testid="alpha-swatch"
           data-fg-disabled={fgAlpha === null ? 'true' : undefined}
+          data-disabled={alphaFullyDisabled ? 'true' : undefined}
           {...(fgIsAlpha ? { 'data-fg-selected': 'true' } : {})}
           {...(bgIsAlpha ? { 'data-bg-selected': 'true' } : {})}
         />

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/colorUtils.test.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/colorUtils.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import { hsvToRgb, rgbToHsv, rgbToHex, hexToRgb, blendRgb, extractGridColors, extractAllLayerColors, simplifyPalette, replaceColorsInGrid, darkenColor, applyMaskOverlay } from './colorUtils'
+import { hsvToRgb, rgbToHsv, rgbToHex, hexToRgb, blendRgb, extractGridColors, extractAllLayerColors, simplifyPalette, replaceColorsInGrid, darkenColor, applyMaskOverlay, isAlphaColor, resolveAlphaForSlot } from './colorUtils'
 import { createLayer } from './layerUtils'
-import { DEFAULT_BG, DEFAULT_FG, DEFAULT_CELL, TRANSPARENT_HALF, HALF_BLOCK, ANSI_ROWS, ANSI_COLS } from './types'
+import { DEFAULT_BG, DEFAULT_FG, DEFAULT_CELL, TRANSPARENT_BG, TRANSPARENT_HALF, HALF_BLOCK, ANSI_ROWS, ANSI_COLS } from './types'
 import type { RGBColor, AnsiGrid, Layer, PaletteEntry } from './types'
 
 describe('hsvToRgb', () => {
@@ -201,6 +201,16 @@ describe('extractGridColors', () => {
     const result = extractGridColors(layer.grid)
     const rgbs = result.map(e => e.rgb)
     expect(rgbs).not.toContainEqual(TRANSPARENT_HALF)
+    expect(rgbs).toContainEqual(green)
+  })
+
+  it('skips TRANSPARENT_BG sentinel colors', () => {
+    const layer = createLayer('test', 'test-4b')
+    const green: RGBColor = [0, 255, 0]
+    layer.grid[0][0] = { char: 'X', fg: green, bg: TRANSPARENT_BG }
+    const result = extractGridColors(layer.grid)
+    const rgbs = result.map(e => e.rgb)
+    expect(rgbs).not.toContainEqual(TRANSPARENT_BG)
     expect(rgbs).toContainEqual(green)
   })
 
@@ -485,5 +495,59 @@ describe('applyMaskOverlay', () => {
     const mask = makeDefaultMask()
     const result = applyMaskOverlay(grid, mask, 0.5)
     expect(result[0][0].char).toBe('A')
+  })
+})
+
+describe('isAlphaColor', () => {
+  it('returns true for TRANSPARENT_HALF', () => {
+    expect(isAlphaColor(TRANSPARENT_HALF)).toBe(true)
+  })
+
+  it('returns true for TRANSPARENT_BG', () => {
+    expect(isAlphaColor(TRANSPARENT_BG)).toBe(true)
+  })
+
+  it('returns false for ordinary colors', () => {
+    expect(isAlphaColor([0, 0, 0])).toBe(false)
+    expect(isAlphaColor([255, 255, 255])).toBe(false)
+    expect(isAlphaColor([170, 85, 0])).toBe(false)
+    expect(isAlphaColor(DEFAULT_FG)).toBe(false)
+    expect(isAlphaColor(DEFAULT_BG)).toBe(false)
+  })
+})
+
+describe('resolveAlphaForSlot', () => {
+  it('returns TRANSPARENT_HALF for FG in pixel mode', () => {
+    expect(resolveAlphaForSlot('fg', 'pixel', HALF_BLOCK)).toEqual(TRANSPARENT_HALF)
+  })
+
+  it('returns TRANSPARENT_HALF for BG in pixel mode', () => {
+    expect(resolveAlphaForSlot('bg', 'pixel', HALF_BLOCK)).toEqual(TRANSPARENT_HALF)
+  })
+
+  it('returns TRANSPARENT_HALF for both slots in eraser mode', () => {
+    expect(resolveAlphaForSlot('fg', 'eraser', HALF_BLOCK)).toEqual(TRANSPARENT_HALF)
+    expect(resolveAlphaForSlot('bg', 'eraser', HALF_BLOCK)).toEqual(TRANSPARENT_HALF)
+  })
+
+  it('returns TRANSPARENT_HALF for both slots in blend-pixel mode', () => {
+    expect(resolveAlphaForSlot('fg', 'blend-pixel', HALF_BLOCK)).toEqual(TRANSPARENT_HALF)
+    expect(resolveAlphaForSlot('bg', 'blend-pixel', HALF_BLOCK)).toEqual(TRANSPARENT_HALF)
+  })
+
+  it('returns TRANSPARENT_HALF when brush mode paints a HALF_BLOCK char', () => {
+    expect(resolveAlphaForSlot('fg', 'brush', HALF_BLOCK)).toEqual(TRANSPARENT_HALF)
+    expect(resolveAlphaForSlot('bg', 'brush', HALF_BLOCK)).toEqual(TRANSPARENT_HALF)
+  })
+
+  it('returns null for FG when brush mode paints a non-HALF_BLOCK glyph', () => {
+    expect(resolveAlphaForSlot('fg', 'brush', 'X')).toBeNull()
+    expect(resolveAlphaForSlot('fg', 'brush', '#')).toBeNull()
+    expect(resolveAlphaForSlot('fg', 'brush', ' ')).toBeNull()
+  })
+
+  it('returns TRANSPARENT_BG for BG when brush mode paints a non-HALF_BLOCK glyph', () => {
+    expect(resolveAlphaForSlot('bg', 'brush', 'X')).toEqual(TRANSPARENT_BG)
+    expect(resolveAlphaForSlot('bg', 'brush', '#')).toEqual(TRANSPARENT_BG)
   })
 })

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/colorUtils.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/colorUtils.ts
@@ -1,6 +1,32 @@
-import type { RGBColor, AnsiGrid, Layer, PaletteEntry } from './types'
-import { TRANSPARENT_HALF, isDrawableLayer } from './types'
+import type { BrushMode, RGBColor, AnsiGrid, Layer, PaletteEntry } from './types'
+import { HALF_BLOCK, TRANSPARENT_BG, TRANSPARENT_HALF, isDrawableLayer } from './types'
 import { isDefaultCell, rgbEqual } from './layerUtils'
+
+/**
+ * Whether `color` is a transparency sentinel ({@link TRANSPARENT_HALF} or
+ * {@link TRANSPARENT_BG}) — i.e. "alpha" / "no color, inherit from below".
+ */
+export function isAlphaColor(color: RGBColor): boolean {
+  return rgbEqual(color, TRANSPARENT_HALF) || rgbEqual(color, TRANSPARENT_BG)
+}
+
+/**
+ * Resolve which alpha sentinel value (if any) should fill a brush slot given
+ * the current brush mode and character. Returns `null` when alpha is not
+ * meaningful for that combination — currently only the FG slot of a brush-mode
+ * stroke that paints a non-{@link HALF_BLOCK} glyph (the compositor would
+ * render the sentinel as garbage instead of resolving it).
+ */
+export function resolveAlphaForSlot(
+  slot: 'fg' | 'bg',
+  brushMode: BrushMode,
+  brushChar: string,
+): RGBColor | null {
+  const writesHalfBlock = brushMode !== 'brush' || brushChar === HALF_BLOCK
+  if (writesHalfBlock) return [...TRANSPARENT_HALF] as RGBColor
+  if (slot === 'fg') return null
+  return [...TRANSPARENT_BG] as RGBColor
+}
 
 /** Darken an RGB color by a factor (0 = black, 1 = original). */
 export function darkenColor(color: RGBColor, factor: number): RGBColor {
@@ -115,7 +141,7 @@ function collectUniqueColors(grids: AnsiGrid[]): PaletteEntry[] {
       for (const cell of row) {
         if (isDefaultCell(cell)) continue
         for (const color of [cell.fg, cell.bg]) {
-          if (rgbEqual(color, TRANSPARENT_HALF)) continue
+          if (isAlphaColor(color)) continue
           const key = rgbKey(color)
           if (seen.has(key)) continue
           seen.add(key)

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/drawHelpers.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/drawHelpers.ts
@@ -1,8 +1,9 @@
 import type { AnsiCell, AnsiGrid, BrushSettings, Layer } from './types'
+import { TRANSPARENT_HALF } from './types'
 import type { CellHalf, ColorTransform } from './gridUtils'
 import {
   parseCellKey, isInBounds,
-  computeErasePixelCell, computeLineCells, computeRectCells, computeOvalCells, computeBorderCells,
+  computePixelCell, computeLineCells, computeRectCells, computeOvalCells, computeBorderCells,
 } from './gridUtils'
 import { prepareComposite, compositeCellPrepared, compositeCellWithOverridePrepared } from './layerUtils'
 import type { TerminalBuffer } from './terminalBuffer'
@@ -101,7 +102,7 @@ export function createDrawHelpers(deps: DrawHelperDeps) {
     const mode = brushRef.current.mode
     if (mode === 'eraser') {
       if (isInBounds(row, col, projectRowsRef.current, projectColsRef.current)) {
-        applyCell(row, col, computeErasePixelCell(getActiveGrid()[row][col], isTopHalf))
+        applyCell(row, col, computePixelCell(getActiveGrid()[row][col], TRANSPARENT_HALF, isTopHalf))
       }
     } else if (mode === 'pixel') {
       paintPixel(row, col, isTopHalf)

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/gridUtils.eraser.test.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/gridUtils.eraser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { computeRectCells, computeFloodFillCells, computeErasePixelCell, computeLineCells } from './gridUtils'
+import { computeRectCells, computeFloodFillCells, computePixelCell, computeLineCells } from './gridUtils'
 import type { AnsiCell, AnsiGrid, RGBColor } from './types'
 import { ANSI_ROWS, ANSI_COLS, DEFAULT_FG, DEFAULT_BG, DEFAULT_CELL, HALF_BLOCK, TRANSPARENT_HALF } from './types'
 
@@ -24,47 +24,47 @@ const red: RGBColor = [255, 0, 0]
 const blue: RGBColor = [0, 0, 255]
 const green: RGBColor = [0, 170, 0]
 
-describe('computeErasePixelCell', () => {
-  it('should erase top half of a half-block cell, preserving bottom', () => {
+describe('computePixelCell — alpha paint (eraser semantics)', () => {
+  it('erases top half of a half-block cell, preserving bottom', () => {
     const cell: AnsiCell = { char: HALF_BLOCK, fg: [...red] as RGBColor, bg: [...blue] as RGBColor }
-    const result = computeErasePixelCell(cell, true)
+    const result = computePixelCell(cell, TRANSPARENT_HALF, true)
     expect(result.char).toBe(HALF_BLOCK)
     expect(result.fg).toEqual(TRANSPARENT_HALF) // top erased
     expect(result.bg).toEqual(blue)             // bottom preserved
   })
 
-  it('should erase bottom half of a half-block cell, preserving top', () => {
+  it('erases bottom half of a half-block cell, preserving top', () => {
     const cell: AnsiCell = { char: HALF_BLOCK, fg: [...red] as RGBColor, bg: [...blue] as RGBColor }
-    const result = computeErasePixelCell(cell, false)
+    const result = computePixelCell(cell, TRANSPARENT_HALF, false)
     expect(result.char).toBe(HALF_BLOCK)
     expect(result.fg).toEqual(red)              // top preserved
     expect(result.bg).toEqual(TRANSPARENT_HALF) // bottom erased
   })
 
-  it('should revert to DEFAULT_CELL when erasing top and bottom is already transparent', () => {
+  it('reverts to DEFAULT_CELL when erasing top and bottom is already transparent', () => {
     const cell: AnsiCell = { char: HALF_BLOCK, fg: [...red] as RGBColor, bg: [...TRANSPARENT_HALF] as RGBColor }
-    const result = computeErasePixelCell(cell, true)
+    const result = computePixelCell(cell, TRANSPARENT_HALF, true)
     expect(result).toEqual(DEFAULT_CELL)
   })
 
-  it('should revert to DEFAULT_CELL when erasing bottom and top is already transparent', () => {
+  it('reverts to DEFAULT_CELL when erasing bottom and top is already transparent', () => {
     const cell: AnsiCell = { char: HALF_BLOCK, fg: [...TRANSPARENT_HALF] as RGBColor, bg: [...blue] as RGBColor }
-    const result = computeErasePixelCell(cell, false)
+    const result = computePixelCell(cell, TRANSPARENT_HALF, false)
     expect(result).toEqual(DEFAULT_CELL)
   })
 
-  it('should handle non-half-block cells by converting to half-block', () => {
+  it('handles non-half-block cells by converting to half-block, preserving original bg', () => {
     const cell: AnsiCell = { char: '#', fg: [...red] as RGBColor, bg: [...blue] as RGBColor }
     // Non-half-block: both halves treated as bg color (blue)
-    const result = computeErasePixelCell(cell, true)
+    const result = computePixelCell(cell, TRANSPARENT_HALF, true)
     expect(result.char).toBe(HALF_BLOCK)
     expect(result.fg).toEqual(TRANSPARENT_HALF) // top erased
     expect(result.bg).toEqual(blue)             // bottom = original bg
   })
 
-  it('should be idempotent on DEFAULT_CELL', () => {
+  it('is idempotent on DEFAULT_CELL', () => {
     const cell: AnsiCell = { ...DEFAULT_CELL }
-    const result = computeErasePixelCell(cell, true)
+    const result = computePixelCell(cell, TRANSPARENT_HALF, true)
     expect(result).toEqual(DEFAULT_CELL)
   })
 })

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/gridUtils.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/gridUtils.ts
@@ -3,7 +3,7 @@ import type { AnsiCell, AnsiGrid, BrushSettings, RGBColor } from './types'
 import { DEFAULT_ANSI_COLS, DEFAULT_ANSI_ROWS, DEFAULT_BG, DEFAULT_BLEND_RATIO, DEFAULT_CELL, DEFAULT_FG, HALF_BLOCK, TRANSPARENT_HALF } from './types'
 import { bresenhamLine, midpointEllipse } from './lineAlgorithm'
 import { rgbEqual } from './layerUtils'
-import { blendRgb } from './colorUtils'
+import { blendRgb, isAlphaColor } from './colorUtils'
 
 export function cloneCell(cell: AnsiCell): AnsiCell {
   return { char: cell.char, fg: [...cell.fg] as RGBColor, bg: [...cell.bg] as RGBColor }
@@ -80,29 +80,25 @@ export function getCellHalfFromMouse(
 }
 
 export function computePixelCell(existingCell: AnsiCell, paintColor: RGBColor, isTopHalf: boolean): AnsiCell {
-  const isPixelCell = existingCell.char === HALF_BLOCK
-  const existingTop: RGBColor = isPixelCell ? [...existingCell.fg] as RGBColor : [...TRANSPARENT_HALF] as RGBColor
-  const existingBottom: RGBColor = isPixelCell ? [...existingCell.bg] as RGBColor : [...TRANSPARENT_HALF] as RGBColor
+  const paintingAlpha = isAlphaColor(paintColor)
 
-  return {
-    char: HALF_BLOCK,
-    fg: isTopHalf ? [...paintColor] as RGBColor : existingTop,
-    bg: isTopHalf ? existingBottom : [...paintColor] as RGBColor,
-  }
-}
-
-export function computeErasePixelCell(existingCell: AnsiCell, isTopHalf: boolean): AnsiCell {
-  // Erasing a default cell is a no-op
-  if (existingCell.char === ' ' && rgbEqual(existingCell.fg, DEFAULT_FG) && rgbEqual(existingCell.bg, DEFAULT_BG)) {
+  if (paintingAlpha
+    && existingCell.char === ' '
+    && rgbEqual(existingCell.fg, DEFAULT_FG)
+    && rgbEqual(existingCell.bg, DEFAULT_BG)) {
     return { ...DEFAULT_CELL }
   }
 
   const isPixelCell = existingCell.char === HALF_BLOCK
-  const existingTop: RGBColor = isPixelCell ? [...existingCell.fg] as RGBColor : [...existingCell.bg] as RGBColor
-  const existingBottom: RGBColor = [...existingCell.bg] as RGBColor
+  const existingTop: RGBColor = isPixelCell
+    ? [...existingCell.fg] as RGBColor
+    : (paintingAlpha ? [...existingCell.bg] : [...TRANSPARENT_HALF]) as RGBColor
+  const existingBottom: RGBColor = isPixelCell
+    ? [...existingCell.bg] as RGBColor
+    : (paintingAlpha ? [...existingCell.bg] : [...TRANSPARENT_HALF]) as RGBColor
 
-  const newTop = isTopHalf ? [...TRANSPARENT_HALF] as RGBColor : existingTop
-  const newBottom = isTopHalf ? existingBottom : [...TRANSPARENT_HALF] as RGBColor
+  const newTop = isTopHalf ? [...paintColor] as RGBColor : existingTop
+  const newBottom = isTopHalf ? existingBottom : [...paintColor] as RGBColor
 
   if (rgbEqual(newTop, TRANSPARENT_HALF) && rgbEqual(newBottom, TRANSPARENT_HALF)) {
     return { ...DEFAULT_CELL }
@@ -114,7 +110,14 @@ export function computeErasePixelCell(existingCell: AnsiCell, isTopHalf: boolean
 export type LineBrush = Omit<BrushSettings, 'tool'>
 
 function effectivePaintColor(brush: LineBrush): RGBColor {
-  return brush.mode === 'blend-pixel' ? blendRgb(brush.bg, brush.fg, brush.blendRatio ?? DEFAULT_BLEND_RATIO) : brush.fg
+  if (brush.mode === 'eraser') return [...TRANSPARENT_HALF] as RGBColor
+  if (brush.mode === 'blend-pixel') {
+    if (isAlphaColor(brush.fg) || isAlphaColor(brush.bg)) {
+      return isAlphaColor(brush.fg) ? [...brush.bg] as RGBColor : [...brush.fg] as RGBColor
+    }
+    return blendRgb(brush.bg, brush.fg, brush.blendRatio ?? DEFAULT_BLEND_RATIO)
+  }
+  return brush.fg
 }
 
 export interface CellHalf {
@@ -156,9 +159,7 @@ export function computeRectCells(
         const isTop = py % 2 === 0
         const key = `${row},${cx}`
         const existing = cells.get(key) ?? baseGrid[row][cx]
-        cells.set(key, brush.mode === 'eraser'
-          ? computeErasePixelCell(existing, isTop)
-          : computePixelCell(existing, effectivePaintColor(brush), isTop))
+        cells.set(key, computePixelCell(existing, effectivePaintColor(brush), isTop))
       }
     }
   } else {
@@ -255,8 +256,7 @@ export function computeOvalCells(
       const isTop = py % 2 === 0
       const key = `${row},${col}`
       const existing = cells.get(key) ?? baseGrid[row][col]
-      cells.set(key, brush.mode === 'eraser'
-        ? computeErasePixelCell(existing, isTop) : computePixelCell(existing, effectivePaintColor(brush), isTop))
+      cells.set(key, computePixelCell(existing, effectivePaintColor(brush), isTop))
     }
 
     if (filled) {
@@ -316,9 +316,7 @@ export function computeLineCells(
       const isTop = pixelY % 2 === 0
       const key = `${row},${col}`
       const existing = cells.get(key) ?? baseGrid[row][col]
-      cells.set(key, brush.mode === 'eraser'
-        ? computeErasePixelCell(existing, isTop)
-        : computePixelCell(existing, effectivePaintColor(brush), isTop))
+      cells.set(key, computePixelCell(existing, effectivePaintColor(brush), isTop))
     }
   } else {
     const points = bresenhamLine(start.col, start.row, end.col, end.row)
@@ -356,7 +354,8 @@ export function computeFloodFillCells(
 
     if (startCell.char !== HALF_BLOCK) {
       // Cell-level BFS: match non-half-block cells by full identity (char+fg+bg)
-      if (brush.mode === 'eraser' && startCell.char === DEFAULT_CELL.char
+      const paintColor = effectivePaintColor(brush)
+      if (isAlphaColor(paintColor) && startCell.char === DEFAULT_CELL.char
         && rgbEqual(startCell.fg, DEFAULT_CELL.fg) && rgbEqual(startCell.bg, DEFAULT_CELL.bg)) return cells
 
       const visited = new Set<string>()
@@ -370,11 +369,8 @@ export function computeFloodFillCells(
           || !rgbEqual(cell.fg, startCell.fg) || !rgbEqual(cell.bg, startCell.bg)) continue
 
         const key = `${r},${c}`
-        const paintColor = effectivePaintColor(brush)
-        let result = brush.mode === 'eraser'
-          ? computeErasePixelCell(cell, true) : computePixelCell(cell, paintColor, true)
-        result = brush.mode === 'eraser'
-          ? computeErasePixelCell(result, false) : computePixelCell(result, paintColor, false)
+        let result = computePixelCell(cell, paintColor, true)
+        result = computePixelCell(result, paintColor, false)
         cells.set(key, result)
 
         const neighbors: [number, number][] = [[r - 1, c], [r + 1, c], [r, c - 1], [r, c + 1]]
@@ -391,8 +387,8 @@ export function computeFloodFillCells(
       const startPY = startRow * 2 + (isTopHalf ? 0 : 1)
       const maxPY = rows * 2
       const targetColor = readPixelColor(baseGrid, startRow, startCol, !!isTopHalf)
-      const noopColor = brush.mode === 'eraser' ? TRANSPARENT_HALF : effectivePaintColor(brush)
-      if (rgbEqual(targetColor, noopColor)) return cells
+      const paintColor = effectivePaintColor(brush)
+      if (rgbEqual(targetColor, paintColor)) return cells
 
       const visited = new Set<string>()
       const queue: [number, number][] = [[startPY, startCol]]
@@ -407,9 +403,7 @@ export function computeFloodFillCells(
 
         const key = `${row},${cx}`
         const existing = cells.get(key) ?? baseGrid[row][cx]
-        cells.set(key, brush.mode === 'eraser'
-          ? computeErasePixelCell(existing, isTop)
-          : computePixelCell(existing, effectivePaintColor(brush), isTop))
+        cells.set(key, computePixelCell(existing, paintColor, isTop))
 
         const neighbors: [number, number][] = [[py - 1, cx], [py + 1, cx], [py, cx - 1], [py, cx + 1]]
         for (const [ny, nx] of neighbors) {

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/useAnsiEditor.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/useAnsiEditor.ts
@@ -3,7 +3,7 @@ import { useState, useCallback, useRef, useMemo, useEffect } from 'react'
 import type { AnsiTerminalHandle } from '../AnsiTerminalPanel/AnsiTerminalPanel'
 import type { AnsiCell, AnsiGrid, BrushMode, DrawTool, BrushSettings, BorderStyle, RGBColor, LayerState, TextAlign, UseAnsiEditorReturn, UseAnsiEditorOptions, DrawableLayer, Layer } from './types'
 import { DEFAULT_FG, DEFAULT_BG, DEFAULT_BLEND_RATIO, DEFAULT_FRAME_DURATION_MS, BORDER_PRESETS, isGroupLayer, isDrawableLayer, isClipLayer, isReferenceLayer } from './types'
-import { blendRgb, applyMaskOverlay } from './colorUtils'
+import { blendRgb, applyMaskOverlay, isAlphaColor } from './colorUtils'
 import type { CellHalf, ColorTransform } from './gridUtils'
 import { createEmptyGrid, isInBounds, getCellHalfFromMouse, computePixelCell, computeFloodFillCells } from './gridUtils'
 import { TerminalBuffer } from './terminalBuffer'
@@ -218,7 +218,14 @@ export function useAnsiEditor(options?: UseAnsiEditorOptions): UseAnsiEditorRetu
   const paintBlendPixel = useCallback((row: number, col: number, isTopHalf: boolean) => {
     if (!isInBounds(row, col, projectRowsRef.current, projectColsRef.current)) return
     const { fg, bg, blendRatio } = brushRef.current
-    applyCell(row, col, computePixelCell(getActiveGrid()[row][col], blendRgb(bg, fg, blendRatio ?? DEFAULT_BLEND_RATIO), isTopHalf))
+    const fgAlpha = isAlphaColor(fg)
+    const bgAlpha = isAlphaColor(bg)
+    const paintColor = fgAlpha && bgAlpha
+      ? fg
+      : fgAlpha ? bg
+      : bgAlpha ? fg
+      : blendRgb(bg, fg, blendRatio ?? DEFAULT_BLEND_RATIO)
+    applyCell(row, col, computePixelCell(getActiveGrid()[row][col], paintColor, isTopHalf))
   }, [applyCell, getActiveGrid])
 
   const paintCell = useCallback((row: number, col: number) => {


### PR DESCRIPTION
## Summary

- Adds an **alpha swatch** in the ANSI editor color panel so the user can explicitly pick "no color, inherit from below" as FG (left-click) or BG (right-click) — previously only the eraser tool could write transparent pixels.
- Unifies the eraser code path through `computePixelCell` + `TRANSPARENT_HALF`; deletes the parallel `computeErasePixelCell`.
- Resolves alpha to the right sentinel based on context: `TRANSPARENT_HALF` for pixel modes / brush mode painting `HALF_BLOCK`, `TRANSPARENT_BG` for the bg of brush mode painting a glyph. FG-alpha is disabled when the brush would write a non-`HALF_BLOCK` glyph (the compositor only resolves transparent FG on `HALF_BLOCK` cells).
- Disables the FG/BG opaque-color picker, brightness +/-, and short-circuits `paintBlendPixel` / `effectivePaintColor` when an alpha is selected. Eyedropper continues to sample post-composite per design.
- Filters `TRANSPARENT_BG` from the Current/Layer dynamic palettes so a transparent brush stroke can't pollute them.

## Test plan

- [x] `npm --prefix lua-learning-website test -- --run` — 4469 passed / 211 files
- [x] `npm test -w @lua-learning/lua-runtime -- --run` — 1724 passed
- [x] `npm test -w @lua-learning/ansi-shared -- --run` — 25 passed
- [x] `npx tsc -p lua-learning-website/tsconfig.app.json --noEmit` — clean
- [x] `npm --prefix lua-learning-website run lint` — 0 errors
- [ ] Manual browser verification: pick alpha as FG/BG in pixel mode, confirm strokes match the eraser output; switch to brush mode with `X`, confirm FG-alpha is disabled and BG-alpha gives transparent-bg glyphs
- [ ] /e2e-verified once tests are green

🤖 Generated with [Claude Code](https://claude.com/claude-code)