### PR TITLE
feat(#774): ANSI editor: visible border + lighter surround for the drawable canvas area

### DIFF
--- a/lua-learning-website/e2e/ansi-editor-canvas-surround.spec.ts
+++ b/lua-learning-website/e2e/ansi-editor-canvas-surround.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from './fixtures'
+import { TIMEOUTS } from './constants'
+
+const DEFAULT_RUNTIME_SURROUND = 'rgb(0, 13, 17)'
+
+test.describe('ANSI editor — canvas surround', () => {
+  test('drawable canvas has a visible border and the surround is not the default runtime black', async ({ cleanEditorPage }) => {
+    const page = cleanEditorPage
+
+    await page.getByRole('button', { name: /extensions/i }).click()
+    await page.getByTestId('open-ansi-editor').click()
+
+    const editor = page.getByTestId('ansi-graphics-editor')
+    await expect(editor).toBeVisible({ timeout: TIMEOUTS.ELEMENT_VISIBLE })
+
+    const surround = editor.locator('div[class*="container"]').first()
+    await expect(surround).toBeVisible({ timeout: TIMEOUTS.ELEMENT_VISIBLE })
+
+    await expect(async () => {
+      const bg = await surround.evaluate((el) => getComputedStyle(el).backgroundColor)
+      expect(bg).not.toBe(DEFAULT_RUNTIME_SURROUND)
+      expect(bg).not.toBe('rgba(0, 0, 0, 0)')
+    }).toPass({ timeout: TIMEOUTS.INIT })
+
+    const wrapper = surround.locator('div[class*="terminalWrapper"]').first()
+    await expect(wrapper).toBeVisible()
+
+    await expect(async () => {
+      const borderTop = await wrapper.evaluate((el) => getComputedStyle(el).borderTopWidth)
+      expect(borderTop).not.toBe('')
+      expect(borderTop).not.toBe('0px')
+    }).toPass({ timeout: TIMEOUTS.INIT })
+  })
+})

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.module.css
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.module.css
@@ -32,6 +32,19 @@
   overflow: hidden;
 }
 
