### PR TITLE
feat(#781): ANSI project.lua + Lua API override for useFontBlocks

### DIFF
--- a/lua-learning-website/public/docs/ansi.md
+++ b/lua-learning-website/public/docs/ansi.md
@@ -742,6 +742,50 @@ end)
 ansi.start()
 ```
 
+## Renderer Toggle (Pixel Renderer)
+
+Each ANSI screen file (`.ansi.lua`) saves a `useFontBlocks` flag that selects between the **pixel renderer** (true; renders block characters from pre-extracted bitmap masks for pixel-perfect output) and the **legacy xterm path** (false). The editor's "Use pixel renderer (font blocks)" checkbox writes this field.
+
+You can override the per-screen value in two places:
+
+### Project-level override (`project.lua`)
+
+```lua
+return {
+  name = "My ANSI App",
+  main = "main.lua",
+  type = "ansi",
+  ansi = {
+    use_font_blocks = "auto",  -- "on" | "off" | "auto"
+  },
+}
+```
+
+- `"auto"` (default): use each screen's saved `useFontBlocks` value.
+- `"on"`: force the pixel renderer for every screen, regardless of the file's saved value.
+- `"off"`: force the legacy xterm path for every screen.
+
+### Runtime override: `ansi.set_use_font_blocks(value)`
+
+Override the renderer at any point while the program is running:
+
+```lua
+ansi.set_use_font_blocks(true)   -- force pixel renderer for every screen
+ansi.set_use_font_blocks(false)  -- force legacy xterm path
+ansi.set_use_font_blocks(nil)    -- clear the runtime override; defer to
+                                  -- project.lua (then to each screen's saved value)
+```
+
+### Resolution priority
+
+When `ansi.set_screen()` activates a screen, the effective `useFontBlocks` value is resolved as:
+
+1. **Runtime override** (`ansi.set_use_font_blocks(true/false)`) — highest priority.
+2. **Project override** (`ansi.use_font_blocks = "on"/"off"` in `project.lua`).
+3. **Screen value** (the screen's saved `useFontBlocks` field, or `true` if unset).
+
+`"auto"` and `nil` mean "not an override at this level — defer to the next one."
+
 ## Quick Reference
 
 | Function | Description |
@@ -771,6 +815,7 @@ ansi.start()
 | `screen:set_layer_offset(id, col, row)` | Set layer position offset in virtual canvas |
 | `screen:get_layer_offset(id)` | Get layer position offset (col, row) |
 | `ansi.crt(config)` | Enable/update CRT shader effect |
+| `ansi.set_use_font_blocks(v)` | Override pixel renderer at runtime (`true`/`false`/`nil`) |
 | `ansi.start()` | Start terminal (blocks until `stop()`) |
 | `ansi.stop()` | Stop terminal |
 | `ansi.tick(fn)` | Register per-frame callback |

--- a/lua-learning-website/src/components/IDELayout/AnsiTabContent.test.tsx
+++ b/lua-learning-website/src/components/IDELayout/AnsiTabContent.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { AnsiTabContent } from './AnsiTabContent'
+
+// Spy that captures the props handed to AnsiTerminalPanel so we can assert
+// useFontBlocks flows through. The real panel construction needs xterm /
+// PixelAnsiRenderer plumbing we don't care about here.
+const panelSpy = vi.fn()
+vi.mock('../AnsiTerminalPanel/AnsiTerminalPanel', () => ({
+  AnsiTerminalPanel: (props: Record<string, unknown>) => {
+    panelSpy(props)
+    return <div data-testid="ansi-terminal-panel-mock" />
+  },
+}))
+
+describe('AnsiTabContent', () => {
+  it('forwards useFontBlocks=true to AnsiTerminalPanel', () => {
+    panelSpy.mockClear()
+    render(
+      <AnsiTabContent
+        tabs={[{ path: 'ansi://main', name: 'ANSI', type: 'ansi', isDirty: false, isPreview: false, isPinned: false }]}
+        activeTab="ansi://main"
+        onSelectTab={vi.fn()}
+        onCloseTab={vi.fn()}
+        useFontBlocks={true}
+      />,
+    )
+    const last = panelSpy.mock.calls[panelSpy.mock.calls.length - 1][0]
+    expect(last.useFontBlocks).toBe(true)
+  })
+
+  it('forwards useFontBlocks=false to AnsiTerminalPanel', () => {
+    panelSpy.mockClear()
+    render(
+      <AnsiTabContent
+        tabs={[{ path: 'ansi://main', name: 'ANSI', type: 'ansi', isDirty: false, isPreview: false, isPinned: false }]}
+        activeTab="ansi://main"
+        onSelectTab={vi.fn()}
+        onCloseTab={vi.fn()}
+        useFontBlocks={false}
+      />,
+    )
+    const last = panelSpy.mock.calls[panelSpy.mock.calls.length - 1][0]
+    expect(last.useFontBlocks).toBe(false)
+  })
+
+  it('forwards undefined useFontBlocks (panel uses default)', () => {
+    panelSpy.mockClear()
+    render(
+      <AnsiTabContent
+        tabs={[{ path: 'ansi://main', name: 'ANSI', type: 'ansi', isDirty: false, isPreview: false, isPinned: false }]}
+        activeTab="ansi://main"
+        onSelectTab={vi.fn()}
+        onCloseTab={vi.fn()}
+      />,
+    )
+    const last = panelSpy.mock.calls[panelSpy.mock.calls.length - 1][0]
+    expect(last.useFontBlocks).toBeUndefined()
+  })
+})

--- a/lua-learning-website/src/components/IDELayout/AnsiTabContent.tsx
+++ b/lua-learning-website/src/components/IDELayout/AnsiTabContent.tsx
@@ -10,6 +10,12 @@ export interface AnsiTabContentProps {
   isActive?: boolean
   /** Callback when the terminal is ready, providing a handle for programmatic control */
   onTerminalReady?: (ansiId: string, handle: AnsiTerminalHandle | null) => void
+  /**
+   * Override the panel's renderer mount: `true` forces the pixel renderer,
+   * `false` forces the legacy xterm path, `undefined` leaves it on the
+   * AnsiTerminalPanel default. Comes from project.lua's `ansi.use_font_blocks`.
+   */
+  useFontBlocks?: boolean
 }
 
 export function AnsiTabContent({
@@ -19,6 +25,7 @@ export function AnsiTabContent({
   onCloseTab,
   isActive,
   onTerminalReady,
+  useFontBlocks,
 }: AnsiTabContentProps) {
   return (
     <div className={styles.canvasContainer}>
@@ -47,6 +54,7 @@ export function AnsiTabContent({
       </div>
       <AnsiTerminalPanel
         isActive={isActive}
+        useFontBlocks={useFontBlocks}
         onTerminalReady={onTerminalReady
           ? (handle) => {
               // Extract ansiId from active tab path (ansi://{ansiId})

--- a/lua-learning-website/src/components/IDELayout/IDELayout.tsx
+++ b/lua-learning-website/src/components/IDELayout/IDELayout.tsx
@@ -179,6 +179,16 @@ function IDELayoutInner({
   // Cached ANSI terminal handle -- allows immediate resolution when the terminal is already mounted
   const ansiTerminalHandleRef = useRef<AnsiTerminalHandle | null>(null)
 
+  // Listeners that subscribe to ANSI terminal-handle changes. The runtime
+  // controller registers one inside ansi.start() so it can pick up the new
+  // handle after a panel-variant remount.
+  const ansiHandleListenersRef = useRef<Set<(handle: unknown) => void>>(new Set())
+
+  const registerAnsiHandleListener = useCallback((listener: (handle: unknown) => void) => {
+    ansiHandleListenersRef.current.add(listener)
+    return () => { ansiHandleListenersRef.current.delete(listener) }
+  }, [])
+
   // Project.lua `ansi.use_font_blocks` override for the ANSI panel mount.
   // `true` / `false` force a variant; `undefined` leaves the AnsiTerminalPanel
   // default. Set by LuaScriptProcess via the `onAnsiPanelMode` callback.
@@ -232,6 +242,12 @@ function IDELayoutInner({
         resolver(handle)
         pendingAnsiRequestsRef.current.delete(key)
       }
+    }
+
+    // Notify any subscribed listeners (e.g., the runtime controller) so they
+    // can pick up the new handle after a panel-variant remount.
+    for (const listener of ansiHandleListenersRef.current) {
+      listener(handle)
     }
   }, [])
 
@@ -613,6 +629,7 @@ function IDELayoutInner({
     registerAnsiCloseHandler,
     unregisterAnsiCloseHandler,
     onAnsiPanelMode: handleAnsiPanelMode,
+    registerAnsiHandleListener,
   }), [
     handleRequestCanvasTab,
     handleCloseCanvasTab,
@@ -648,6 +665,7 @@ function IDELayoutInner({
     registerAnsiCloseHandler,
     unregisterAnsiCloseHandler,
     handleAnsiPanelMode,
+    registerAnsiHandleListener,
   ])
 
   const combinedClassName = className

--- a/lua-learning-website/src/components/IDELayout/IDELayout.tsx
+++ b/lua-learning-website/src/components/IDELayout/IDELayout.tsx
@@ -179,6 +179,24 @@ function IDELayoutInner({
   // Cached ANSI terminal handle -- allows immediate resolution when the terminal is already mounted
   const ansiTerminalHandleRef = useRef<AnsiTerminalHandle | null>(null)
 
+  // Project.lua `ansi.use_font_blocks` override for the ANSI panel mount.
+  // `true` / `false` force a variant; `undefined` leaves the AnsiTerminalPanel
+  // default. Set by LuaScriptProcess via the `onAnsiPanelMode` callback.
+  const [ansiPanelUseFontBlocks, setAnsiPanelUseFontBlocks] = useState<boolean | undefined>(undefined)
+  const ansiPanelUseFontBlocksRef = useRef<boolean | undefined>(undefined)
+
+  const handleAnsiPanelMode = useCallback((useFontBlocks: boolean | null) => {
+    const next = useFontBlocks === null ? undefined : useFontBlocks
+    if (next !== ansiPanelUseFontBlocksRef.current) {
+      // The panel variant is about to change — invalidate the cached handle
+      // so the next request waits for the freshly-mounted panel rather than
+      // returning the stale handle from the old variant.
+      ansiTerminalHandleRef.current = null
+      ansiPanelUseFontBlocksRef.current = next
+    }
+    setAnsiPanelUseFontBlocks(next)
+  }, [])
+
   // Handle ANSI tab request from shell (ansi.start())
   const handleRequestAnsiTab = useCallback(async (ansiId: string): Promise<AnsiTerminalHandle> => {
     const tabPath = `ansi://${ansiId}`
@@ -594,6 +612,7 @@ function IDELayoutInner({
     onCloseAnsiTab: handleCloseAnsiTab,
     registerAnsiCloseHandler,
     unregisterAnsiCloseHandler,
+    onAnsiPanelMode: handleAnsiPanelMode,
   }), [
     handleRequestCanvasTab,
     handleCloseCanvasTab,
@@ -628,6 +647,7 @@ function IDELayoutInner({
     handleCloseAnsiTab,
     registerAnsiCloseHandler,
     unregisterAnsiCloseHandler,
+    handleAnsiPanelMode,
   ])
 
   const combinedClassName = className
@@ -881,6 +901,7 @@ function IDELayoutInner({
                             onCloseTab={handleCloseTab}
                             isActive={activeTabType === 'ansi'}
                             onTerminalReady={handleAnsiTerminalReady}
+                            useFontBlocks={ansiPanelUseFontBlocks}
                           />
                         </div>
                       )}

--- a/lua-learning-website/src/hooks/useShell.ts
+++ b/lua-learning-website/src/hooks/useShell.ts
@@ -233,6 +233,14 @@ export interface ShellCanvasCallbacks {
    * Called by LuaScriptProcess before the panel is requested.
    */
   onAnsiPanelMode?: (useFontBlocks: boolean | null) => void
+  /**
+   * Subscribe to ANSI terminal-handle changes. The controller registers a
+   * listener that fires whenever the panel (re)mounts and a new handle
+   * becomes available. Returns an unsubscribe function.
+   */
+  registerAnsiHandleListener?: (
+    listener: (handle: unknown) => void
+  ) => () => void
 }
 
 /**
@@ -449,6 +457,7 @@ export function useShell(fileSystem: UseShellFileSystem, options?: UseShellOptio
         registerAnsiCloseHandler: options?.canvasCallbacks?.registerAnsiCloseHandler,
         unregisterAnsiCloseHandler: options?.canvasCallbacks?.unregisterAnsiCloseHandler,
         onAnsiPanelMode: options?.canvasCallbacks?.onAnsiPanelMode,
+        registerAnsiHandleListener: options?.canvasCallbacks?.registerAnsiHandleListener,
         // Editor integration callback for 'open' command
         onRequestOpenFile: options?.onRequestOpenFile,
         // Filesystem change notification for UI refresh (e.g., file tree)

--- a/lua-learning-website/src/hooks/useShell.ts
+++ b/lua-learning-website/src/hooks/useShell.ts
@@ -227,6 +227,12 @@ export interface ShellCanvasCallbacks {
   registerAnsiCloseHandler?: (ansiId: string, handler: () => void) => void
   /** Unregister the ANSI close handler */
   unregisterAnsiCloseHandler?: (ansiId: string) => void
+  /**
+   * Hint the UI which ANSI panel variant to mount (pixel vs xterm) based
+   * on the running script's `project.lua` `ansi.use_font_blocks` field.
+   * Called by LuaScriptProcess before the panel is requested.
+   */
+  onAnsiPanelMode?: (useFontBlocks: boolean | null) => void
 }
 
 /**
@@ -442,6 +448,7 @@ export function useShell(fileSystem: UseShellFileSystem, options?: UseShellOptio
         onCloseAnsiTab: options?.canvasCallbacks?.onCloseAnsiTab,
         registerAnsiCloseHandler: options?.canvasCallbacks?.registerAnsiCloseHandler,
         unregisterAnsiCloseHandler: options?.canvasCallbacks?.unregisterAnsiCloseHandler,
+        onAnsiPanelMode: options?.canvasCallbacks?.onAnsiPanelMode,
         // Editor integration callback for 'open' command
         onRequestOpenFile: options?.onRequestOpenFile,
         // Filesystem change notification for UI refresh (e.g., file tree)

--- a/packages/export/src/AnsiHtmlGenerator.ts
+++ b/packages/export/src/AnsiHtmlGenerator.ts
@@ -43,6 +43,11 @@ export function generateAnsiHtml(
   const fontSize = config.ansi?.font_size ?? 16
   const scaleMode = config.ansi?.scale ?? 'integer'
   const crtEnabled = config.ansi?.crt ?? false
+  const useFontBlocksMode = config.ansi?.use_font_blocks ?? 'auto'
+  const useFontBlocksOverride =
+    useFontBlocksMode === 'on' ? 'true'
+    : useFontBlocksMode === 'off' ? 'false'
+    : 'null'
 
   // Build CRT config JS object entries — use literal values when set, CRT_DEFAULTS fallback otherwise
   const crtConfigEntries = crtEnabled ? [
@@ -351,6 +356,8 @@ export function generateAnsiHtml(
       const AnsiController = globalThis.AnsiStandalone.AnsiController;
       const setupAnsiAPI = globalThis.AnsiStandalone.setupAnsiAPI;
       const controller = new AnsiController(callbacks);
+      // Apply the project-level use_font_blocks override from project.lua.
+      controller.setProjectUseFontBlocksOverride(${useFontBlocksOverride});
 
       // Initialize Lua runtime
       try {

--- a/packages/export/src/ExportCommand.ts
+++ b/packages/export/src/ExportCommand.ts
@@ -173,6 +173,11 @@ export class ExportCommand implements ICommand {
     rows = 25,
     font_size = 16,
     scale = "integer",  -- "integer" | "full" | "1x" | "2x" | "3x"
+    -- Override the per-screen pixel renderer toggle saved in each .ansi.lua:
+    --   "auto" (default): use whatever each screen's file specifies
+    --   "on": force the pixel renderer for every screen
+    --   "off": force the legacy xterm path for every screen
+    use_font_blocks = "auto",  -- "on" | "off" | "auto"
     -- CRT monitor effect
     -- crt = true,
     -- crt_smoothing = true,

--- a/packages/export/src/ProjectConfigParser.ts
+++ b/packages/export/src/ProjectConfigParser.ts
@@ -85,8 +85,11 @@ const DEFAULT_ANSI_CONFIG: AnsiConfig = {
   rows: 25,
   font_size: 16,
   scale: 'integer',
+  use_font_blocks: 'auto',
   crt: false,
 }
+
+const VALID_USE_FONT_BLOCKS = ['on', 'off', 'auto'] as const
 
 /**
  * Default export configuration values.
@@ -301,6 +304,10 @@ export class ProjectConfigParser {
         ...config.canvas,
       }
     } else if (config.type === 'ansi') {
+      const ufb = config.ansi?.use_font_blocks
+      if (ufb !== undefined && !VALID_USE_FONT_BLOCKS.includes(ufb)) {
+        throw new Error("ansi.use_font_blocks must be 'on', 'off', or 'auto'")
+      }
       result.ansi = {
         ...DEFAULT_ANSI_CONFIG,
         ...config.ansi,

--- a/packages/export/src/types.ts
+++ b/packages/export/src/types.ts
@@ -104,6 +104,14 @@ export interface AnsiConfig {
    */
   scale?: 'integer' | 'full' | '1x' | '2x' | '3x'
 
+  /**
+   * Project-level override for the pixel renderer toggle. Default: 'auto'.
+   * - 'on': force the pixel renderer regardless of each screen's saved value
+   * - 'off': force the xterm + CanvasAddon path regardless of saved value
+   * - 'auto': use each screen's `useFontBlocks` field from its .ansi.lua file
+   */
+  use_font_blocks?: 'on' | 'off' | 'auto'
+
   /** Enable CRT monitor effect (scanlines, vignette, phosphor glow). Default: false */
   crt?: boolean
 

--- a/packages/export/tests/ExportCommand.test.ts
+++ b/packages/export/tests/ExportCommand.test.ts
@@ -432,6 +432,33 @@ describe('ExportCommand', () => {
       expect(content).toContain('singleFile = true')
     })
 
+    it('should create ansi project template with --type=ansi', () => {
+      const command = new ExportCommand()
+      const filesystem = createMockFilesystem({})
+      const context = createMockContext(filesystem)
+
+      command.execute(['--init', '--type=ansi'], context)
+
+      const writeCall = (filesystem.writeFile as ReturnType<typeof vi.fn>).mock.calls[0]
+      const content = writeCall[1] as string
+      expect(content).toContain('type = "ansi"')
+      expect(content).toContain('columns = 80')
+      expect(content).toContain('rows = 25')
+    })
+
+    it('should include use_font_blocks in ansi template', () => {
+      const command = new ExportCommand()
+      const filesystem = createMockFilesystem({})
+      const context = createMockContext(filesystem)
+
+      command.execute(['--init', '--type=ansi'], context)
+
+      const writeCall = (filesystem.writeFile as ReturnType<typeof vi.fn>).mock.calls[0]
+      const content = writeCall[1] as string
+      expect(content).toContain('use_font_blocks')
+      expect(content).toContain('"on" | "off" | "auto"')
+    })
+
     it('should include export section with singleFile in shell template', () => {
       const command = new ExportCommand()
       const filesystem = createMockFilesystem({})

--- a/packages/export/tests/HtmlGenerator-ansi.test.ts
+++ b/packages/export/tests/HtmlGenerator-ansi.test.ts
@@ -376,4 +376,40 @@ describe('HtmlGenerator - generateAnsi', () => {
     expect(html).toContain('crtShader.disable()')
     expect(html).not.toContain('crt-enabled')
   })
+
+  describe('use_font_blocks override', () => {
+    it('emits setProjectUseFontBlocksOverride(null) for default (auto)', () => {
+      const generator = new HtmlGenerator(createOptions())
+      const config = createConfig()
+      const html = generator.generateAnsi(config, [], [])
+      expect(html).toContain('controller.setProjectUseFontBlocksOverride(null)')
+    })
+
+    it('emits setProjectUseFontBlocksOverride(null) for explicit "auto"', () => {
+      const generator = new HtmlGenerator(createOptions())
+      const config = createConfig({
+        ansi: { columns: 80, rows: 25, use_font_blocks: 'auto' },
+      })
+      const html = generator.generateAnsi(config, [], [])
+      expect(html).toContain('controller.setProjectUseFontBlocksOverride(null)')
+    })
+
+    it('emits setProjectUseFontBlocksOverride(true) for "on"', () => {
+      const generator = new HtmlGenerator(createOptions())
+      const config = createConfig({
+        ansi: { columns: 80, rows: 25, use_font_blocks: 'on' },
+      })
+      const html = generator.generateAnsi(config, [], [])
+      expect(html).toContain('controller.setProjectUseFontBlocksOverride(true)')
+    })
+
+    it('emits setProjectUseFontBlocksOverride(false) for "off"', () => {
+      const generator = new HtmlGenerator(createOptions())
+      const config = createConfig({
+        ansi: { columns: 80, rows: 25, use_font_blocks: 'off' },
+      })
+      const html = generator.generateAnsi(config, [], [])
+      expect(html).toContain('controller.setProjectUseFontBlocksOverride(false)')
+    })
+  })
 })

--- a/packages/export/tests/ProjectConfigParser.test.ts
+++ b/packages/export/tests/ProjectConfigParser.test.ts
@@ -476,6 +476,7 @@ describe('ProjectConfigParser', () => {
       expect(config.ansi?.columns).toBe(80)
       expect(config.ansi?.rows).toBe(25)
       expect(config.ansi?.font_size).toBe(16)
+      expect(config.ansi?.use_font_blocks).toBe('auto')
     })
 
     it('should merge provided ansi config with defaults', () => {
@@ -491,6 +492,49 @@ describe('ProjectConfigParser', () => {
       expect(config.ansi?.columns).toBe(120)
       expect(config.ansi?.rows).toBe(25) // default
       expect(config.ansi?.font_size).toBe(16) // default
+      expect(config.ansi?.use_font_blocks).toBe('auto') // default
+    })
+
+    it('should accept use_font_blocks = "on"', () => {
+      const config = parser.validate({
+        name: 'test',
+        main: 'main.lua',
+        type: 'ansi',
+        ansi: { use_font_blocks: 'on' },
+      })
+      expect(config.ansi?.use_font_blocks).toBe('on')
+    })
+
+    it('should accept use_font_blocks = "off"', () => {
+      const config = parser.validate({
+        name: 'test',
+        main: 'main.lua',
+        type: 'ansi',
+        ansi: { use_font_blocks: 'off' },
+      })
+      expect(config.ansi?.use_font_blocks).toBe('off')
+    })
+
+    it('should accept use_font_blocks = "auto"', () => {
+      const config = parser.validate({
+        name: 'test',
+        main: 'main.lua',
+        type: 'ansi',
+        ansi: { use_font_blocks: 'auto' },
+      })
+      expect(config.ansi?.use_font_blocks).toBe('auto')
+    })
+
+    it('should reject invalid use_font_blocks value', () => {
+      expect(() =>
+        parser.validate({
+          name: 'test',
+          main: 'main.lua',
+          type: 'ansi',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ansi: { use_font_blocks: 'maybe' as any },
+        })
+      ).toThrow("ansi.use_font_blocks must be 'on', 'off', or 'auto'")
     })
   })
 })
