### PR TITLE
feat(ansi-editor): expose text layer default color via context menu

### DIFF
--- a/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.tsx
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.tsx
@@ -142,7 +142,7 @@ export function AnsiGraphicsEditor({ filePath, onDirtyChange, isActive }: AnsiGr
     textBoundsRef,
     textCursorRef,
     setTextAlign,
-    setTextLayerFg,
+    setTextLayerFgFromBrush,
     flipSelectionHorizontal,
     flipSelectionVertical,
     cgaPreview,
@@ -494,7 +494,7 @@ export function AnsiGraphicsEditor({ filePath, onDirtyChange, isActive }: AnsiGr
           onCreateTag={createTag}
           onDeleteTag={deleteTag}
           onRenameTag={renameTag}
-          onSetTextLayerFgFromBrush={(layerId) => setTextLayerFg(layerId, brush.fg)}
+          onSetTextLayerFgFromBrush={setTextLayerFgFromBrush}
           crtConfig={crtConfig}
           onSetCrtConfig={setCrtConfig}
         />

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.tsx
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/AnsiGraphicsEditor.tsx
@@ -142,6 +142,7 @@ export function AnsiGraphicsEditor({ filePath, onDirtyChange, isActive }: AnsiGr
     textBoundsRef,
     textCursorRef,
     setTextAlign,
+    setTextLayerFg,
     flipSelectionHorizontal,
     flipSelectionVertical,
     cgaPreview,
@@ -493,6 +494,7 @@ export function AnsiGraphicsEditor({ filePath, onDirtyChange, isActive }: AnsiGr
           onCreateTag={createTag}
           onDeleteTag={deleteTag}
           onRenameTag={renameTag}
+          onSetTextLayerFgFromBrush={(layerId) => setTextLayerFg(layerId, brush.fg)}
           crtConfig={crtConfig}
           onSetCrtConfig={setCrtConfig}
         />

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/LayerContextMenu.tsx
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/LayerContextMenu.tsx
@@ -22,6 +22,7 @@ export interface LayerContextMenuProps {
   onAddTagToLayer: (layerId: string, tag: string) => void
   onRemoveTagFromLayer: (layerId: string, tag: string) => void
   onSetTagsSubmenuOpen: (open: boolean) => void
+  onSetTextLayerFgFromBrush: (layerId: string) => void
   onClose: () => void
   onBackdropContextMenu: (e: React.MouseEvent) => void
 }
@@ -46,6 +47,7 @@ export function LayerContextMenu({
   onAddTagToLayer,
   onRemoveTagFromLayer,
   onSetTagsSubmenuOpen,
+  onSetTextLayerFgFromBrush,
   onClose,
   onBackdropContextMenu,
 }: LayerContextMenuProps): React.JSX.Element {
@@ -122,6 +124,15 @@ export function LayerContextMenu({
         >
           Copy Layer ID
         </button>
+        {contextLayer?.type === 'text' && (
+          <button
+            className={styles.layerContextMenuItem}
+            data-testid="context-set-text-fg-from-brush"
+            onClick={() => { onSetTextLayerFgFromBrush(contextMenu.layerId); close() }}
+          >
+            Set Default Color From Brush
+          </button>
+        )}
         <div
           className={[styles.layerContextMenuItem, styles.layerContextMenuItemSubmenu].filter(Boolean).join(' ')}
           data-testid="context-tags-submenu-trigger"

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/LayerContextMenu.tsx
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/LayerContextMenu.tsx
@@ -130,7 +130,7 @@ export function LayerContextMenu({
             data-testid="context-set-text-fg-from-brush"
             onClick={() => { onSetTextLayerFgFromBrush(contextMenu.layerId); close() }}
           >
-            Set Default Color From Brush
+            Set Default Color from Brush
           </button>
         )}
         <div

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/LayersPanel.test.tsx
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/LayersPanel.test.tsx
@@ -38,6 +38,7 @@ describe('LayersPanel', () => {
     onCreateTag?: (tag: string) => void
     onDeleteTag?: (tag: string) => void
     onRenameTag?: (oldTag: string, newTag: string) => void
+    onSetTextLayerFgFromBrush?: (layerId: string) => void
   }) {
     const layers = overrides?.layers ?? makeLayers('Background', 'Foreground')
     return render(
@@ -66,8 +67,25 @@ describe('LayersPanel', () => {
         onCreateTag={overrides?.onCreateTag ?? noop}
         onDeleteTag={overrides?.onDeleteTag ?? noop}
         onRenameTag={overrides?.onRenameTag ?? noop}
+        onSetTextLayerFgFromBrush={overrides?.onSetTextLayerFgFromBrush ?? noop}
       />
     )
+  }
+
+  function makeTextLayer(id: string, name = 'Label'): TextLayer {
+    const emptyGrid = Array.from({ length: ANSI_ROWS }, () =>
+      Array.from({ length: ANSI_COLS }, () => ({ ...DEFAULT_CELL }))
+    )
+    return {
+      type: 'text',
+      id,
+      name,
+      visible: true,
+      text: 'Hi',
+      bounds: { r0: 0, c0: 0, r1: 2, c1: 10 },
+      textFg: [170, 85, 0],
+      grid: emptyGrid,
+    }
   }
 
   it('renders layer names', () => {
@@ -469,6 +487,41 @@ describe('LayersPanel', () => {
       // Context menu should still be open, now for layer-0
       expect(screen.getByTestId('layer-context-menu')).toBeTruthy()
       expect(screen.getByTestId('context-merge-down')).toBeDisabled()
+    })
+
+    it('shows "Set Default Color From Brush" for text layers', () => {
+      const drawn = createLayer('Background', 'layer-0')
+      const text = makeTextLayer('text-1')
+      renderPanel({ layers: [drawn, text] })
+      fireEvent.contextMenu(screen.getByTestId('layer-row-text-1'))
+      const item = screen.getByTestId('context-set-text-fg-from-brush')
+      expect(item).toBeTruthy()
+      expect(item.textContent).toBe('Set Default Color From Brush')
+    })
+
+    it('does not show "Set Default Color From Brush" for drawn layers', () => {
+      renderPanel()
+      fireEvent.contextMenu(screen.getByTestId('layer-row-layer-1'))
+      expect(screen.queryByTestId('context-set-text-fg-from-brush')).toBeNull()
+    })
+
+    it('clicking "Set Default Color From Brush" calls onSetTextLayerFgFromBrush with the layer id', () => {
+      const drawn = createLayer('Background', 'layer-0')
+      const text = makeTextLayer('text-1')
+      const onSetTextLayerFgFromBrush = vi.fn()
+      renderPanel({ layers: [drawn, text], onSetTextLayerFgFromBrush })
+      fireEvent.contextMenu(screen.getByTestId('layer-row-text-1'))
+      fireEvent.click(screen.getByTestId('context-set-text-fg-from-brush'))
+      expect(onSetTextLayerFgFromBrush).toHaveBeenCalledWith('text-1')
+    })
+
+    it('closes context menu after clicking "Set Default Color From Brush"', () => {
+      const drawn = createLayer('Background', 'layer-0')
+      const text = makeTextLayer('text-1')
+      renderPanel({ layers: [drawn, text] })
+      fireEvent.contextMenu(screen.getByTestId('layer-row-text-1'))
+      fireEvent.click(screen.getByTestId('context-set-text-fg-from-brush'))
+      expect(screen.queryByTestId('layer-context-menu')).toBeNull()
     })
 
     it('right-clicking backdrop over non-layer area closes context menu', () => {

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/LayersPanel.test.tsx
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/LayersPanel.test.tsx
@@ -489,37 +489,35 @@ describe('LayersPanel', () => {
       expect(screen.getByTestId('context-merge-down')).toBeDisabled()
     })
 
-    it('shows "Set Default Color From Brush" for text layers', () => {
+    function openTextLayerContextMenu(onSetTextLayerFgFromBrush?: (id: string) => void) {
       const drawn = createLayer('Background', 'layer-0')
       const text = makeTextLayer('text-1')
-      renderPanel({ layers: [drawn, text] })
+      renderPanel({ layers: [drawn, text], onSetTextLayerFgFromBrush })
       fireEvent.contextMenu(screen.getByTestId('layer-row-text-1'))
+    }
+
+    it('shows "Set Default Color from Brush" for text layers', () => {
+      openTextLayerContextMenu()
       const item = screen.getByTestId('context-set-text-fg-from-brush')
       expect(item).toBeTruthy()
-      expect(item.textContent).toBe('Set Default Color From Brush')
+      expect(item.textContent).toBe('Set Default Color from Brush')
     })
 
-    it('does not show "Set Default Color From Brush" for drawn layers', () => {
+    it('does not show "Set Default Color from Brush" for drawn layers', () => {
       renderPanel()
       fireEvent.contextMenu(screen.getByTestId('layer-row-layer-1'))
       expect(screen.queryByTestId('context-set-text-fg-from-brush')).toBeNull()
     })
 
-    it('clicking "Set Default Color From Brush" calls onSetTextLayerFgFromBrush with the layer id', () => {
-      const drawn = createLayer('Background', 'layer-0')
-      const text = makeTextLayer('text-1')
+    it('clicking "Set Default Color from Brush" calls onSetTextLayerFgFromBrush with the layer id', () => {
       const onSetTextLayerFgFromBrush = vi.fn()
-      renderPanel({ layers: [drawn, text], onSetTextLayerFgFromBrush })
-      fireEvent.contextMenu(screen.getByTestId('layer-row-text-1'))
+      openTextLayerContextMenu(onSetTextLayerFgFromBrush)
       fireEvent.click(screen.getByTestId('context-set-text-fg-from-brush'))
       expect(onSetTextLayerFgFromBrush).toHaveBeenCalledWith('text-1')
     })
 
-    it('closes context menu after clicking "Set Default Color From Brush"', () => {
-      const drawn = createLayer('Background', 'layer-0')
-      const text = makeTextLayer('text-1')
-      renderPanel({ layers: [drawn, text] })
-      fireEvent.contextMenu(screen.getByTestId('layer-row-text-1'))
+    it('closes context menu after clicking "Set Default Color from Brush"', () => {
+      openTextLayerContextMenu()
       fireEvent.click(screen.getByTestId('context-set-text-fg-from-brush'))
       expect(screen.queryByTestId('layer-context-menu')).toBeNull()
     })

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/LayersPanel.tsx
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/LayersPanel.tsx
@@ -36,6 +36,7 @@ export interface LayersPanelProps {
   onCreateTag: (tag: string) => void
   onDeleteTag: (tag: string) => void
   onRenameTag: (oldTag: string, newTag: string) => void
+  onSetTextLayerFgFromBrush: (layerId: string) => void
   crtConfig?: CrtConfig | null
   onSetCrtConfig?: (config: CrtConfig | null) => void
 }
@@ -77,6 +78,7 @@ export function LayersPanel({
   onCreateTag,
   onDeleteTag,
   onRenameTag,
+  onSetTextLayerFgFromBrush,
   crtConfig,
   onSetCrtConfig,
 }: LayersPanelProps) {
@@ -396,6 +398,7 @@ export function LayersPanel({
           onAddTagToLayer={onAddTagToLayer}
           onRemoveTagFromLayer={onRemoveTagFromLayer}
           onSetTagsSubmenuOpen={setTagsSubmenuOpen}
+          onSetTextLayerFgFromBrush={onSetTextLayerFgFromBrush}
           onClose={closeContextMenu}
           onBackdropContextMenu={handleBackdropContextMenu}
         />

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/types.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/types.ts
@@ -250,7 +250,7 @@ export interface UseAnsiEditorReturn {
   importLayersWithUndo: (layers: Layer[]) => void
   simplifyColors: (mapping: Map<string, RGBColor>, scope: 'current' | 'layer') => void
   setTextAlign: (align: TextAlign) => void
-  setTextLayerFg: (layerId: string, textFg: RGBColor) => void
+  setTextLayerFgFromBrush: (layerId: string) => void
   flipSelectionHorizontal: () => void
   flipSelectionVertical: () => void
   // Move tool

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/types.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/types.ts
@@ -250,6 +250,7 @@ export interface UseAnsiEditorReturn {
   importLayersWithUndo: (layers: Layer[]) => void
   simplifyColors: (mapping: Map<string, RGBColor>, scope: 'current' | 'layer') => void
   setTextAlign: (align: TextAlign) => void
+  setTextLayerFg: (layerId: string, textFg: RGBColor) => void
   flipSelectionHorizontal: () => void
   flipSelectionVertical: () => void
   // Move tool

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/useAnsiEditor.setTextLayerFg.test.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/useAnsiEditor.setTextLayerFg.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useAnsiEditor } from './useAnsiEditor'
+import type { AnsiGrid, LayerState, RGBColor, TextLayer } from './types'
+
+const emptyCell = { char: ' ', fg: [0, 0, 0] as RGBColor, bg: [0, 0, 0] as RGBColor }
+const emptyGrid: AnsiGrid = [[{ ...emptyCell }]]
+
+function textLayerState(textFg: RGBColor): LayerState {
+  return {
+    layers: [{
+      type: 'text',
+      id: 'text-1',
+      name: 'Label',
+      visible: true,
+      text: '',
+      bounds: { r0: 0, c0: 0, r1: 0, c1: 4 },
+      textFg,
+      grid: emptyGrid,
+    } as TextLayer],
+    activeLayerId: 'text-1',
+  }
+}
+
+describe('useAnsiEditor.setTextLayerFgFromBrush', () => {
+  it('updates the targeted text layer’s textFg from the current brush', () => {
+    const { result } = renderHook(() => useAnsiEditor({ initialLayerState: textLayerState([170, 85, 0]) }))
+    const green: RGBColor = [0, 170, 0]
+    act(() => result.current.setBrushFg(green))
+    act(() => result.current.setTextLayerFgFromBrush('text-1'))
+    const layer = result.current.layers.find(l => l.id === 'text-1') as TextLayer
+    expect(layer.textFg).toEqual(green)
+  })
+
+  it('is undoable', () => {
+    const orange: RGBColor = [170, 85, 0]
+    const { result } = renderHook(() => useAnsiEditor({ initialLayerState: textLayerState(orange) }))
+    act(() => result.current.setBrushFg([0, 170, 0]))
+    act(() => result.current.setTextLayerFgFromBrush('text-1'))
+    expect(result.current.canUndo).toBe(true)
+    act(() => result.current.undo())
+    const layer = result.current.layers.find(l => l.id === 'text-1') as TextLayer
+    expect(layer.textFg).toEqual(orange)
+  })
+
+  it('is a no-op for non-text layers (silently)', () => {
+    const drawnOnlyState: LayerState = {
+      layers: [{
+        type: 'drawn', id: 'bg', name: 'Background', visible: true,
+        grid: emptyGrid,
+        frames: [emptyGrid], currentFrameIndex: 0, frameDurationMs: 100,
+      }],
+      activeLayerId: 'bg',
+    }
+    const { result } = renderHook(() => useAnsiEditor({ initialLayerState: drawnOnlyState }))
+    act(() => result.current.setBrushFg([0, 170, 0]))
+    act(() => result.current.setTextLayerFgFromBrush('bg'))
+    expect(result.current.canUndo).toBe(false)
+  })
+})

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/useAnsiEditor.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/useAnsiEditor.ts
@@ -879,13 +879,14 @@ export function useAnsiEditor(options?: UseAnsiEditorOptions): UseAnsiEditorRetu
     textToolRef.current?.refreshOverlays()
   }, [pushSnapshot, rawUpdateTextLayer, layersRef, activeLayerIdRef])
 
-  const setTextLayerFg = useCallback((layerId: string, textFg: RGBColor) => {
+  const setTextLayerFgFromBrush = useCallback((layerId: string) => {
     const layer = layersRef.current.find(l => l.id === layerId)
     if (!layer || layer.type !== 'text') return
     pushSnapshot()
-    rawUpdateTextLayer(layerId, { textFg })
+    rawUpdateTextLayer(layerId, { textFg: [...brushRef.current.fg] as RGBColor })
     setIsDirty(true)
     flushLayers(layersRef.current)
+    textToolRef.current?.refreshOverlays()
   }, [pushSnapshot, rawUpdateTextLayer, layersRef])
 
   const setCgaPreview = useCallback((on: boolean) => {
@@ -1013,7 +1014,7 @@ export function useAnsiEditor(options?: UseAnsiEditorOptions): UseAnsiEditorRetu
     mergeDown: mergeDownWithUndo,
     wrapInGroup: wrapInGroupWithUndo, removeFromGroup: removeFromGroupWithUndo,
     duplicateLayer: duplicateLayerWithUndo, toggleGroupCollapsed: toggleGroupCollapsedNoUndo,
-    importPngAsLayer, parseAnsiFile, importLayersWithUndo, simplifyColors, setTextAlign, setTextLayerFg, flipSelectionHorizontal, flipSelectionVertical,
+    importPngAsLayer, parseAnsiFile, importLayersWithUndo, simplifyColors, setTextAlign, setTextLayerFgFromBrush, flipSelectionHorizontal, flipSelectionVertical,
     activeLayerIsGroup, isMoveDragging,
     flipOriginOverlayRef, flipOrigin, flipLayerHorizontal, flipLayerVertical,
     cgaPreview, setCgaPreview,

--- a/lua-learning-website/src/components/AnsiGraphicsEditor/useAnsiEditor.ts
+++ b/lua-learning-website/src/components/AnsiGraphicsEditor/useAnsiEditor.ts
@@ -879,6 +879,15 @@ export function useAnsiEditor(options?: UseAnsiEditorOptions): UseAnsiEditorRetu
     textToolRef.current?.refreshOverlays()
   }, [pushSnapshot, rawUpdateTextLayer, layersRef, activeLayerIdRef])
 
+  const setTextLayerFg = useCallback((layerId: string, textFg: RGBColor) => {
+    const layer = layersRef.current.find(l => l.id === layerId)
+    if (!layer || layer.type !== 'text') return
+    pushSnapshot()
+    rawUpdateTextLayer(layerId, { textFg })
+    setIsDirty(true)
+    flushLayers(layersRef.current)
+  }, [pushSnapshot, rawUpdateTextLayer, layersRef])
+
   const setCgaPreview = useCallback((on: boolean) => {
     setCgaPreviewRaw(on)
     colorTransformRef.current = on ? cgaQuantize : undefined
@@ -1004,7 +1013,7 @@ export function useAnsiEditor(options?: UseAnsiEditorOptions): UseAnsiEditorRetu
     mergeDown: mergeDownWithUndo,
     wrapInGroup: wrapInGroupWithUndo, removeFromGroup: removeFromGroupWithUndo,
     duplicateLayer: duplicateLayerWithUndo, toggleGroupCollapsed: toggleGroupCollapsedNoUndo,
-    importPngAsLayer, parseAnsiFile, importLayersWithUndo, simplifyColors, setTextAlign, flipSelectionHorizontal, flipSelectionVertical,
+    importPngAsLayer, parseAnsiFile, importLayersWithUndo, simplifyColors, setTextAlign, setTextLayerFg, flipSelectionHorizontal, flipSelectionVertical,
     activeLayerIsGroup, isMoveDragging,
     flipOriginOverlayRef, flipOrigin, flipLayerHorizontal, flipLayerVertical,
     cgaPreview, setCgaPreview,


### PR DESCRIPTION
## Summary
- Adds a **"Set Default Color From Brush"** item to the Layers panel context menu, visible only on text layers.
- Wires it through `useAnsiEditor` (`setTextLayerFg`) to update the target layer's `textFg` with the current brush foreground (snapshot + undo + dirty + flush, matching the existing `setTextAlign` pattern).
- The item is hidden for drawn/group/clip/reference layers.

## Why
Before this change, a text layer's `textFg` was set once at creation (from whatever brush color was active at that moment) and there was **no UI** anywhere in the editor to update it. Authors who changed the brush color before typing ended up with per-character colors that differed from the layer's default. The discrepancy was invisible in the editor (per-character colors render fine), but `screen:set_label(id, "string")` from Lua falls back to `textFg`, causing characters to render in the stale creation-time color (e.g. the simyon-adventure `computer-monitor-area` rendering orange instead of green).

This closes the UX gap: text-layer default color is now editable.

## Test plan
- [x] TDD: 3 red→green tests in `LayersPanel.test.tsx` for show/hide gating and the callback invocation
- [x] `npm run lint` — 0 errors (pre-existing warnings unchanged)
- [x] `tsc -p lua-learning-website/tsconfig.app.json --noEmit` — clean
- [x] Full `lua-learning-website` test suite — 4595/4595 pass (pre-push gate)
- [ ] Manual verification in the dev server: open a text layer, switch brush color, right-click the layer → "Set Default Color From Brush", confirm `textFg` updates and undo works

🤖 Generated with [Claude Code](https://claude.com/claude-code)