+/* Surround treatment for the AnsiTerminalPanel container while it's
+   embedded in the editor. Lightens the surround so a black canvas no
+   longer blends into the chrome, and frames the canvas with a 1px
+   border that reads against any content. Cascades into the panel via
+   CSS custom properties so runtime playback (which doesn't apply this
+   class) stays unchanged. */
+.editorSurround {
+  --ansi-surround-bg: var(--theme-bg-secondary);
+  --ansi-canvas-border-style: solid;
+  --ansi-canvas-border-width: 1px;
+  --ansi-canvas-border-color: var(--theme-border);
+}
+
 .canvasMove {
   cursor: grab;
 }

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.tsx
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.tsx
@@ -448,6 +448,7 @@ export function AnsiGraphicsEditor({ filePath, onDirtyChange, isActive }: AnsiGr
               fontId={font}
               useFontBlocks={useFontBlocks}
               onTerminalReady={wrappedOnTerminalReady}
+              surroundClassName={styles.editorSurround}
             />
           </div>
           {activeLayerIsDrawn && (

--- a/lua-learning-website/src/components/AnsiTerminalPanel/AnsiTerminalPanel.module.css
+++ b/lua-learning-website/src/components/AnsiTerminalPanel/AnsiTerminalPanel.module.css
@@ -23,12 +23,22 @@
   place-content: safe center;
   width: 100%;
   height: 100%;
-  background: #000d11;
+  /* Surround background — variable so editor consumers can lighten it
+     via `surroundClassName` without affecting runtime playback. */
+  background: var(--ansi-surround-bg, #000d11);
   overflow: auto;
 }
 
 .terminalWrapper {
   outline: none;
+  /* Border around the drawable canvas. Longhands (not the `border`
+     shorthand) so editor consumers can drive each piece via custom
+     properties — the shorthand doesn't reliably substitute nested
+     `var()` references in every browser. Defaults to no border so
+     runtime playback stays chrome-free. */
+  border-style: var(--ansi-canvas-border-style, none);
+  border-width: var(--ansi-canvas-border-width, 0);
+  border-color: var(--ansi-canvas-border-color, transparent);
   border-radius: 0;
   cursor: default;
   user-select: none;

--- a/lua-learning-website/src/components/AnsiTerminalPanel/AnsiTerminalPanel.test.tsx
+++ b/lua-learning-website/src/components/AnsiTerminalPanel/AnsiTerminalPanel.test.tsx
@@ -196,6 +196,38 @@ describe('AnsiTerminalPanel — pixel variant (default)', () => {
     expect(mockRenderer.dispose).toHaveBeenCalled()
   })
 
+  it('applies surroundClassName to the container element (pixel variant)', async () => {
+    const { container } = render(
+      <AnsiTerminalPanel surroundClassName="editor-surround" onTerminalReady={vi.fn()} />,
+    )
+    await act(async () => {})
+    const outer = container.firstChild as HTMLElement
+    expect(outer.classList.contains('container')).toBe(true)
+    expect(outer.classList.contains('editor-surround')).toBe(true)
+  })
+
+  it('omits surroundClassName when not provided (pixel variant)', async () => {
+    const { container } = render(<AnsiTerminalPanel onTerminalReady={vi.fn()} />)
+    await act(async () => {})
+    const outer = container.firstChild as HTMLElement
+    expect(outer.classList.contains('container')).toBe(true)
+    expect(outer.className).not.toMatch(/editor-surround/)
+  })
+
+  it('applies surroundClassName to the container element (xterm variant)', async () => {
+    const { container } = render(
+      <AnsiTerminalPanel
+        useFontBlocks={false}
+        surroundClassName="editor-surround"
+        onTerminalReady={vi.fn()}
+      />,
+    )
+    await act(async () => {})
+    const outer = container.firstChild as HTMLElement
+    expect(outer.classList.contains('container')).toBe(true)
+    expect(outer.classList.contains('editor-surround')).toBe(true)
+  })
+
   it('constructs a new renderer on useFontBlocks toggle (key-swap remount)', async () => {
     const onTerminalReady = vi.fn()
     const { rerender, unmount } = render(

--- a/lua-learning-website/src/components/AnsiTerminalPanel/AnsiTerminalPanelPixel.tsx
+++ b/lua-learning-website/src/components/AnsiTerminalPanel/AnsiTerminalPanelPixel.tsx
@@ -23,6 +23,7 @@ export function AnsiTerminalPanelPixel({
   fontId = DEFAULT_FONT_ID,
   zoom,
   onTerminalReady,
+  surroundClassName,
 }: AnsiTerminalPanelProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const wrapperRef = useRef<HTMLDivElement>(null)
@@ -167,10 +168,14 @@ export function AnsiTerminalPanelPixel({
     wrapperRef.current?.focus()
   }, [])
 
+  const containerClassName = surroundClassName
+    ? `${styles.container} ${surroundClassName}`
+    : styles.container
+
   return (
     <div
       ref={containerRef}
-      className={styles.container}
+      className={containerClassName}
       onMouseDown={handleMouseDown}
     >
       <div ref={wrapperRef} className={styles.terminalWrapper} tabIndex={0} />

--- a/lua-learning-website/src/components/AnsiTerminalPanel/AnsiTerminalPanelXterm.tsx
+++ b/lua-learning-website/src/components/AnsiTerminalPanel/AnsiTerminalPanelXterm.tsx
@@ -35,6 +35,7 @@ export function AnsiTerminalPanelXterm({
   fontId = DEFAULT_FONT_ID,
   zoom,
   onTerminalReady,
+  surroundClassName,
 }: AnsiTerminalPanelProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const wrapperRef = useRef<HTMLDivElement>(null)
@@ -223,10 +224,14 @@ export function AnsiTerminalPanelXterm({
     wrapperRef.current?.focus()
   }, [])
 
+  const containerClassName = surroundClassName
+    ? `${styles.container} ${surroundClassName}`
+    : styles.container
+
   return (
     <div
       ref={containerRef}
-      className={styles.container}
+      className={containerClassName}
       onMouseDown={handleMouseDown}
     >
       <div ref={wrapperRef} className={styles.terminalWrapper} tabIndex={0} />

--- a/lua-learning-website/src/components/AnsiTerminalPanel/types.ts
+++ b/lua-learning-website/src/components/AnsiTerminalPanel/types.ts
@@ -60,4 +60,11 @@ export interface AnsiTerminalPanelProps {
    * Called with the handle on mount and with null on unmount.
    */
   onTerminalReady?: (handle: AnsiTerminalHandle | null) => void
+  /**
+   * Extra class merged onto the panel's outer container element. Lets
+   * consumers layer additional surround styling (e.g. the ANSI editor's
+   * lighter background + border) without affecting other consumers
+   * (e.g. runtime ANSI playback) that share this panel.
+   */
+  surroundClassName?: string
 }

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,6 @@
+{
+  "status": "failed",
+  "failedTests": [
+    "26f2e73933f27731fcf0-49f584eab30fa8d3741e"
+  ]
+}


### PR DESCRIPTION
## Summary
Adds a 1px border around the drawable canvas in the ANSI editor and lightens the surround so a black canvas no longer blends into the chrome. Editor-only — runtime ANSI playback is unchanged.

Implementation surfaces a `surroundClassName` prop on `AnsiTerminalPanel`, which both renderer variants (pixel + xterm) merge onto their outer container. The ANSI editor passes a class that sets two CSS custom properties (`--ansi-surround-bg` and the three `--ansi-canvas-border-*` longhands). The panel CSS reads them with sensible defaults (the pre-existing `#000d11` surround and no border) so consumers that don't pass the prop see no behavior change. Custom-property longhands are used instead of the `border` shorthand because nested `var()` substitution into shorthands is unreliable.

Closes #774.

## Test plan
- [ ] Open the ANSI editor (Activity bar → Extensions → ANSI Graphics Editor) and confirm the drawable canvas has a visible 1px border and the area outside the canvas is lighter than a fully-black canvas.
- [ ] Confirm the runtime ANSI tab visuals are unchanged (run a Lua script that calls `ansi.start()`; the runtime canvas surround stays the deep blue-black `#000d11` with no border).
- [ ] Toggle the editor's `useFontBlocks` (font-blocks) setting to swap renderer variants and confirm both pixel and xterm paths render the surround styling identically.
- [ ] Pan/zoom the editor canvas and confirm the border tightly hugs the wrapper at every zoom level and does not scroll independently of the canvas.
- [ ] Verify the new colors fit the existing IDE palette (no jarring saturation, no theme break) in both light and dark themes.

## Manual Testing
**UI Changes:**
  - [ ] Verify `AnsiGraphicsEditor` renders correctly
  - [ ] Verify `AnsiTerminalPanelPixel` renders correctly
  - [ ] Verify `AnsiTerminalPanelXterm` renders correctly

**Visual Changes:**
  - [ ] Check styling changes visually across affected components

Fixes #774

🤖 Generated with [Claude Code](https://claude.com/claude-code)