@@ -554,6 +598,36 @@ describe('ProjectConfigParser - ANSI parsing', () => {
       expect(result.success).toBe(false)
       if (!result.success) {
         expect(result.error).toContain('main')
+      }
+    })
+
+    it('should parse use_font_blocks from project.lua content', () => {
+      const content = `return {
+        name = "test",
+        main = "main.lua",
+        type = "ansi",
+        ansi = { use_font_blocks = "off" }
+      }`
+      const result = ProjectConfigParser.parseContent(content)
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.config.ansi?.use_font_blocks).toBe('off')
+      }
+    })
+
+    it('should reject invalid use_font_blocks from project.lua content', () => {
+      const content = `return {
+        name = "test",
+        main = "main.lua",
+        type = "ansi",
+        ansi = { use_font_blocks = "yes" }
+      }`
+      const result = ProjectConfigParser.parseContent(content)
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).toContain('use_font_blocks')
       }
     })
 

--- a/packages/export/tests/ProjectConfigParser.test.ts
+++ b/packages/export/tests/ProjectConfigParser.test.ts
@@ -476,7 +476,6 @@ describe('ProjectConfigParser', () => {
       expect(config.ansi?.columns).toBe(80)
       expect(config.ansi?.rows).toBe(25)
       expect(config.ansi?.font_size).toBe(16)
-      expect(config.ansi?.use_font_blocks).toBe('auto')
     })
 
     it('should merge provided ansi config with defaults', () => {
@@ -492,49 +491,6 @@ describe('ProjectConfigParser', () => {
       expect(config.ansi?.columns).toBe(120)
       expect(config.ansi?.rows).toBe(25) // default
       expect(config.ansi?.font_size).toBe(16) // default
-      expect(config.ansi?.use_font_blocks).toBe('auto') // default
-    })
-
-    it('should accept use_font_blocks = "on"', () => {
-      const config = parser.validate({
-        name: 'test',
-        main: 'main.lua',
-        type: 'ansi',
-        ansi: { use_font_blocks: 'on' },
-      })
-      expect(config.ansi?.use_font_blocks).toBe('on')
-    })
-
-    it('should accept use_font_blocks = "off"', () => {
-      const config = parser.validate({
-        name: 'test',
-        main: 'main.lua',
-        type: 'ansi',
-        ansi: { use_font_blocks: 'off' },
-      })
-      expect(config.ansi?.use_font_blocks).toBe('off')
-    })
-
-    it('should accept use_font_blocks = "auto"', () => {
-      const config = parser.validate({
-        name: 'test',
-        main: 'main.lua',
-        type: 'ansi',
-        ansi: { use_font_blocks: 'auto' },
-      })
-      expect(config.ansi?.use_font_blocks).toBe('auto')
-    })
-
-    it('should reject invalid use_font_blocks value', () => {
-      expect(() =>
-        parser.validate({
-          name: 'test',
-          main: 'main.lua',
-          type: 'ansi',
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          ansi: { use_font_blocks: 'maybe' as any },
-        })
-      ).toThrow("ansi.use_font_blocks must be 'on', 'off', or 'auto'")
     })
   })
 })
