### PR TITLE
fix(ansi-runtime): sync handle to controller on attach in start()

### DIFF
--- a/packages/lua-runtime/src/AnsiController.ts
+++ b/packages/lua-runtime/src/AnsiController.ts
@@ -183,6 +183,24 @@ export class AnsiController {
     // Request ANSI tab from UI
     this.handle = await this.callbacks.onRequestAnsiTab(this.ansiId)
 
+    // Sync the freshly-attached handle to whatever state the controller
+    // accumulated before start(). set_screen() called before ansi.start()
+    // (the pattern every example uses) updates currentCols/currentRows/
+    // currentFont but cannot push to a null handle, so without this the
+    // panel stays at its mount-time 80×25 / default font even though the
+    // controller is already compositing at the screen's real dims.
+    // Only forward when the controller has moved off defaults — panels
+    // mount at the same defaults, so a redundant resize is avoidable.
+    if (this.currentCols !== DEFAULT_ANSI_COLS || this.currentRows !== DEFAULT_ANSI_ROWS) {
+      this.handle.resize?.(this.currentCols, this.currentRows)
+    }
+    if (this.currentFont !== DEFAULT_ANSI_FONT_ID) {
+      this.handle.setFontFamily?.(this.currentFont)
+    }
+    if (this.currentUseFontBlocks !== DEFAULT_USE_FONT_BLOCKS) {
+      this.handle.setUseFontBlocks?.(this.currentUseFontBlocks)
+    }
+
     // Register close handler so UI can stop us when tab is closed
     this.callbacks.registerAnsiCloseHandler?.(this.ansiId, () => this.stop())
 
@@ -284,8 +302,8 @@ export class AnsiController {
   /**
    * Apply per-screen font + renderer-mode settings to the attached handle,
    * skipping calls when the values are unchanged. Safe to call before the
-   * handle is attached — values are remembered on the controller and
-   * applied the next time `setScreen` runs after a handle attaches.
+   * handle is attached — values are remembered on the controller, and
+   * `start()` forwards them to the handle once it attaches.
    */
   private applyFontSettings(font: string, useFontBlocks: boolean): void {
     if (font !== this.currentFont) {

--- a/packages/lua-runtime/tests/AnsiController.resize.test.ts
+++ b/packages/lua-runtime/tests/AnsiController.resize.test.ts
@@ -27,12 +27,20 @@ function makeV1Data(cols: number, rows: number, char: string): Record<string, un
   return { version: 1, width: cols, height: rows, grid }
 }
 
-function makeHandle(): AnsiTerminalHandle & { resize: ReturnType<typeof vi.fn> } {
+interface HandleMocks {
+  resize: ReturnType<typeof vi.fn>
+  setFontFamily: ReturnType<typeof vi.fn>
+  setUseFontBlocks: ReturnType<typeof vi.fn>
+}
+
+function makeHandle(): AnsiTerminalHandle & HandleMocks {
   return {
     write: vi.fn(),
     container: { getBoundingClientRect: () => ({ width: 800, height: 500 }) } as unknown as HTMLElement,
     dispose: vi.fn(),
     resize: vi.fn(),
+    setFontFamily: vi.fn(),
+    setUseFontBlocks: vi.fn(),
   }
 }
 
@@ -112,6 +120,24 @@ describe('AnsiController — terminal resize on screen load', () => {
     controller.setCursor(35, 110)
     // Row 35 is within 40, col 110 is within 120 — no clamping.
     expect((handle.write as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith('\x1b[35;110H')
+    await teardown()
+  })
+
+  // Regression: every example program calls set_screen() before ansi.start().
+  // setScreen runs resizeTerminal (which does handle?.resize) while the handle
+  // is still null, so the panel never learned the new dims. start() must
+  // forward the controller's accumulated dims to the freshly-attached handle.
+  it('forwards pre-start setScreen dimensions to the handle once it attaches', async () => {
+    const id = controller.createScreen(makeV1Data(120, 40, 'A'))
+    // setScreen BEFORE bringUp — handle is still null inside resizeTerminal,
+    // so the resize call must come from start() instead.
+    controller.setScreen(id)
+    expect(handle.resize).not.toHaveBeenCalled()
+    expect(controller.getCols()).toBe(120)
+    expect(controller.getRows()).toBe(40)
+
+    const teardown = await bringUp(controller)
+    expect(handle.resize).toHaveBeenCalledWith(120, 40)
     await teardown()
   })
 })


### PR DESCRIPTION
## Summary

- `set_screen()` called **before** `ansi.start()` (the pattern every ANSI example uses) updated `currentCols/Rows/Font` on the controller but couldn't push to a null handle. The freshly-attached handle then stayed at its mount-time 80×25 / default font even though the controller composited at the screen's authored dims, so non-default screens (e.g. 120×32) rendered into a still-80×25 terminal with wrap and clipping.
- `start()` now forwards the controller's dims, font, and `useFontBlocks` to the handle once it attaches, conditionally on each value having moved off its default — so panels that already match the defaults don't take a redundant resize.
- Adds a regression test that reproduces the bug: `setScreen(120×40)` before `bringUp`, then assert `handle.resize` was called with `(120, 40)` after start ran.
- Drops the misleading "applied the next time `setScreen` runs" claim from the `applyFontSettings` doc comment — `start()` is now what forwards them.

The fix lands in the standalone export automatically since it bundles `AnsiController` from the runtime; the export bundle was rebuilt and all export tests pass.

## Test plan

- [x] `AnsiController.resize` tests — 7/7 pass (was 6, +1 new regression test)
- [x] Full lua-runtime suite — 1738/1738 pass
- [x] Export suite (rebundled with the fix) — 203/203 pass
- [x] AnsiTerminalPanel website tests — 24/24 pass
- [x] Website tsc — clean
- [ ] Manual: load `load_screen_demo.lua` against a non-80×25 `.ansi.lua` and confirm the runtime tab + standalone export both render at the screen's authored dims

🤖 Generated with [Claude Code](https://claude.com/claude-code)