@@ -598,36 +554,6 @@ describe('ProjectConfigParser - ANSI parsing', () => {
       expect(result.success).toBe(false)
       if (!result.success) {
         expect(result.error).toContain('main')
-      }
-    })
-
-    it('should parse use_font_blocks from project.lua content', () => {
-      const content = `return {
-        name = "test",
-        main = "main.lua",
-        type = "ansi",
-        ansi = { use_font_blocks = "off" }
-      }`
-      const result = ProjectConfigParser.parseContent(content)
-
-      expect(result.success).toBe(true)
-      if (result.success) {
-        expect(result.config.ansi?.use_font_blocks).toBe('off')
-      }
-    })
-
-    it('should reject invalid use_font_blocks from project.lua content', () => {
-      const content = `return {
-        name = "test",
-        main = "main.lua",
-        type = "ansi",
-        ansi = { use_font_blocks = "yes" }
-      }`
-      const result = ProjectConfigParser.parseContent(content)
-
-      expect(result.success).toBe(false)
-      if (!result.success) {
-        expect(result.error).toContain('use_font_blocks')
       }
     })
 

--- a/packages/export/tests/ProjectConfigParser.useFontBlocks.test.ts
+++ b/packages/export/tests/ProjectConfigParser.useFontBlocks.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import { ProjectConfigParser } from '../src/ProjectConfigParser'
+
+describe('ProjectConfigParser - ansi.use_font_blocks', () => {
+  describe('validate', () => {
+    it('applies "auto" as the default when not specified', () => {
+      const config = ProjectConfigParser.validateConfig({
+        name: 'test',
+        main: 'main.lua',
+        type: 'ansi',
+      })
+      expect(config.ansi?.use_font_blocks).toBe('auto')
+    })
+
+    it('preserves "auto" when explicitly set', () => {
+      const config = ProjectConfigParser.validateConfig({
+        name: 'test',
+        main: 'main.lua',
+        type: 'ansi',
+        ansi: { use_font_blocks: 'auto' },
+      })
+      expect(config.ansi?.use_font_blocks).toBe('auto')
+    })
+
+    it('accepts "on"', () => {
+      const config = ProjectConfigParser.validateConfig({
+        name: 'test',
+        main: 'main.lua',
+        type: 'ansi',
+        ansi: { use_font_blocks: 'on' },
+      })
+      expect(config.ansi?.use_font_blocks).toBe('on')
+    })
+
+    it('accepts "off"', () => {
+      const config = ProjectConfigParser.validateConfig({
+        name: 'test',
+        main: 'main.lua',
+        type: 'ansi',
+        ansi: { use_font_blocks: 'off' },
+      })
+      expect(config.ansi?.use_font_blocks).toBe('off')
+    })
+
+    it('rejects an invalid value', () => {
+      expect(() =>
+        ProjectConfigParser.validateConfig({
+          name: 'test',
+          main: 'main.lua',
+          type: 'ansi',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ansi: { use_font_blocks: 'maybe' as any },
+        })
+      ).toThrow("ansi.use_font_blocks must be 'on', 'off', or 'auto'")
+    })
+  })
+
+  describe('parseContent', () => {
+    it('parses use_font_blocks from project.lua', () => {
+      const content = `return {
+        name = "test",
+        main = "main.lua",
+        type = "ansi",
+        ansi = { use_font_blocks = "off" }
+      }`
+      const result = ProjectConfigParser.parseContent(content)
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.config.ansi?.use_font_blocks).toBe('off')
+      }
+    })
+
+    it('rejects an invalid use_font_blocks value from project.lua', () => {
+      const content = `return {
+        name = "test",
+        main = "main.lua",
+        type = "ansi",
+        ansi = { use_font_blocks = "yes" }
+      }`
+      const result = ProjectConfigParser.parseContent(content)
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).toContain('use_font_blocks')
+      }
+    })
+  })
+})

--- a/packages/lua-runtime/src/AnsiController.ts
+++ b/packages/lua-runtime/src/AnsiController.ts
@@ -76,6 +76,15 @@ export interface AnsiCallbacks {
    * Called after each frame to ensure print() output appears immediately.
    */
   onFlushOutput?: () => void
+  /**
+   * Hint the UI which terminal-panel variant to mount before the panel
+   * is requested. Called by LuaScriptProcess when it discovers the
+   * project's `ansi.use_font_blocks` override.
+   * - `true` → mount the pixel renderer
+   * - `false` → mount the xterm path
+   * - `null` → no project-level override; the UI uses its default
+   */
+  onAnsiPanelMode?: (useFontBlocks: boolean | null) => void
 }
 
 export interface LayerInfo {

--- a/packages/lua-runtime/src/AnsiController.ts
+++ b/packages/lua-runtime/src/AnsiController.ts
@@ -77,14 +77,30 @@ export interface AnsiCallbacks {
    */
   onFlushOutput?: () => void
   /**
-   * Hint the UI which terminal-panel variant to mount before the panel
-   * is requested. Called by LuaScriptProcess when it discovers the
-   * project's `ansi.use_font_blocks` override.
-   * - `true` → mount the pixel renderer
-   * - `false` → mount the xterm path
-   * - `null` → no project-level override; the UI uses its default
+   * Request that the UI mount (or remount) the ANSI terminal panel with the
+   * given renderer variant. Called from two sources:
+   * 1. `LuaScriptProcess` before the panel is opened, with the project-level
+   *    `ansi.use_font_blocks` override (`true`/`false`/`null` for auto).
+   * 2. `AnsiController.applyFontSettings`, when a screen switch resolves a
+   *    new effective `useFontBlocks` that differs from the currently mounted
+   *    variant (e.g., the screen file says `useFontBlocks = false` and there
+   *    is no project override).
+   * The UI is expected to mount the matching variant; the controller picks
+   * up the new handle via `registerHandleListener`.
    */
   onAnsiPanelMode?: (useFontBlocks: boolean | null) => void
+  /**
+   * Subscribe to terminal-handle changes. Called once by the controller
+   * inside `start()`; the UI invokes the listener whenever the panel
+   * (re)mounts and a new handle becomes available (or `null` on unmount).
+   * Returns an unsubscribe function. Without this, the controller cannot
+   * pick up the new handle that arrives after a panel-variant remount.
+   *
+   * The listener is typed as `unknown` so callers (e.g., `ShellContext`)
+   * don't need to depend on the controller's `AnsiTerminalHandle` shape.
+   * The controller casts the incoming value at runtime.
+   */
+  registerHandleListener?: (listener: (handle: unknown) => void) => () => void
 }
 
 export interface LayerInfo {
@@ -130,6 +146,7 @@ export class AnsiController {
   private readonly callbacks: AnsiCallbacks
   private readonly ansiId: string
   private handle: AnsiTerminalHandle | null = null
+  private unregisterHandleListener: (() => void) | null = null
   private inputCapture: InputCapture | null = null
   private inputAPI: InputAPI = new InputAPI()
   private gameLoop: GameLoopController | null = null
@@ -193,26 +210,18 @@ export class AnsiController {
       throw new Error('ANSI terminal is already running. Call ansi.stop() first.')
     }
 
+    // Subscribe to handle changes BEFORE requesting the tab — the panel
+    // may remount mid-session (when the screen's useFontBlocks differs from
+    // the currently mounted variant), and the controller needs to pick up
+    // the new handle. The first call from onRequestAnsiTab seeds this.handle
+    // below; subsequent calls come through the listener.
+    this.unregisterHandleListener = this.callbacks.registerHandleListener?.(
+      (handle) => this.attachHandle(handle as AnsiTerminalHandle | null)
+    ) ?? null
+
     // Request ANSI tab from UI
     this.handle = await this.callbacks.onRequestAnsiTab(this.ansiId)
-
-    // Sync the freshly-attached handle to whatever state the controller
-    // accumulated before start(). set_screen() called before ansi.start()
-    // (the pattern every example uses) updates currentCols/currentRows/
-    // currentFont but cannot push to a null handle, so without this the
-    // panel stays at its mount-time 80×25 / default font even though the
-    // controller is already compositing at the screen's real dims.
-    // Only forward when the controller has moved off defaults — panels
-    // mount at the same defaults, so a redundant resize is avoidable.
-    if (this.currentCols !== DEFAULT_ANSI_COLS || this.currentRows !== DEFAULT_ANSI_ROWS) {
-      this.handle.resize?.(this.currentCols, this.currentRows)
-    }
-    if (this.currentFont !== DEFAULT_ANSI_FONT_ID) {
-      this.handle.setFontFamily?.(this.currentFont)
-    }
-    if (this.currentUseFontBlocks !== DEFAULT_USE_FONT_BLOCKS) {
-      this.handle.setUseFontBlocks?.(this.currentUseFontBlocks)
-    }
+    this.syncHandleState()
 
     // Register close handler so UI can stop us when tab is closed
     this.callbacks.registerAnsiCloseHandler?.(this.ansiId, () => this.stop())
@@ -237,6 +246,51 @@ export class AnsiController {
     return new Promise<void>((resolve) => {
       this.stopResolver = resolve
     })
+  }
+
+  /**
+   * Push controller state (dims, font, useFontBlocks) onto the currently
+   * attached handle. Used after the initial handle attaches and after a
+   * panel remount delivers a new handle. Only fires calls when the state
+   * has moved off defaults — panels mount at the same defaults, so a
+   * redundant resize is avoidable.
+   */
+  private syncHandleState(): void {
+    if (!this.handle) return
+    if (this.currentCols !== DEFAULT_ANSI_COLS || this.currentRows !== DEFAULT_ANSI_ROWS) {
+      this.handle.resize?.(this.currentCols, this.currentRows)
+    }
+    if (this.currentFont !== DEFAULT_ANSI_FONT_ID) {
+      this.handle.setFontFamily?.(this.currentFont)
+    }
+    if (this.currentUseFontBlocks !== DEFAULT_USE_FONT_BLOCKS) {
+      this.handle.setUseFontBlocks?.(this.currentUseFontBlocks)
+    }
+  }
+
+  /**
+   * Swap the attached handle (e.g., after a panel-variant remount) and
+   * re-sync controller state to it. Mark every screen dirty so the next
+   * frame pushes a full redraw — diff-against-stale-handle would emit
+   * garbage. A null handle is treated as a temporary detach and ignored
+   * (we keep the previous handle until a fresh one arrives).
+   */
+  private attachHandle(handle: AnsiTerminalHandle | null): void {
+    if (!handle) return
+    if (handle === this.handle) return
+    this.handle = handle
+    // Replace input capture against the new container so keyboard input
+    // continues to flow once the new panel takes over.
+    if (this.inputCapture) {
+      this.inputCapture.dispose()
+      this.inputCapture = new InputCapture(handle.container)
+      this.inputAPI.setInputCapture(this.inputCapture)
+    }
+    this.syncHandleState()
+    for (const state of this.screenStates.values()) {
+      state.lastGrid = null
+      state.dirty = true
+    }
   }
 
   /**
@@ -266,6 +320,10 @@ export class AnsiController {
 
     // Unregister close handler to prevent double-cleanup
     this.callbacks.unregisterAnsiCloseHandler?.(this.ansiId)
+
+    // Unsubscribe from handle changes
+    this.unregisterHandleListener?.()
+    this.unregisterHandleListener = null
 
     // Clear all screen state
     this.screenStates.clear()
@@ -337,6 +395,11 @@ export class AnsiController {
     if (effective !== this.currentUseFontBlocks) {
       this.currentUseFontBlocks = effective
       this.handle?.setUseFontBlocks?.(effective)
+      // Ask the UI to remount the panel variant. The pixel renderer's
+      // setUseFontBlocks() is currently a no-op, so without this signal
+      // a screen-level useFontBlocks=false would have no visible effect
+      // when the panel is already mounted as pixel.
+      this.callbacks.onAnsiPanelMode?.(effective)
     }
   }
 
@@ -367,6 +430,7 @@ export class AnsiController {
     if (effective !== this.currentUseFontBlocks) {
       this.currentUseFontBlocks = effective
       this.handle?.setUseFontBlocks?.(effective)
+      this.callbacks.onAnsiPanelMode?.(effective)
     }
   }
 

--- a/packages/lua-runtime/src/AnsiController.ts
+++ b/packages/lua-runtime/src/AnsiController.ts
@@ -136,6 +136,10 @@ export class AnsiController {
   private currentRows: number = DEFAULT_ANSI_ROWS
   private currentFont: string = DEFAULT_ANSI_FONT_ID
   private currentUseFontBlocks: boolean = DEFAULT_USE_FONT_BLOCKS
+  /** Project-level override from project.lua (null = auto / use screen value). */
+  private projectUseFontBlocksOverride: boolean | null = null
+  /** Dynamic Lua API override (null = no override; outranks project + screen). */
+  private runtimeUseFontBlocksOverride: boolean | null = null
   private compositeBufferA: AnsiGrid = createEmptyGrid(DEFAULT_ANSI_COLS, DEFAULT_ANSI_ROWS)
   private compositeBufferB: AnsiGrid = createEmptyGrid(DEFAULT_ANSI_COLS, DEFAULT_ANSI_ROWS)
   private useBufferA = true
@@ -300,6 +304,16 @@ export class AnsiController {
   getRows(): number { return this.currentRows }
 
   /**
+   * Resolve the effective useFontBlocks value, applying override priority:
+   * runtime API override > project.lua override > screen's saved value.
+   */
+  private resolveUseFontBlocks(screenValue: boolean): boolean {
+    if (this.runtimeUseFontBlocksOverride !== null) return this.runtimeUseFontBlocksOverride
+    if (this.projectUseFontBlocksOverride !== null) return this.projectUseFontBlocksOverride
+    return screenValue
+  }
+
+  /**
    * Apply per-screen font + renderer-mode settings to the attached handle,
    * skipping calls when the values are unchanged. Safe to call before the
    * handle is attached — values are remembered on the controller, and
@@ -310,9 +324,40 @@ export class AnsiController {
       this.currentFont = font
       this.handle?.setFontFamily?.(font)
     }
-    if (useFontBlocks !== this.currentUseFontBlocks) {
-      this.currentUseFontBlocks = useFontBlocks
-      this.handle?.setUseFontBlocks?.(useFontBlocks)
+    const effective = this.resolveUseFontBlocks(useFontBlocks)
+    if (effective !== this.currentUseFontBlocks) {
+      this.currentUseFontBlocks = effective
+      this.handle?.setUseFontBlocks?.(effective)
+    }
+  }
+
+  /**
+   * Set the project-level useFontBlocks override (from project.lua).
+   * Pass null for "auto" (use each screen's saved value).
+   */
+  setProjectUseFontBlocksOverride(value: boolean | null): void {
+    this.projectUseFontBlocksOverride = value
+    this.reapplyUseFontBlocks()
+  }
+
+  /**
+   * Set the dynamic runtime useFontBlocks override (from ansi.set_use_font_blocks).
+   * Pass null to clear the override (defer to project / screen value).
+   */
+  setRuntimeUseFontBlocksOverride(value: boolean | null): void {
+    this.runtimeUseFontBlocksOverride = value
+    this.reapplyUseFontBlocks()
+  }
+
+  /** Re-resolve and apply useFontBlocks for the active screen (if any). */
+  private reapplyUseFontBlocks(): void {
+    const screenValue = this.activeScreenId !== null
+      ? this.screenStates.get(this.activeScreenId)?.useFontBlocks ?? DEFAULT_USE_FONT_BLOCKS
+      : DEFAULT_USE_FONT_BLOCKS
+    const effective = this.resolveUseFontBlocks(screenValue)
+    if (effective !== this.currentUseFontBlocks) {
+      this.currentUseFontBlocks = effective
+      this.handle?.setUseFontBlocks?.(effective)
     }
   }
 

--- a/packages/lua-runtime/src/LuaCommand.ts
+++ b/packages/lua-runtime/src/LuaCommand.ts
@@ -222,6 +222,7 @@ export class LuaCommand implements ICommand {
             onCloseAnsiTab: context.onCloseAnsiTab,
             registerAnsiCloseHandler: context.registerAnsiCloseHandler,
             unregisterAnsiCloseHandler: context.unregisterAnsiCloseHandler,
+            onAnsiPanelMode: context.onAnsiPanelMode,
           }
         : undefined
 

--- a/packages/lua-runtime/src/LuaCommand.ts
+++ b/packages/lua-runtime/src/LuaCommand.ts
@@ -223,6 +223,7 @@ export class LuaCommand implements ICommand {
             registerAnsiCloseHandler: context.registerAnsiCloseHandler,
             unregisterAnsiCloseHandler: context.unregisterAnsiCloseHandler,
             onAnsiPanelMode: context.onAnsiPanelMode,
+            registerHandleListener: context.registerAnsiHandleListener,
           }
         : undefined
 

--- a/packages/lua-runtime/src/LuaScriptProcess.ts
+++ b/packages/lua-runtime/src/LuaScriptProcess.ts
@@ -26,7 +26,7 @@ import { chipLuaCode } from './chipLuaCode'
 import { AnsiController, type AnsiCallbacks, type AnsiTerminalHandle } from './AnsiController'
 import type { CrtConfig } from './crtShader'
 import { setupAnsiAPI } from './setupAnsiAPI'
-import { extractCrtConfig } from './projectCrtConfig'
+import { extractCrtConfig, extractUseFontBlocksOverride } from './projectCrtConfig'
 import { FileOperationsHandler } from './FileOperationsHandler'
 import type { CanvasMode, ScreenMode, HotReloadMode } from './LuaCommand'
 
@@ -522,7 +522,7 @@ __clear_execution_hook()
       // Consume any ansi.crt() calls made before ansi.start()
       const pending = this.ansiController?.consumePendingCrt()
 
-      // Load project.lua CRT config
+      // Load project.lua CRT config and use_font_blocks override
       let projectCrt: CrtConfig | null = null
       const projectLuaPath = `${this.context.cwd}/project.lua`
       try {
@@ -530,6 +530,9 @@ __clear_execution_hook()
           const content = this.context.filesystem.readFile(projectLuaPath)
           if (content) {
             projectCrt = extractCrtConfig(content)
+            this.ansiController?.setProjectUseFontBlocksOverride(
+              extractUseFontBlocksOverride(content)
+            )
           }
         }
       } catch {

--- a/packages/lua-runtime/src/LuaScriptProcess.ts
+++ b/packages/lua-runtime/src/LuaScriptProcess.ts
@@ -538,7 +538,16 @@ __clear_execution_hook()
         // Silently ignore project.lua read/parse errors
       }
       this.ansiController?.setProjectUseFontBlocksOverride(useFontBlocksOverride)
-      originalOnPanelMode?.(useFontBlocksOverride)
+      // Only push the UI's panel mode for an *actual* project override —
+      // for "auto" (null), leave the UI state alone. The controller has
+      // typically already fired onAnsiPanelMode from set_screen (when the
+      // script ran set_screen before start()), and passing null here would
+      // overwrite that value and force the panel back to its default
+      // variant. The controller will fire onAnsiPanelMode again later if
+      // the script's first set_screen happens after start().
+      if (useFontBlocksOverride !== null) {
+        originalOnPanelMode?.(useFontBlocksOverride)
+      }
 
       const handle = await originalOnRequest(ansiId)
 

--- a/packages/lua-runtime/src/LuaScriptProcess.ts
+++ b/packages/lua-runtime/src/LuaScriptProcess.ts
@@ -516,28 +516,34 @@ __clear_execution_hook()
 
     // Wrap onRequestAnsiTab to merge pre-start CRT calls with project.lua defaults
     const originalOnRequest = this.options.ansiCallbacks.onRequestAnsiTab
+    const originalOnPanelMode = this.options.ansiCallbacks.onAnsiPanelMode
     const wrappedOnRequest = async (ansiId: string): Promise<AnsiTerminalHandle> => {
-      const handle = await originalOnRequest(ansiId)
-
-      // Consume any ansi.crt() calls made before ansi.start()
-      const pending = this.ansiController?.consumePendingCrt()
-
-      // Load project.lua CRT config and use_font_blocks override
+      // Read project.lua up front so the UI can mount the correct panel
+      // variant (pixel vs xterm) BEFORE the terminal handle is created.
+      // `useFontBlocks` is a mount-time React prop on AnsiTerminalPanel;
+      // switching variants after mount won't take effect, so the override
+      // must reach the UI before the tab is opened.
       let projectCrt: CrtConfig | null = null
+      let useFontBlocksOverride: boolean | null = null
       const projectLuaPath = `${this.context.cwd}/project.lua`
       try {
         if (this.context.filesystem.exists(projectLuaPath)) {
           const content = this.context.filesystem.readFile(projectLuaPath)
           if (content) {
             projectCrt = extractCrtConfig(content)
-            this.ansiController?.setProjectUseFontBlocksOverride(
-              extractUseFontBlocksOverride(content)
-            )
+            useFontBlocksOverride = extractUseFontBlocksOverride(content)
           }
         }
       } catch {
         // Silently ignore project.lua read/parse errors
       }
+      this.ansiController?.setProjectUseFontBlocksOverride(useFontBlocksOverride)
+      originalOnPanelMode?.(useFontBlocksOverride)
+
+      const handle = await originalOnRequest(ansiId)
+
+      // Consume any ansi.crt() calls made before ansi.start()
+      const pending = this.ansiController?.consumePendingCrt()
 
       // Merge: explicit pre-start values override project.lua values
       if (pending || projectCrt) {

--- a/packages/lua-runtime/src/ansiLuaCode/core.ts
+++ b/packages/lua-runtime/src/ansiLuaCode/core.ts
@@ -138,6 +138,17 @@ export const ansiLuaCoreCode = `
       __ansi_reset()
     end
 
+    -- Renderer toggle: override the per-screen pixel renderer setting.
+    -- ansi.set_use_font_blocks(true)   -- force the pixel renderer for every screen
+    -- ansi.set_use_font_blocks(false)  -- force the legacy xterm path
+    -- ansi.set_use_font_blocks(nil)    -- clear the override; defer to project.lua / screen
+    function _ansi.set_use_font_blocks(value)
+      if value ~= nil and type(value) ~= 'boolean' then
+        error("ansi.set_use_font_blocks() expects true, false, or nil")
+      end
+      __ansi_setUseFontBlocks(value)
+    end
+
     -- CRT effect
     -- ansi.crt(true)              -- enable with defaults
     -- ansi.crt(false)             -- disable

--- a/packages/lua-runtime/src/lua/ansi.lua
+++ b/packages/lua-runtime/src/lua/ansi.lua
@@ -158,6 +158,22 @@ function ansi.reset() end
 ---@usage ansi.crt({ curvature = 0.2, bloomIntensity = 0.8, phosphor = 0.3 })
 function ansi.crt(enabled_or_config, intensity) end
 
+--- Override the per-screen pixel renderer (font blocks) toggle at runtime.
+--- Each ANSI screen file saves a `useFontBlocks` flag, and `project.lua` can
+--- supply a project-wide override via `ansi.use_font_blocks = "on" | "off" | "auto"`.
+--- This function lets a running program override both, screen-by-screen or globally:
+---
+---   ansi.set_use_font_blocks(true)   -- force the pixel renderer for every screen
+---   ansi.set_use_font_blocks(false)  -- force the legacy xterm path
+---   ansi.set_use_font_blocks(nil)    -- clear the runtime override; defer to
+---                                    -- project.lua (then to each screen's saved value)
+---
+--- Priority: runtime API > project.lua > screen file.
+---@param value boolean|nil true (pixel), false (xterm), or nil (clear override)
+---@return nil
+---@usage ansi.set_use_font_blocks(true)
+function ansi.set_use_font_blocks(value) end
+
 -- =============================================================================
 -- Color Constants
 -- =============================================================================

--- a/packages/lua-runtime/src/projectCrtConfig.ts
+++ b/packages/lua-runtime/src/projectCrtConfig.ts
@@ -17,6 +17,7 @@ interface LuaTableField extends LuaNode { type: string; key?: LuaNode; value: Lu
 interface LuaIdentifier extends LuaNode { name: string }
 interface LuaNumericLiteral extends LuaNode { value: number }
 interface LuaBooleanLiteral extends LuaNode { value: boolean }
+interface LuaStringLiteral extends LuaNode { value: string | null; raw: string }
 
 /**
  * Extract a flat key→value map from a Lua table AST node.
@@ -30,6 +31,17 @@ function tableToMap(table: LuaTableConstructor): Record<string, unknown> {
     const val = field.value
     if (val.type === 'NumericLiteral') result[key] = (val as LuaNumericLiteral).value
     else if (val.type === 'BooleanLiteral') result[key] = (val as LuaBooleanLiteral).value
+    else if (val.type === 'StringLiteral') {
+      const s = val as LuaStringLiteral
+      if (typeof s.value === 'string') {
+        result[key] = s.value
+      } else if (typeof s.raw === 'string' && s.raw.length >= 2) {
+        const first = s.raw[0]
+        if ((first === '"' || first === "'") && s.raw.endsWith(first)) {
+          result[key] = s.raw.slice(1, -1)
+        }
+      }
+    }
     else if (val.type === 'TableConstructorExpression') result[key] = tableToMap(val as LuaTableConstructor)
   }
   return result
@@ -70,6 +82,33 @@ export function extractCrtConfig(content: string): CrtConfig | null {
       flickerStrength: typeof ansi.crt_flickerStrength === 'number' ? ansi.crt_flickerStrength : CRT_DEFAULTS.flickerStrength,
       phosphor: typeof ansi.crt_phosphor === 'number' ? ansi.crt_phosphor : CRT_DEFAULTS.phosphor,
     }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Extract a project.lua `ansi.use_font_blocks` override.
+ * Returns `true` for "on", `false` for "off", and `null` for "auto"
+ * (or missing / unparseable).
+ */
+export function extractUseFontBlocksOverride(content: string): boolean | null {
+  try {
+    const ast = luaparse.parse(content, {
+      luaVersion: '5.3',
+      comments: false,
+      scope: false,
+    }) as LuaChunk
+
+    const ret = ast.body.find((n): n is LuaReturnStatement => n.type === 'ReturnStatement')
+    if (!ret?.arguments?.[0] || ret.arguments[0].type !== 'TableConstructorExpression') return null
+
+    const root = tableToMap(ret.arguments[0] as LuaTableConstructor)
+    const ansi = root.ansi as Record<string, unknown> | undefined
+    const value = ansi?.use_font_blocks
+    if (value === 'on') return true
+    if (value === 'off') return false
+    return null
   } catch {
     return null
   }

--- a/packages/lua-runtime/src/setupAnsiAPI.ts
+++ b/packages/lua-runtime/src/setupAnsiAPI.ts
@@ -154,6 +154,12 @@ export function setupAnsiAPI(
     getController()?.setCrt(enabled, intensity, config)
   })
 
+  // --- Renderer toggle ---
+  engine.global.set('__ansi_setUseFontBlocks', (value: boolean | null | undefined) => {
+    const normalized = value === null || value === undefined ? null : Boolean(value)
+    getController()?.setRuntimeUseFontBlocksOverride(normalized)
+  })
+
   // --- Timing functions ---
   engine.global.set('__ansi_getDelta', () => {
     return getController()?.getDelta() ?? 0

--- a/packages/lua-runtime/tests/AnsiController.font.test.ts
+++ b/packages/lua-runtime/tests/AnsiController.font.test.ts
@@ -118,3 +118,73 @@ describe('AnsiController per-screen font settings', () => {
     expect(handle.setUseFontBlocks).toHaveBeenLastCalledWith(true)
   })
 })
+
+describe('AnsiController useFontBlocks override resolution', () => {
+  let controller: AnsiController
+  let handle: MockHandle
+
+  beforeEach(async () => {
+    ;({ controller, handle } = await bootController())
+    handle.setFontFamily.mockClear()
+    handle.setUseFontBlocks.mockClear()
+  })
+
+  it('project override "on" forces useFontBlocks=true even when screen says false', () => {
+    controller.setProjectUseFontBlocksOverride(true)
+    const id = controller.createScreen(makeV1Data({ useFontBlocks: false }))
+    controller.setScreen(id)
+    // Screen says false but override forces true; default is true so no callback fires.
+    expect(handle.setUseFontBlocks).not.toHaveBeenCalled()
+  })
+
+  it('project override "off" forces useFontBlocks=false even when screen says true', () => {
+    controller.setProjectUseFontBlocksOverride(false)
+    const id = controller.createScreen(makeV1Data({ useFontBlocks: true }))
+    controller.setScreen(id)
+    expect(handle.setUseFontBlocks).toHaveBeenLastCalledWith(false)
+  })
+
+  it('project override null (auto) uses each screen\'s saved value', () => {
+    controller.setProjectUseFontBlocksOverride(null)
+    const id = controller.createScreen(makeV1Data({ useFontBlocks: false }))
+    controller.setScreen(id)
+    expect(handle.setUseFontBlocks).toHaveBeenLastCalledWith(false)
+  })
+
+  it('dynamic Lua API override takes precedence over project override', () => {
+    // Set screen first so the override calls during setup don't apply twice.
+    const id = controller.createScreen(makeV1Data({ useFontBlocks: false }))
+    controller.setScreen(id)
+    expect(handle.setUseFontBlocks).toHaveBeenLastCalledWith(false) // screen=false, no overrides
+    handle.setUseFontBlocks.mockClear()
+
+    controller.setProjectUseFontBlocksOverride(false) // no change — already false
+    expect(handle.setUseFontBlocks).not.toHaveBeenCalled()
+
+    controller.setRuntimeUseFontBlocksOverride(true)
+    // Runtime true wins over project false and screen false.
+    expect(handle.setUseFontBlocks).toHaveBeenLastCalledWith(true)
+  })
+
+  it('dynamic Lua API override null falls back to project override', () => {
+    controller.setProjectUseFontBlocksOverride(false)
+    controller.setRuntimeUseFontBlocksOverride(null)
+    const id = controller.createScreen(makeV1Data({ useFontBlocks: true }))
+    controller.setScreen(id)
+    // Runtime null → project override false wins over screen true.
+    expect(handle.setUseFontBlocks).toHaveBeenLastCalledWith(false)
+  })
+
+  it('changing runtime override re-applies to current screen', () => {
+    const id = controller.createScreen(makeV1Data({ useFontBlocks: true }))
+    controller.setScreen(id)
+    expect(handle.setUseFontBlocks).not.toHaveBeenCalled() // default true
+
+    controller.setRuntimeUseFontBlocksOverride(false)
+    expect(handle.setUseFontBlocks).toHaveBeenLastCalledWith(false)
+
+    controller.setRuntimeUseFontBlocksOverride(null)
+    // Back to screen's true value (default) — no callback because already at default.
+    expect(handle.setUseFontBlocks).toHaveBeenLastCalledWith(true)
+  })
+})

--- a/packages/lua-runtime/tests/AnsiController.panelRemount.test.ts
+++ b/packages/lua-runtime/tests/AnsiController.panelRemount.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { AnsiController } from '../src/AnsiController'
+import type { AnsiCallbacks, AnsiTerminalHandle } from '../src/AnsiController'
+import type { RGBColor } from '../src/screenTypes'
+import { ANSI_ROWS, ANSI_COLS, DEFAULT_FG, DEFAULT_BG } from '../src/screenTypes'
+
+vi.mock('@lua-learning/canvas-runtime', () => ({
+  InputCapture: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.dispose = vi.fn()
+    this.update = vi.fn()
+  }),
+  GameLoopController: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.start = vi.fn()
+    this.stop = vi.fn()
+    this.dispose = vi.fn()
+  }),
+}))
+
+function makeV1Data(overrides?: Partial<Record<string, unknown>>): Record<string, unknown> {
+  const grid: Record<number, Record<number, { char: string; fg: RGBColor; bg: RGBColor }>> = {}
+  for (let r = 0; r < ANSI_ROWS; r++) {
+    const row: Record<number, { char: string; fg: RGBColor; bg: RGBColor }> = {}
+    for (let c = 0; c < ANSI_COLS; c++) {
+      row[c + 1] = { char: ' ', fg: [...DEFAULT_FG] as RGBColor, bg: [...DEFAULT_BG] as RGBColor }
+    }
+    grid[r + 1] = row
+  }
+  return { version: 1, width: ANSI_COLS, height: ANSI_ROWS, grid, ...overrides }
+}
+
+interface MockHandle {
+  setFontFamily: ReturnType<typeof vi.fn>
+  setUseFontBlocks: ReturnType<typeof vi.fn>
+  write: ReturnType<typeof vi.fn>
+  dispose: ReturnType<typeof vi.fn>
+  container: { getBoundingClientRect: () => { width: number; height: number } }
+  resize: ReturnType<typeof vi.fn>
+}
+
+function makeMockHandle(): MockHandle {
+  return {
+    setFontFamily: vi.fn(),
+    setUseFontBlocks: vi.fn(),
+    write: vi.fn(),
+    dispose: vi.fn(),
+    container: { getBoundingClientRect: () => ({ width: 0, height: 0 }) },
+    resize: vi.fn(),
+  }
+}
+
+describe('AnsiController panel remount on effective useFontBlocks change', () => {
+  let controller: AnsiController
+  let handle: MockHandle
+  let onAnsiPanelMode: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    handle = makeMockHandle()
+    onAnsiPanelMode = vi.fn()
+    const callbacks: AnsiCallbacks = {
+      onRequestAnsiTab: vi.fn().mockResolvedValue(handle as unknown as AnsiTerminalHandle),
+      onCloseAnsiTab: vi.fn(),
+      onAnsiPanelMode,
+    }
+    controller = new AnsiController(callbacks)
+    void controller.start()
+    await new Promise(resolve => setTimeout(resolve, 0))
+    onAnsiPanelMode.mockClear()
+  })
+
+  it('fires onAnsiPanelMode(false) when screen has useFontBlocks=false and no override', () => {
+    const id = controller.createScreen(makeV1Data({ useFontBlocks: false }))
+    controller.setScreen(id)
+    expect(onAnsiPanelMode).toHaveBeenLastCalledWith(false)
+  })
+
+  it('does not fire onAnsiPanelMode when screen uses the default useFontBlocks=true', () => {
+    const id = controller.createScreen(makeV1Data())
+    controller.setScreen(id)
+    expect(onAnsiPanelMode).not.toHaveBeenCalled()
+  })
+
+  it('fires onAnsiPanelMode when project override changes the effective value', () => {
+    controller.setProjectUseFontBlocksOverride(false)
+    expect(onAnsiPanelMode).toHaveBeenLastCalledWith(false)
+  })
+
+  it('fires onAnsiPanelMode when runtime override is set', () => {
+    controller.setRuntimeUseFontBlocksOverride(false)
+    expect(onAnsiPanelMode).toHaveBeenLastCalledWith(false)
+  })
+
+  it('skips onAnsiPanelMode when project override matches existing state', () => {
+    controller.setProjectUseFontBlocksOverride(true) // default already true
+    expect(onAnsiPanelMode).not.toHaveBeenCalled()
+  })
+})
+
+describe('AnsiController handle re-attach via registerHandleListener', () => {
+  it('subscribes inside start() and re-syncs state on new handle', async () => {
+    const handle1 = makeMockHandle()
+    const handle2 = makeMockHandle()
+    let listener: ((h: unknown) => void) | null = null
+    const callbacks: AnsiCallbacks = {
+      onRequestAnsiTab: vi.fn().mockResolvedValue(handle1 as unknown as AnsiTerminalHandle),
+      onCloseAnsiTab: vi.fn(),
+      registerHandleListener: vi.fn((cb: (h: unknown) => void) => {
+        listener = cb
+        return () => { listener = null }
+      }),
+    }
+    const controller = new AnsiController(callbacks)
+    void controller.start()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(callbacks.registerHandleListener).toHaveBeenCalledTimes(1)
+
+    // Create a screen with non-default font/useFontBlocks so we can verify
+    // that the new handle gets the state re-synced onto it.
+    const id = controller.createScreen(makeV1Data({ font: 'IBM_VGA_9x16', useFontBlocks: false }))
+    controller.setScreen(id)
+    handle2.setFontFamily.mockClear()
+    handle2.setUseFontBlocks.mockClear()
+
+    // Simulate the UI delivering a new handle after a panel-variant remount.
+    expect(listener).not.toBeNull()
+    listener!(handle2)
+
+    // The controller should push current state onto the new handle.
+    expect(handle2.setFontFamily).toHaveBeenCalledWith('IBM_VGA_9x16')
+    expect(handle2.setUseFontBlocks).toHaveBeenCalledWith(false)
+  })
+
+  it('ignores null handle (panel detach is transient, keep current handle)', async () => {
+    const handle1 = makeMockHandle()
+    let listener: ((h: unknown) => void) | null = null
+    const callbacks: AnsiCallbacks = {
+      onRequestAnsiTab: vi.fn().mockResolvedValue(handle1 as unknown as AnsiTerminalHandle),
+      onCloseAnsiTab: vi.fn(),
+      registerHandleListener: vi.fn((cb: (h: unknown) => void) => {
+        listener = cb
+        return () => { listener = null }
+      }),
+    }
+    const controller = new AnsiController(callbacks)
+    void controller.start()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    handle1.write.mockClear()
+    listener!(null)
+    // After a null detach the original handle is still usable; controller
+    // continues writing to it until a fresh handle arrives.
+    controller.write('hello')
+    expect(handle1.write).toHaveBeenCalledWith('hello')
+  })
+})

--- a/packages/lua-runtime/tests/LuaScriptProcess.ansiPanelMode.test.ts
+++ b/packages/lua-runtime/tests/LuaScriptProcess.ansiPanelMode.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Integration test: reproduces the bug where a script with
+ *   load_screen(...) -> set_screen(s) -> start()
+ * and `project.lua` having `ansi.use_font_blocks = "auto"` causes the
+ * panel to mount as the pixel renderer even though the screen file
+ * declared `useFontBlocks = false`.
+ *
+ * The bug lives in LuaScriptProcess.initAnsiAPI's `wrappedOnRequest`,
+ * which calls `originalOnPanelMode(useFontBlocksOverride)` *unconditionally*.
+ * For an "auto" project that passes `null`, overwriting any value the
+ * controller already pushed when `set_screen` fired before `start()`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { LuaScriptProcess } from '../src/LuaScriptProcess'
+import type { AnsiCallbacks, AnsiTerminalHandle } from '../src/AnsiController'
+import type { ShellContext, IFileSystem } from '@lua-learning/shell-core'
+
+function makeScreenFileContent(useFontBlocks: boolean): string {
+  // Minimal v1 ANSI screen file. The grid array uses 1-based row/col so
+  // the parser can pick it up.
+  return `return {
+    version = 1,
+    width = 80,
+    height = 25,
+    useFontBlocks = ${useFontBlocks ? 'true' : 'false'},
+    grid = {},
+  }`
+}
+
+function makeProjectLua(useFontBlocks: 'on' | 'off' | 'auto'): string {
+  return `return {
+    name = "test",
+    main = "main.lua",
+    type = "ansi",
+    ansi = { use_font_blocks = "${useFontBlocks}" },
+  }`
+}
+
+function makeFakeFs(files: Record<string, string>): IFileSystem {
+  return {
+    getCurrentDirectory: vi.fn().mockReturnValue('/proj'),
+    setCurrentDirectory: vi.fn(),
+    exists: vi.fn().mockImplementation((p: string) => Object.hasOwn(files, p)),
+    isDirectory: vi.fn().mockReturnValue(false),
+    isFile: vi.fn().mockImplementation((p: string) => Object.hasOwn(files, p)),
+    listDirectory: vi.fn().mockReturnValue([]),
+    readFile: vi.fn().mockImplementation((p: string) => {
+      if (!Object.hasOwn(files, p)) throw new Error('not found: ' + p)
+      return files[p]
+    }),
+    writeFile: vi.fn(),
+    createDirectory: vi.fn(),
+    delete: vi.fn(),
+  }
+}
+
+function makeMockHandle(): AnsiTerminalHandle {
+  return {
+    write: vi.fn(),
+    container: { addEventListener: vi.fn(), removeEventListener: vi.fn() } as unknown as HTMLElement,
+    dispose: vi.fn(),
+    resize: vi.fn(),
+    setCrt: vi.fn(),
+    setFontFamily: vi.fn(),
+    setUseFontBlocks: vi.fn(),
+  }
+}
+
+describe('LuaScriptProcess ANSI panel-mode integration', () => {
+  let onAnsiPanelMode: ReturnType<typeof vi.fn>
+  let ansiCallbacks: AnsiCallbacks
+  let context: ShellContext
+
+  beforeEach(() => {
+    onAnsiPanelMode = vi.fn()
+  })
+
+  it('does not overwrite the controller-driven panel mode when project.lua = "auto"', async () => {
+    // The user's setup: project = "auto", screen file says false.
+    // The expectation: after the script's set_screen + start sequence,
+    // onAnsiPanelMode should land on `false`, NOT be reset to `null`.
+    const main = `
+      local ansi = require("ansi")
+      local s = ansi.load_screen("/proj/foo.ansi.lua")
+      ansi.set_screen(s)
+      ansi.start()
+    `
+    const files: Record<string, string> = {
+      '/proj/main.lua': main,
+      '/proj/project.lua': makeProjectLua('auto'),
+      '/proj/foo.ansi.lua': makeScreenFileContent(false),
+    }
+    const fs = makeFakeFs(files)
+
+    const handle = makeMockHandle()
+    ansiCallbacks = {
+      onRequestAnsiTab: vi.fn().mockResolvedValue(handle),
+      onCloseAnsiTab: vi.fn(),
+      onAnsiPanelMode,
+    }
+    context = {
+      cwd: '/proj',
+      filesystem: fs,
+      output: vi.fn(),
+      error: vi.fn(),
+    }
+
+    const proc = new LuaScriptProcess('main.lua', context, { ansiCallbacks })
+    proc.onOutput = vi.fn()
+    proc.onError = vi.fn()
+    proc.onExit = vi.fn()
+    proc.start()
+
+    // Let wasmoon initialize, run the script, dispatch through the bridge.
+    await new Promise((r) => setTimeout(r, 400))
+
+    // Filter to the calls the UI would have applied. The LAST call wins as
+    // the panel-mount state, so the final value here is what the user sees.
+    const lastCall = onAnsiPanelMode.mock.calls[onAnsiPanelMode.mock.calls.length - 1]
+    expect(lastCall, 'onAnsiPanelMode should have been called').toBeDefined()
+    expect(lastCall?.[0], 'final panel mode should reflect the screen file (false), not be reset to null by wrappedOnRequest').toBe(false)
+
+    proc.stop()
+  }, 10000)
+})

--- a/packages/lua-runtime/tests/projectUseFontBlocksOverride.test.ts
+++ b/packages/lua-runtime/tests/projectUseFontBlocksOverride.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { extractUseFontBlocksOverride } from '../src/projectCrtConfig'
+
+describe('extractUseFontBlocksOverride', () => {
+  it('returns null when ansi section is missing', () => {
+    const content = `return { name = "t", main = "m.lua", type = "ansi" }`
+    expect(extractUseFontBlocksOverride(content)).toBeNull()
+  })
+
+  it('returns null when use_font_blocks is "auto"', () => {
+    const content = `return {
+      name = "t", main = "m.lua", type = "ansi",
+      ansi = { use_font_blocks = "auto" }
+    }`
+    expect(extractUseFontBlocksOverride(content)).toBeNull()
+  })
+
+  it('returns null when use_font_blocks is unset', () => {
+    const content = `return {
+      name = "t", main = "m.lua", type = "ansi",
+      ansi = { crt = false }
+    }`
+    expect(extractUseFontBlocksOverride(content)).toBeNull()
+  })
+
+  it('returns true when use_font_blocks is "on"', () => {
+    const content = `return {
+      name = "t", main = "m.lua", type = "ansi",
+      ansi = { use_font_blocks = "on" }
+    }`
+    expect(extractUseFontBlocksOverride(content)).toBe(true)
+  })
+
+  it('returns false when use_font_blocks is "off"', () => {
+    const content = `return {
+      name = "t", main = "m.lua", type = "ansi",
+      ansi = { use_font_blocks = "off" }
+    }`
+    expect(extractUseFontBlocksOverride(content)).toBe(false)
+  })
+
+  it('returns null for invalid values', () => {
+    const content = `return {
+      name = "t", main = "m.lua", type = "ansi",
+      ansi = { use_font_blocks = "yes" }
+    }`
+    expect(extractUseFontBlocksOverride(content)).toBeNull()
+  })
+
+  it('returns null for unparseable input', () => {
+    expect(extractUseFontBlocksOverride('return {')).toBeNull()
+  })
+})

--- a/packages/lua-runtime/tests/setupAnsiAPI.setUseFontBlocks.test.ts
+++ b/packages/lua-runtime/tests/setupAnsiAPI.setUseFontBlocks.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for ansi.set_use_font_blocks() — Lua API → JS bridge → AnsiController.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { LuaFactory, LuaEngine } from 'wasmoon'
+import { setupAnsiAPI } from '../src/setupAnsiAPI'
+import type { AnsiController } from '../src/AnsiController'
+
+function createMockController(): AnsiController {
+  return {
+    isActive: vi.fn().mockReturnValue(false),
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn(),
+    setRuntimeUseFontBlocksOverride: vi.fn(),
+  } as unknown as AnsiController
+}
+
+describe('ansi.set_use_font_blocks bridge', () => {
+  let engine: LuaEngine
+  let controller: AnsiController
+
+  beforeEach(async () => {
+    const factory = new LuaFactory()
+    engine = await factory.createEngine()
+    controller = createMockController()
+    setupAnsiAPI(engine, () => controller)
+  })
+
+  afterEach(() => {
+    engine.global.close()
+  })
+
+  it('forwards true to setRuntimeUseFontBlocksOverride', async () => {
+    await engine.doString(`
+      local ansi = require("ansi")
+      ansi.set_use_font_blocks(true)
+    `)
+    expect(controller.setRuntimeUseFontBlocksOverride).toHaveBeenCalledWith(true)
+  })
+
+  it('forwards false to setRuntimeUseFontBlocksOverride', async () => {
+    await engine.doString(`
+      local ansi = require("ansi")
+      ansi.set_use_font_blocks(false)
+    `)
+    expect(controller.setRuntimeUseFontBlocksOverride).toHaveBeenCalledWith(false)
+  })
+
+  it('forwards nil as null override (clears override)', async () => {
+    await engine.doString(`
+      local ansi = require("ansi")
+      ansi.set_use_font_blocks(nil)
+    `)
+    expect(controller.setRuntimeUseFontBlocksOverride).toHaveBeenCalledWith(null)
+  })
+
+  it('throws when given a non-boolean non-nil value', async () => {
+    await expect(
+      engine.doString(`
+        local ansi = require("ansi")
+        ansi.set_use_font_blocks("on")
+      `)
+    ).rejects.toThrow(/expects true, false, or nil/)
+  })
+})

--- a/packages/shell-core/src/interfaces/ShellContext.ts
+++ b/packages/shell-core/src/interfaces/ShellContext.ts
@@ -291,6 +291,16 @@ export interface ShellContext {
   onAnsiPanelMode?: (useFontBlocks: boolean | null) => void
 
   /**
+   * Subscribe to ANSI terminal-handle changes. The controller registers
+   * a listener that fires whenever the panel (re)mounts and a new handle
+   * becomes available — needed so the controller can pick up the new
+   * handle after a panel-variant remount. Returns an unsubscribe function.
+   */
+  registerAnsiHandleListener?: (
+    listener: (handle: unknown) => void
+  ) => () => void
+
+  /**
    * Request a file to be opened in the editor.
    * Called by the 'open' command to integrate with an IDE or editor.
    * Optional - when undefined, the open command will report that

--- a/packages/shell-core/src/interfaces/ShellContext.ts
+++ b/packages/shell-core/src/interfaces/ShellContext.ts
@@ -283,6 +283,14 @@ export interface ShellContext {
   unregisterAnsiCloseHandler?: (ansiId: string) => void
 
   /**
+   * Hint the UI which ANSI terminal panel variant to mount (pixel vs xterm)
+   * before the panel is requested. Called by LuaScriptProcess when it
+   * discovers the project's `ansi.use_font_blocks` override.
+   * `true` → pixel, `false` → xterm, `null` → no override (use default).
+   */
+  onAnsiPanelMode?: (useFontBlocks: boolean | null) => void
+
+  /**
    * Request a file to be opened in the editor.
    * Called by the 'open' command to integrate with an IDE or editor.
    * Optional - when undefined, the open command will report that


### PR DESCRIPTION
Closes #781.

## Summary

Adds three new entry points for the per-screen "use pixel renderer" (`useFontBlocks`) toggle, resolved in priority order **runtime API > project.lua > screen file**:

1. **`project.lua`** — new field `ansi.use_font_blocks = "on" | "off" | "auto"` (default `"auto"`).
   - `"auto"`: use each screen's saved `useFontBlocks` value (current behavior).
   - `"on"` / `"off"`: force the pixel renderer / xterm path for every screen.
   - Validated by `ProjectConfigParser`; invalid values throw.
   - Surfaced in the `--init --type=ansi` template with an inline comment.
2. **Runtime Lua API** — `ansi.set_use_font_blocks(true | false | nil)`.
   - `nil` clears the runtime override; defers to `project.lua` (then to each screen's saved value).
3. **`AnsiController`** — new `setProjectUseFontBlocksOverride()` / `setRuntimeUseFontBlocksOverride()` and a `resolveUseFontBlocks()` helper. Re-applies on `setScreen()` and whenever an override changes.

Wired through `LuaScriptProcess` (website runtime, reads `project.lua` adjacent to the running script) and `AnsiHtmlGenerator` (exported HTML, embeds the override at build time).

## Test plan

- [x] Unit tests pass: `npm --prefix lua-learning-website run test` (4647 tests)
- [x] Runtime tests pass: `npm test -w @lua-learning/lua-runtime` (1755 tests)
- [x] Export tests pass: `npm test -w @lua-learning/export` (215 tests, 38 covering the new field)
- [x] Lint: 0 errors (pre-push CI gate green)
- [x] Typecheck clean: `npx tsc -p lua-learning-website/tsconfig.app.json --noEmit`
- [x] Full build: `npm run build`
- [x] Duplication: 2.31% (under 3% threshold)

## Manual verification

- Run a script with no `project.lua` → each screen's saved `useFontBlocks` value applies (no behavior change).
- Add `ansi = { use_font_blocks = "off" }` to `project.lua` → every screen falls back to the legacy xterm path.
- From Lua: `ansi.set_use_font_blocks(true)` mid-program overrides everything; `ansi.set_use_font_blocks(nil)` defers back to project / screen.

## Docs

`public/docs/ansi.md` gets a new **Renderer Toggle (Pixel Renderer)** section explaining the three priority levels, with examples for both `project.lua` and the new Lua API. Quick Reference row added.

## Notes

- The export currently bundles only `PixelAnsiRenderer` with a no-op `setUseFontBlocks` handle (per the renderer plan); the override is plumbed end-to-end through `AnsiController` so it will take effect the moment the export gains a pixel/xterm chooser. Visual output is unchanged in today's exports.
- `DEFAULT_USE_FONT_BLOCKS` (= `true`) remains the implicit default when no override or screen value is provided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)